### PR TITLE
[plan][java] Support serializing / deserializing Java workflow plan to / from JSON

### DIFF
--- a/plan/src/main/java/org/apache/flink/agents/plan/Action.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/Action.java
@@ -19,6 +19,10 @@
 package org.apache.flink.agents.plan;
 
 import org.apache.flink.agents.api.Event;
+import org.apache.flink.agents.plan.serializer.ActionJsonDeserializer;
+import org.apache.flink.agents.plan.serializer.ActionJsonSerializer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.util.List;
 
@@ -28,6 +32,8 @@ import java.util.List;
  * <p>This class encapsulates a named workflow action that listens for specific event types and
  * executes an associated function when those events occur.
  */
+@JsonSerialize(using = ActionJsonSerializer.class)
+@JsonDeserialize(using = ActionJsonDeserializer.class)
 public class Action {
     private final String name;
     private final Function exec;

--- a/plan/src/main/java/org/apache/flink/agents/plan/JavaFunction.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/JavaFunction.java
@@ -100,8 +100,10 @@ public class JavaFunction implements Function {
     public void checkSignature(Class<?>[] parameterTypes) {
         String errMsg =
                 String.format(
-                        "Expect signature %s, but got %s",
-                        Arrays.toString(parameterTypes), Arrays.toString(this.parameterTypes));
+                        "Function \"%s\" expects signature %s, but got %s",
+                        qualName + '.' + methodName,
+                        Arrays.toString(parameterTypes),
+                        Arrays.toString(this.parameterTypes));
         if (this.parameterTypes.length != parameterTypes.length) {
             throw new IllegalArgumentException(errMsg);
         }

--- a/plan/src/main/java/org/apache/flink/agents/plan/PythonFunction.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/PythonFunction.java
@@ -37,4 +37,12 @@ public class PythonFunction implements Function {
     public void checkSignature(Class<?>[] parameterTypes) throws Exception {
         throw new UnsupportedOperationException();
     }
+
+    public String getModule() {
+        return module;
+    }
+
+    public String getQualName() {
+        return qualName;
+    }
 }

--- a/plan/src/main/java/org/apache/flink/agents/plan/WorkflowPlan.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/WorkflowPlan.java
@@ -19,23 +19,33 @@
 package org.apache.flink.agents.plan;
 
 import org.apache.flink.agents.api.Event;
+import org.apache.flink.agents.plan.serializer.WorkflowPlanJsonDeserializer;
+import org.apache.flink.agents.plan.serializer.WorkflowPlanJsonSerializer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.util.List;
 import java.util.Map;
 
 /** Workflow plan compiled from user defined workflow. */
+@JsonSerialize(using = WorkflowPlanJsonSerializer.class)
+@JsonDeserialize(using = WorkflowPlanJsonDeserializer.class)
 public class WorkflowPlan {
-    private final Map<Class<? extends Event>, List<Action>> actions;
+    private final Map<String, Action> actions;
+    private final Map<Class<? extends Event>, List<Action>> eventTriggerActions;
 
-    public WorkflowPlan(Map<Class<? extends Event>, List<Action>> actions) {
+    public WorkflowPlan(
+            Map<String, Action> actions,
+            Map<Class<? extends Event>, List<Action>> eventTriggerActions) {
         this.actions = actions;
+        this.eventTriggerActions = eventTriggerActions;
     }
 
-    public List<Action> getAction(Class<? extends Event> type) {
-        return actions.get(type);
-    }
-
-    public Map<Class<? extends Event>, List<Action>> getActions() {
+    public Map<String, Action> getActions() {
         return actions;
+    }
+
+    public Map<Class<? extends Event>, List<Action>> getEventTriggerActions() {
+        return eventTriggerActions;
     }
 }

--- a/plan/src/main/java/org/apache/flink/agents/plan/serializer/ActionJsonDeserializer.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/serializer/ActionJsonDeserializer.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.plan.serializer;
+
+import org.apache.flink.agents.api.Event;
+import org.apache.flink.agents.plan.Action;
+import org.apache.flink.agents.plan.Function;
+import org.apache.flink.agents.plan.JavaFunction;
+import org.apache.flink.agents.plan.PythonFunction;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Custom deserializer for {@link Action} that handles the deserialization of the function and event
+ * types.
+ */
+public class ActionJsonDeserializer extends StdDeserializer<Action> {
+
+    public ActionJsonDeserializer() {
+        super(Action.class);
+    }
+
+    @Override
+    public Action deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+            throws IOException {
+        JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+        String name = node.get("name").asText();
+
+        // Deserialize the function based on its type
+        JsonNode execNode = node.get("exec");
+        String funcType = execNode.get("func_type").asText();
+        Function func;
+        if (JavaFunction.class.getSimpleName().equals(funcType)) {
+            func = deserializeJavaFunction(execNode);
+        } else if (PythonFunction.class.getSimpleName().equals(funcType)) {
+            func = deserializePythonFunction(execNode);
+        } else {
+            throw new IOException("Unsupported function type: " + funcType);
+        }
+
+        // Deserialize listenEventTypes
+        List<Class<? extends Event>> listenEventTypes = new ArrayList<>();
+        node.get("listen_event_types")
+                .forEach(
+                        eventTypeNode -> {
+                            String eventTypeName = eventTypeNode.asText();
+                            try {
+                                Class<? extends Event> eventType =
+                                        (Class<? extends Event>) Class.forName(eventTypeName);
+                                listenEventTypes.add(eventType);
+                            } catch (ClassNotFoundException e) {
+                                throw new RuntimeException(
+                                        String.format(
+                                                "Failed to deserialize event type \"%s\"",
+                                                eventTypeName),
+                                        e);
+                            }
+                        });
+
+        try {
+            return new Action(name, func, listenEventTypes);
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    String.format("Failed to create Action with name \"%s\"", name), e);
+        }
+    }
+
+    private PythonFunction deserializePythonFunction(JsonNode execNode) {
+        String module = execNode.get("module").asText();
+        String qualName = execNode.get("qualname").asText();
+        return new PythonFunction(module, qualName);
+    }
+
+    private JavaFunction deserializeJavaFunction(JsonNode execNode) throws IOException {
+        String qualName = execNode.get("qualname").asText();
+        String methodName = execNode.get("method_name").asText();
+        Class<?>[] parameterTypes = new Class<?>[execNode.get("parameter_types").size()];
+        for (int i = 0; i < parameterTypes.length; i++) {
+            try {
+                String parameterTypeName = execNode.get("parameter_types").get(i).asText();
+                parameterTypes[i] = Class.forName(parameterTypeName);
+            } catch (ClassNotFoundException e) {
+                throw new IOException("Failed to deserialize parameter type", e);
+            }
+        }
+        try {
+            return new JavaFunction(qualName, methodName, parameterTypes);
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    String.format(
+                            "Failed to create JavaFunction with qualName \"%s\" and method name \"%s\"",
+                            qualName, methodName),
+                    e);
+        }
+    }
+}

--- a/plan/src/main/java/org/apache/flink/agents/plan/serializer/ActionJsonSerializer.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/serializer/ActionJsonSerializer.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.plan.serializer;
+
+import org.apache.flink.agents.api.Event;
+import org.apache.flink.agents.plan.Action;
+import org.apache.flink.agents.plan.JavaFunction;
+import org.apache.flink.agents.plan.PythonFunction;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializerProvider;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+/**
+ * Custom serializer for {@link Action} that handles the serialization of the function and event
+ * types.
+ */
+public class ActionJsonSerializer extends StdSerializer<Action> {
+    public ActionJsonSerializer() {
+        super(Action.class);
+    }
+
+    @Override
+    public void serialize(
+            Action action, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+            throws IOException {
+        jsonGenerator.writeStartObject();
+
+        // Write name field
+        jsonGenerator.writeStringField("name", action.getName());
+
+        // Write exec field
+        if (action.getExec() instanceof JavaFunction) {
+            JavaFunction javaFunction = (JavaFunction) action.getExec();
+            serializeJavaFunction(jsonGenerator, javaFunction);
+        } else if (action.getExec() instanceof PythonFunction) {
+            PythonFunction pythonFunction = (PythonFunction) action.getExec();
+            serializePythonFunction(jsonGenerator, pythonFunction);
+        } else {
+            throw new IllegalArgumentException(
+                    "Unsupported function type: " + action.getExec().getClass().getName());
+        }
+
+        // Write listenEventTypes field
+        jsonGenerator.writeFieldName("listenEventTypes");
+        jsonGenerator.writeStartArray();
+        for (Class<? extends Event> eventType : action.getListenEventTypes()) {
+            jsonGenerator.writeString(eventType.getName());
+        }
+        jsonGenerator.writeEndArray();
+
+        jsonGenerator.writeEndObject();
+    }
+
+    private void serializePythonFunction(JsonGenerator gen, PythonFunction func)
+            throws IOException {
+        gen.writeFieldName("exec");
+        gen.writeStartObject();
+        // Mark it as a Python function
+        gen.writeStringField("func_type", PythonFunction.class.getSimpleName());
+        // Write the Python function details
+        gen.writeStringField("module", func.getModule());
+        gen.writeStringField("qualname", func.getQualName());
+        gen.writeEndObject();
+    }
+
+    private void serializeJavaFunction(JsonGenerator gen, JavaFunction func) throws IOException {
+        gen.writeFieldName("exec");
+        gen.writeStartObject();
+        // Mark it as a Java function
+        gen.writeStringField("func_type", JavaFunction.class.getSimpleName());
+        // Write the Java function details
+        gen.writeStringField("qualname", func.getQualName());
+        gen.writeStringField("method_name", func.getMethodName());
+        gen.writeArrayFieldStart("parameter_types");
+        for (Class<?> paramType : func.getParameterTypes()) {
+            gen.writeString(paramType.getName());
+        }
+        gen.writeEndArray();
+        gen.writeEndObject();
+    }
+}

--- a/plan/src/main/java/org/apache/flink/agents/plan/serializer/WorkflowPlanJsonDeserializer.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/serializer/WorkflowPlanJsonDeserializer.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.plan.serializer;
+
+import org.apache.flink.agents.api.Event;
+import org.apache.flink.agents.plan.Action;
+import org.apache.flink.agents.plan.WorkflowPlan;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JacksonException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.ObjectCodec;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JavaType;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonDeserializer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class WorkflowPlanJsonDeserializer extends StdDeserializer<WorkflowPlan> {
+
+    public WorkflowPlanJsonDeserializer() {
+        super(WorkflowPlan.class);
+    }
+
+    @Override
+    public WorkflowPlan deserialize(JsonParser parser, DeserializationContext ctx)
+            throws IOException, JacksonException {
+        ObjectCodec codec = parser.getCodec();
+        JsonNode node = codec.readTree(parser);
+        JsonNode actionsNode = node.get("actions");
+
+        // Deserialize actions
+        JavaType actionType = ctx.constructType(Action.class);
+        JsonDeserializer<?> actionDeserializer =
+                ctx.findContextualValueDeserializer(actionType, null);
+        Map<String, Action> actions = new HashMap<>();
+        if (actionsNode != null && actionsNode.isObject()) {
+            Iterator<Map.Entry<String, JsonNode>> iterator = actionsNode.fields();
+            while (iterator.hasNext()) {
+                Map.Entry<String, JsonNode> entry = iterator.next();
+                String actionName = entry.getKey();
+                JsonNode actionNode = entry.getValue();
+                JsonParser actionParser = codec.treeAsTokens(actionNode);
+                Action action = (Action) actionDeserializer.deserialize(actionParser, ctx);
+                actions.put(actionName, action);
+            }
+        }
+
+        // Deserialize event trigger actions
+        JsonNode eventTriggerActionsNode = node.get("event_trigger_actions");
+        Map<Class<? extends Event>, List<Action>> eventTriggerActions = new HashMap<>();
+        if (eventTriggerActionsNode != null && eventTriggerActionsNode.isObject()) {
+            Iterator<Map.Entry<String, JsonNode>> iterator = eventTriggerActionsNode.fields();
+            while (iterator.hasNext()) {
+                Map.Entry<String, JsonNode> entry = iterator.next();
+                String eventClassName = entry.getKey();
+                JsonNode actionsArrayNode = entry.getValue();
+
+                Class<? extends Event> eventClass;
+                try {
+                    eventClass = (Class<? extends Event>) Class.forName(eventClassName);
+                } catch (ClassNotFoundException e) {
+                    throw new IOException("Event class not found: " + eventClassName, e);
+                }
+
+                List<Action> actionsTriggeredByEvent = new ArrayList<>();
+                for (JsonNode actionNameNode : actionsArrayNode) {
+                    String actionName = actionNameNode.asText();
+                    Action action = actions.get(actionName);
+                    if (action == null) {
+                        throw new IllegalStateException("Unknown action name: " + actionName);
+                    }
+                    actionsTriggeredByEvent.add(action);
+                }
+                eventTriggerActions.put(eventClass, actionsTriggeredByEvent);
+            }
+        }
+
+        return new WorkflowPlan(actions, eventTriggerActions);
+    }
+}

--- a/plan/src/main/java/org/apache/flink/agents/plan/serializer/WorkflowPlanJsonSerializer.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/serializer/WorkflowPlanJsonSerializer.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.plan.serializer;
+
+import org.apache.flink.agents.plan.Action;
+import org.apache.flink.agents.plan.WorkflowPlan;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializerProvider;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+public class WorkflowPlanJsonSerializer extends StdSerializer<WorkflowPlan> {
+
+    public WorkflowPlanJsonSerializer() {
+        super(WorkflowPlan.class);
+    }
+
+    @Override
+    public void serialize(
+            WorkflowPlan workflowPlan,
+            JsonGenerator jsonGenerator,
+            SerializerProvider serializerProvider)
+            throws IOException {
+        jsonGenerator.writeStartObject();
+
+        // Serialize actions
+        jsonGenerator.writeFieldName("actions");
+        jsonGenerator.writeStartObject();
+        workflowPlan
+                .getActions()
+                .forEach(
+                        (name, action) -> {
+                            try {
+                                jsonGenerator.writeFieldName(name);
+                                serializerProvider
+                                        .findValueSerializer(Action.class)
+                                        .serialize(action, jsonGenerator, serializerProvider);
+                            } catch (IOException e) {
+                                throw new RuntimeException("Error writing action: " + name, e);
+                            }
+                        });
+        jsonGenerator.writeEndObject();
+
+        // Serialize event trigger actions
+        jsonGenerator.writeFieldName("event_trigger_actions");
+        jsonGenerator.writeStartObject();
+        workflowPlan
+                .getEventTriggerActions()
+                .forEach(
+                        (eventClass, actions) -> {
+                            try {
+                                jsonGenerator.writeFieldName(eventClass.getName());
+                                jsonGenerator.writeStartArray();
+                                for (Action action : actions) {
+                                    jsonGenerator.writeString(action.getName());
+                                }
+                                jsonGenerator.writeEndArray();
+                            } catch (IOException e) {
+                                throw new RuntimeException(
+                                        "Error writing event trigger actions for: "
+                                                + eventClass.getName(),
+                                        e);
+                            }
+                        });
+        jsonGenerator.writeEndObject();
+    }
+}

--- a/plan/src/test/java/org/apache/flink/agents/plan/serializer/ActionJsonDeserializerTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/serializer/ActionJsonDeserializerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.plan.serializer;
+
+import org.apache.flink.agents.api.InputEvent;
+import org.apache.flink.agents.plan.Action;
+import org.apache.flink.agents.plan.JavaFunction;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Test for {@link ActionJsonDeserializer}. */
+public class ActionJsonDeserializerTest {
+
+    /**
+     * Reads a JSON file from the resources directory.
+     *
+     * @param resourcePath the path to the resource file
+     * @return the content of the file as a string
+     * @throws IOException if an I/O error occurs
+     */
+    private String readJsonFromResource(String resourcePath) throws IOException {
+        try (InputStream inputStream =
+                getClass().getClassLoader().getResourceAsStream(resourcePath)) {
+            if (inputStream == null) {
+                throw new IOException("Resource not found: " + resourcePath);
+            }
+            byte[] bytes = inputStream.readAllBytes();
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+    }
+
+    @Test
+    public void testDeserializeJavaFunction() throws Exception {
+        // Read JSON for an Action with JavaFunction from resource file
+        String json = readJsonFromResource("actions/action_java_function.json");
+
+        // Deserialize the JSON to an Action
+        ObjectMapper mapper = new ObjectMapper();
+        Action action = mapper.readValue(json, Action.class);
+
+        // Verify the deserialized Action
+        assertEquals("testAction", action.getName());
+        assertTrue(action.getExec() instanceof JavaFunction);
+        JavaFunction javaFunction = (JavaFunction) action.getExec();
+        assertEquals("org.apache.flink.agents.plan.TestAction", javaFunction.getQualName());
+        assertEquals("legal", javaFunction.getMethodName());
+        assertEquals(1, javaFunction.getParameterTypes().length);
+        assertEquals(InputEvent.class, javaFunction.getParameterTypes()[0]);
+        assertEquals(1, action.getListenEventTypes().size());
+        assertEquals(InputEvent.class, action.getListenEventTypes().get(0));
+    }
+
+    @Test
+    public void testDeserializePythonFunction() throws IOException {
+        // Read JSON for an Action with PythonFunction from resource file
+        String json = readJsonFromResource("actions/action_python_function.json");
+
+        // Deserialize the JSON to an Action
+        // Since PythonFunction's checkSignature method throws UnsupportedOperationException,
+        // we expect the deserialization to fail with an IOException
+        ObjectMapper mapper = new ObjectMapper();
+        Exception exception =
+                assertThrows(Exception.class, () -> mapper.readValue(json, Action.class));
+
+        // Verify the exception message
+        assertTrue(
+                exception
+                        .getMessage()
+                        .contains("Failed to create Action with name \"testPythonAction\""));
+    }
+
+    @Test
+    public void testDeserializeInvalidFunctionType() throws IOException {
+        // Read JSON with an invalid function type from resource file
+        String json = readJsonFromResource("actions/action_invalid_function_type.json");
+
+        // Attempt to deserialize the JSON
+        ObjectMapper mapper = new ObjectMapper();
+        assertThrows(IOException.class, () -> mapper.readValue(json, Action.class));
+    }
+
+    @Test
+    public void testDeserializeMissingFields() throws IOException {
+        // Read JSON with missing fields from resource file
+        String json = readJsonFromResource("actions/action_missing_fields.json");
+
+        // Attempt to deserialize the JSON
+        ObjectMapper mapper = new ObjectMapper();
+        assertThrows(Exception.class, () -> mapper.readValue(json, Action.class));
+    }
+
+    @Test
+    public void testDeserializeInvalidEventType() throws IOException {
+        // Read JSON with an invalid event type from resource file
+        String json = readJsonFromResource("actions/action_invalid_event_type.json");
+
+        // Attempt to deserialize the JSON
+        ObjectMapper mapper = new ObjectMapper();
+        assertThrows(RuntimeException.class, () -> mapper.readValue(json, Action.class));
+    }
+}

--- a/plan/src/test/java/org/apache/flink/agents/plan/serializer/ActionJsonSerializerTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/serializer/ActionJsonSerializerTest.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.plan.serializer;
+
+import org.apache.flink.agents.api.Event;
+import org.apache.flink.agents.api.InputEvent;
+import org.apache.flink.agents.api.OutputEvent;
+import org.apache.flink.agents.plan.Action;
+import org.apache.flink.agents.plan.JavaFunction;
+import org.apache.flink.agents.plan.PythonFunction;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Test for {@link ActionJsonSerializer}. */
+public class ActionJsonSerializerTest {
+    @Test
+    public void testSerializeJavaFunction() throws Exception {
+        // Create a JavaFunction
+        JavaFunction function =
+                new JavaFunction(
+                        "org.apache.flink.agents.plan.TestAction",
+                        "legal",
+                        new Class[] {InputEvent.class});
+
+        // Create an Action
+        Action action = new Action("testAction", function, List.of(InputEvent.class));
+
+        // Serialize the action to JSON
+        String json = new ObjectMapper().writeValueAsString(action);
+
+        // Verify the JSON contains the expected fields
+        assertTrue(json.contains("\"name\":\"testAction\""), "JSON should contain the action name");
+        assertTrue(json.contains("\"exec\":{"), "JSON should contain the exec field");
+        assertTrue(
+                json.contains("\"func_type\":\"JavaFunction\""),
+                "JSON should contain the function type");
+        assertTrue(
+                json.contains("\"qualname\":\"org.apache.flink.agents.plan.TestAction\""),
+                "JSON should contain the function's qualified name");
+        assertTrue(
+                json.contains("\"method_name\":\"legal\""), "JSON should contain the method name");
+        assertTrue(
+                json.contains("\"listenEventTypes\":["),
+                "JSON should contain the listen event types");
+        assertTrue(
+                json.contains("\"org.apache.flink.agents.api.InputEvent\""),
+                "JSON should contain the event type class name");
+    }
+
+    @Test
+    public void testSerializePythonFunction() throws Exception {
+        // Create a TestPythonFunction (which overrides checkSignature to not throw an exception)
+        PythonFunction function =
+                new PythonFunction("test_module", "test_function") {
+                    @Override
+                    public void checkSignature(Class<?>[] args) {
+                        // Do nothing to avoid throwing an exception
+                    }
+                };
+
+        // Create an Action
+        Action action = new Action("testPythonAction", function, List.of(InputEvent.class));
+
+        // Serialize the action to JSON
+        String json = new ObjectMapper().writeValueAsString(action);
+
+        // Verify the JSON contains the expected fields
+        assertTrue(
+                json.contains("\"name\":\"testPythonAction\""),
+                "JSON should contain the action name");
+        assertTrue(json.contains("\"exec\":{"), "JSON should contain the exec field");
+        assertTrue(
+                json.contains("\"func_type\":\"PythonFunction\""),
+                "JSON should contain the function type");
+        assertTrue(
+                json.contains("\"module\":\"test_module\""), "JSON should contain the module name");
+        assertTrue(
+                json.contains("\"qualname\":\"test_function\""),
+                "JSON should contain the qualified name");
+        assertTrue(
+                json.contains("\"listenEventTypes\":["),
+                "JSON should contain the listen event types");
+        assertTrue(
+                json.contains("\"org.apache.flink.agents.api.InputEvent\""),
+                "JSON should contain the event type class name");
+    }
+
+    @Test
+    public void testSerializeMultipleEventTypes() throws Exception {
+        // Create a JavaFunction
+        JavaFunction function =
+                new JavaFunction(
+                        "org.apache.flink.agents.plan.TestAction",
+                        "legal",
+                        new Class[] {InputEvent.class});
+
+        // Create an Action with multiple event types
+        List<Class<? extends Event>> eventTypes = new ArrayList<>();
+        eventTypes.add(InputEvent.class);
+        eventTypes.add(OutputEvent.class);
+        Action action = new Action("multiEventAction", function, eventTypes);
+
+        // Serialize the action to JSON
+        String json = new ObjectMapper().writeValueAsString(action);
+
+        // Verify the JSON contains the expected fields
+        assertTrue(
+                json.contains("\"name\":\"multiEventAction\""),
+                "JSON should contain the action name");
+        assertTrue(
+                json.contains("\"listenEventTypes\":["),
+                "JSON should contain the listen event types");
+        assertTrue(
+                json.contains("\"org.apache.flink.agents.api.InputEvent\""),
+                "JSON should contain the InputEvent class name");
+        assertTrue(
+                json.contains("\"org.apache.flink.agents.api.OutputEvent\""),
+                "JSON should contain the OutputEvent class name");
+    }
+
+    @Test
+    public void testSerializeEmptyEventTypes() throws Exception {
+        // Create a JavaFunction
+        JavaFunction function =
+                new JavaFunction(
+                        "org.apache.flink.agents.plan.TestAction",
+                        "legal",
+                        new Class[] {InputEvent.class});
+
+        // Create an Action with an empty event types list
+        Action action = new Action("emptyEventsAction", function, Collections.emptyList());
+
+        // Serialize the action to JSON
+        String json = new ObjectMapper().writeValueAsString(action);
+
+        // Verify the JSON contains the expected fields
+        assertTrue(
+                json.contains("\"name\":\"emptyEventsAction\""),
+                "JSON should contain the action name");
+        assertTrue(
+                json.contains("\"listenEventTypes\":[]"),
+                "JSON should contain an empty listen event types array");
+    }
+
+    @Test
+    public void testSerializeDeserializeRoundTrip() throws Exception {
+        // Create a JavaFunction
+        JavaFunction function =
+                new JavaFunction(
+                        "org.apache.flink.agents.plan.TestAction",
+                        "legal",
+                        new Class[] {InputEvent.class});
+
+        // Create an Action
+        Action originalAction = new Action("roundTripAction", function, List.of(InputEvent.class));
+
+        // Serialize the action to JSON
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(originalAction);
+
+        // Deserialize the JSON back to an Action
+        Action deserializedAction = mapper.readValue(json, Action.class);
+
+        // Verify the deserialized Action matches the original
+        assertEquals("roundTripAction", deserializedAction.getName());
+        assertInstanceOf(JavaFunction.class, deserializedAction.getExec());
+        JavaFunction deserializedFunction = (JavaFunction) deserializedAction.getExec();
+        assertEquals("org.apache.flink.agents.plan.TestAction", deserializedFunction.getQualName());
+        assertEquals("legal", deserializedFunction.getMethodName());
+        assertEquals(1, deserializedFunction.getParameterTypes().length);
+        assertEquals(InputEvent.class, deserializedFunction.getParameterTypes()[0]);
+        assertEquals(1, deserializedAction.getListenEventTypes().size());
+        assertEquals(InputEvent.class, deserializedAction.getListenEventTypes().get(0));
+    }
+}

--- a/plan/src/test/java/org/apache/flink/agents/plan/serializer/WorkflowPlanJsonDeserializerTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/serializer/WorkflowPlanJsonDeserializerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.plan.serializer;
+
+import org.apache.flink.agents.api.Event;
+import org.apache.flink.agents.api.InputEvent;
+import org.apache.flink.agents.plan.Action;
+import org.apache.flink.agents.plan.JavaFunction;
+import org.apache.flink.agents.plan.WorkflowPlan;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class WorkflowPlanJsonDeserializerTest {
+    @Test
+    public void testDeserialize() throws Exception {
+        // Read JSON for an Action with JavaFunction from resource file
+        String json = readJsonFromResource("workflow_plans/workflow_plan.json");
+        WorkflowPlan workflowPlan = new ObjectMapper().readValue(json, WorkflowPlan.class);
+        assertEquals(2, workflowPlan.getActions().size());
+
+        // Check the first action
+        assertTrue(workflowPlan.getActions().containsKey("first_action"));
+        Action firstAction = workflowPlan.getActions().get("first_action");
+        assertInstanceOf(JavaFunction.class, firstAction.getExec());
+        assertEquals(List.of(InputEvent.class), firstAction.getListenEventTypes());
+
+        // Check the second action
+        assertTrue(workflowPlan.getActions().containsKey("second_action"));
+        Action secondAction = workflowPlan.getActions().get("second_action");
+        assertInstanceOf(JavaFunction.class, secondAction.getExec());
+        assertEquals(List.of(InputEvent.class, MyEvent.class), secondAction.getListenEventTypes());
+
+        // Check event trigger actions
+        assertEquals(2, workflowPlan.getEventTriggerActions().size());
+        assertTrue(workflowPlan.getEventTriggerActions().containsKey(InputEvent.class));
+        assertEquals(
+                List.of(firstAction, secondAction),
+                workflowPlan.getEventTriggerActions().get(InputEvent.class));
+        assertEquals(
+                List.of(secondAction), workflowPlan.getEventTriggerActions().get(MyEvent.class));
+    }
+
+    /**
+     * Reads a JSON file from the resources directory.
+     *
+     * @param resourcePath the path to the resource file
+     * @return the content of the file as a string
+     * @throws IOException if an I/O error occurs
+     */
+    private String readJsonFromResource(String resourcePath) throws IOException {
+        try (InputStream inputStream =
+                getClass().getClassLoader().getResourceAsStream(resourcePath)) {
+            if (inputStream == null) {
+                throw new IOException("Resource not found: " + resourcePath);
+            }
+            byte[] bytes = inputStream.readAllBytes();
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+    }
+
+    private static class MyEvent extends Event {}
+
+    private static class MyAction extends Action {
+
+        public static void doNothing(Event event) {
+            // No operation
+        }
+
+        public MyAction() throws Exception {
+            super(
+                    "MyAction",
+                    new JavaFunction(
+                            MyAction.class.getName(), "doNothing", new Class[] {Event.class}),
+                    List.of(InputEvent.class, MyEvent.class));
+        }
+    }
+}

--- a/plan/src/test/java/org/apache/flink/agents/plan/serializer/WorkflowPlanJsonSerializerTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/serializer/WorkflowPlanJsonSerializerTest.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.plan.serializer;
+
+import org.apache.flink.agents.api.Event;
+import org.apache.flink.agents.api.InputEvent;
+import org.apache.flink.agents.api.OutputEvent;
+import org.apache.flink.agents.plan.Action;
+import org.apache.flink.agents.plan.JavaFunction;
+import org.apache.flink.agents.plan.WorkflowPlan;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Test for {@link WorkflowPlanJsonSerializer}. */
+public class WorkflowPlanJsonSerializerTest {
+    @Test
+    public void testSerializeWorkflowPlanWithActions() throws Exception {
+        // Create a JavaFunction
+        JavaFunction function =
+                new JavaFunction(
+                        "org.apache.flink.agents.plan.TestAction",
+                        "legal",
+                        new Class[] {InputEvent.class});
+
+        // Create an Action
+        Action action = new Action("testAction", function, List.of(InputEvent.class));
+
+        // Create a map of actions
+        Map<String, Action> actions = new HashMap<>();
+        actions.put(action.getName(), action);
+
+        // Create a WorkflowPlan with actions but no event trigger actions
+        WorkflowPlan workflowPlan = new WorkflowPlan(actions, new HashMap<>());
+
+        // Serialize the workflow plan to JSON
+        String json = new ObjectMapper().writeValueAsString(workflowPlan);
+
+        // Verify the JSON contains the expected fields
+        assertTrue(json.contains("\"actions\":{"), "JSON should contain the actions field");
+        assertTrue(json.contains("\"testAction\":{"), "JSON should contain the action name");
+        assertTrue(json.contains("\"name\":\"testAction\""), "JSON should contain the action name");
+        assertTrue(json.contains("\"exec\":{"), "JSON should contain the exec field");
+        assertTrue(
+                json.contains("\"func_type\":\"JavaFunction\""),
+                "JSON should contain the function type");
+        assertTrue(
+                json.contains("\"qualname\":\"org.apache.flink.agents.plan.TestAction\""),
+                "JSON should contain the function's qualified name");
+        assertTrue(
+                json.contains("\"method_name\":\"legal\""), "JSON should contain the method name");
+        assertTrue(
+                json.contains("\"listenEventTypes\":["),
+                "JSON should contain the listen event types");
+        assertTrue(
+                json.contains("\"org.apache.flink.agents.api.InputEvent\""),
+                "JSON should contain the event type class name");
+        assertTrue(
+                json.contains("\"event_trigger_actions\":{}"),
+                "JSON should contain empty event trigger actions");
+    }
+
+    @Test
+    public void testSerializeWorkflowPlanWithEventTriggerActions() throws Exception {
+        // Create a JavaFunction
+        JavaFunction function =
+                new JavaFunction(
+                        "org.apache.flink.agents.plan.TestAction",
+                        "legal",
+                        new Class[] {InputEvent.class});
+
+        // Create an Action
+        Action action = new Action("testAction", function, List.of(InputEvent.class));
+
+        // Create a map of event trigger actions
+        Map<Class<? extends Event>, List<Action>> eventTriggerActions = new HashMap<>();
+        eventTriggerActions.put(InputEvent.class, List.of(action));
+
+        // Create a WorkflowPlan with event trigger actions but no regular actions
+        WorkflowPlan workflowPlan = new WorkflowPlan(new HashMap<>(), eventTriggerActions);
+
+        // Serialize the workflow plan to JSON
+        String json = new ObjectMapper().writeValueAsString(workflowPlan);
+
+        // Verify the JSON contains the expected fields
+        assertTrue(json.contains("\"actions\":{}"), "JSON should contain empty actions");
+        assertTrue(
+                json.contains("\"event_trigger_actions\":{"),
+                "JSON should contain the event trigger actions field");
+        assertTrue(
+                json.contains("\"org.apache.flink.agents.api.InputEvent\":["),
+                "JSON should contain the event class name and an array of action names");
+        assertTrue(
+                json.contains("\"testAction\""),
+                "JSON should contain the action name in event triggers");
+    }
+
+    @Test
+    public void testSerializeWorkflowPlanWithBothActionsAndEventTriggerActions() throws Exception {
+        // Create JavaFunctions
+        JavaFunction function1 =
+                new JavaFunction(
+                        "org.apache.flink.agents.plan.TestAction",
+                        "legal",
+                        new Class[] {InputEvent.class});
+        JavaFunction function2 =
+                new JavaFunction(
+                        "org.apache.flink.agents.plan.TestAction",
+                        "legal",
+                        new Class[] {InputEvent.class});
+
+        // Create Actions
+        Action action1 = new Action("action1", function1, List.of(InputEvent.class));
+        Action action2 = new Action("action2", function2, List.of(OutputEvent.class));
+
+        // Create a map of actions
+        Map<String, Action> actions = new HashMap<>();
+        actions.put(action1.getName(), action1);
+        actions.put(action2.getName(), action2);
+
+        // Create a map of event trigger actions
+        Map<Class<? extends Event>, List<Action>> eventTriggerActions = new HashMap<>();
+        eventTriggerActions.put(InputEvent.class, List.of(action1));
+        eventTriggerActions.put(OutputEvent.class, List.of(action2));
+
+        // Create a WorkflowPlan with both actions and event trigger actions
+        WorkflowPlan workflowPlan = new WorkflowPlan(actions, eventTriggerActions);
+
+        // Serialize the workflow plan to JSON
+        String json = new ObjectMapper().writeValueAsString(workflowPlan);
+
+        // Verify the JSON contains the expected fields
+        assertTrue(json.contains("\"actions\":{"), "JSON should contain the actions field");
+        assertTrue(json.contains("\"action1\":{"), "JSON should contain the first action name");
+        assertTrue(json.contains("\"action2\":{"), "JSON should contain the second action name");
+        assertTrue(
+                json.contains("\"event_trigger_actions\":{"),
+                "JSON should contain the event trigger actions field");
+        assertTrue(
+                json.contains("\"org.apache.flink.agents.api.InputEvent\":["),
+                "JSON should contain the InputEvent class name and an array of action names");
+        assertTrue(
+                json.contains("\"org.apache.flink.agents.api.OutputEvent\":["),
+                "JSON should contain the OutputEvent class name and an array of action names");
+        assertTrue(
+                json.contains("\"action1\""),
+                "JSON should contain the first action name in event triggers");
+        assertTrue(
+                json.contains("\"action2\""),
+                "JSON should contain the second action name in event triggers");
+    }
+
+    @Test
+    public void testSerializeEmptyWorkflowPlan() throws Exception {
+        // Create an empty WorkflowPlan
+        WorkflowPlan workflowPlan = new WorkflowPlan(new HashMap<>(), new HashMap<>());
+
+        // Serialize the workflow plan to JSON
+        String json = new ObjectMapper().writeValueAsString(workflowPlan);
+
+        // Verify the JSON contains the expected fields
+        assertTrue(json.contains("\"actions\":{}"), "JSON should contain empty actions");
+        assertTrue(
+                json.contains("\"event_trigger_actions\":{}"),
+                "JSON should contain empty event trigger actions");
+    }
+}

--- a/plan/src/test/resources/actions/action_invalid_event_type.json
+++ b/plan/src/test/resources/actions/action_invalid_event_type.json
@@ -1,0 +1,10 @@
+{
+  "name": "testAction",
+  "exec": {
+    "func_type": "JavaFunction",
+    "qualname": "org.apache.flink.agents.plan.TestAction",
+    "method_name": "legal",
+    "parameter_types": ["org.apache.flink.agents.api.InputEvent"]
+  },
+  "listenEventTypes": ["org.apache.flink.agents.api.NonExistentEvent"]
+}

--- a/plan/src/test/resources/actions/action_invalid_function_type.json
+++ b/plan/src/test/resources/actions/action_invalid_function_type.json
@@ -1,0 +1,10 @@
+{
+  "name": "testAction",
+  "exec": {
+    "func_type": "InvalidFunction",
+    "qualname": "org.apache.flink.agents.plan.TestAction",
+    "method_name": "legal",
+    "parameter_types": ["org.apache.flink.agents.api.InputEvent"]
+  },
+  "listenEventTypes": ["org.apache.flink.agents.api.InputEvent"]
+}

--- a/plan/src/test/resources/actions/action_java_function.json
+++ b/plan/src/test/resources/actions/action_java_function.json
@@ -1,0 +1,10 @@
+{
+  "name": "testAction",
+  "exec": {
+    "func_type": "JavaFunction",
+    "qualname": "org.apache.flink.agents.plan.TestAction",
+    "method_name": "legal",
+    "parameter_types": ["org.apache.flink.agents.api.InputEvent"]
+  },
+  "listenEventTypes": ["org.apache.flink.agents.api.InputEvent"]
+}

--- a/plan/src/test/resources/actions/action_missing_fields.json
+++ b/plan/src/test/resources/actions/action_missing_fields.json
@@ -1,0 +1,7 @@
+{
+  "name": "testAction",
+  "exec": {
+    "func_type": "JavaFunction"
+  },
+  "listenEventTypes": ["org.apache.flink.agents.api.InputEvent"]
+}

--- a/plan/src/test/resources/actions/action_python_function.json
+++ b/plan/src/test/resources/actions/action_python_function.json
@@ -1,0 +1,9 @@
+{
+  "name": "testPythonAction",
+  "exec": {
+    "func_type": "PythonFunction",
+    "module": "test_module",
+    "qualname": "test_function"
+  },
+  "listenEventTypes": ["org.apache.flink.agents.api.InputEvent"]
+}

--- a/plan/src/test/resources/workflow_plans/workflow_plan.json
+++ b/plan/src/test/resources/workflow_plans/workflow_plan.json
@@ -1,0 +1,40 @@
+{
+  "actions": {
+    "first_action": {
+      "name": "first_action",
+      "exec": {
+        "qualname": "org.apache.flink.agents.plan.TestAction",
+        "method_name": "legal",
+        "parameter_types": ["org.apache.flink.agents.api.InputEvent"],
+        "func_type": "JavaFunction"
+      },
+      "listen_event_types": [
+        "org.apache.flink.agents.api.InputEvent"
+      ]
+    },
+    "second_action": {
+      "name": "second_action",
+      "exec": {
+        "qualname": "org.apache.flink.agents.plan.serializer.WorkflowPlanJsonDeserializerTest$MyAction",
+        "method_name": "doNothing",
+        "parameter_types": [
+          "org.apache.flink.agents.api.Event"
+        ],
+        "func_type": "JavaFunction"
+      },
+      "listen_event_types": [
+        "org.apache.flink.agents.api.InputEvent",
+        "org.apache.flink.agents.plan.serializer.WorkflowPlanJsonDeserializerTest$MyEvent"
+      ]
+    }
+  },
+  "event_trigger_actions": {
+    "org.apache.flink.agents.api.InputEvent": [
+      "first_action",
+      "second_action"
+    ],
+    "org.apache.flink.agents.plan.serializer.WorkflowPlanJsonDeserializerTest$MyEvent": [
+      "second_action"
+    ]
+  }
+}


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #14

### Purpose of change

This pull request implements JSON serializer / deserializer for `Action` and `WorkflowPlan` for Java API. 

There are some known issues considering compatibility with Python, which might be fixed in followup pull requests:
- The type of event that an action listens to can be defined in Java or Python. This PR only considers events defined in Java
- Method `checkSignature` in `PythonFunction` is not implemented, but it is used in the constructor of `Action`. The workaround now when I implement tests is extending the `PythonFunction` and overriding the `checkSignature` method with no-op.

### Tests

Serializers / deserializers are guarded by unit tests.

### API

No.

### Documentation

No.
