### PR TITLE
[hotfix] Rename input/output event name in EventUtil to keep consiste…

### DIFF
--- a/python/flink_agents/integrations/chat_models/tests/test_ollama_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/tests/test_ollama_chat_model.py
@@ -34,7 +34,8 @@ current_dir = Path(__file__).parent
 try:
     # only auto setup ollama in ci with python3.9 to reduce ci cost.
     if "3.9" in sys.version:
-        subprocess.run(["bash", f"{current_dir}/start_ollama_server.sh"], check=True)
+        subprocess.run(["bash", f"{current_dir}/start_ollama_server.sh"],
+                       timeout=300, check=True)
     client = Client()
     models = client.list()
 

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/utils/EventUtil.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/utils/EventUtil.java
@@ -25,9 +25,10 @@ import org.apache.flink.agents.runtime.python.event.PythonEvent;
 /** Utilities related to the {@link Event}. */
 public class EventUtil {
 
-    public static final String PYTHON_INPUT_EVENT_NAME = "flink_agents.api.event.InputEvent";
+    public static final String PYTHON_INPUT_EVENT_NAME = "flink_agents.api.events.event.InputEvent";
 
-    public static final String PYTHON_OUTPUT_EVENT_NAME = "flink_agents.api.event.OutputEvent";
+    public static final String PYTHON_OUTPUT_EVENT_NAME =
+            "flink_agents.api.events.event.OutputEvent";
 
     public static boolean isInputEvent(Event event) {
         if (event instanceof InputEvent) {


### PR DESCRIPTION
### Purpose of change

After revise the module of event in python code, the input and output event name must be renamed to keep consistency, or the example will hang.

### Tests

Manually test, will add e2e test later.

### API

No

### Documentation

No
