### PR TITLE
[api][python][java] Support serialize and deserialize AgentPlan with python resource providers.

### DIFF
--- a/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
@@ -71,6 +71,16 @@ public class AgentPlan implements Serializable {
         this.resourceCache = new ConcurrentHashMap<>();
     }
 
+    public AgentPlan(
+            Map<String, Action> actions,
+            Map<String, List<Action>> actionsByEvent,
+            Map<ResourceType, Map<String, ResourceProvider>> resourceProviders) {
+        this.actions = actions;
+        this.actionsByEvent = actionsByEvent;
+        this.resourceProviders = resourceProviders;
+        this.resourceCache = new ConcurrentHashMap<>();
+    }
+
     /**
      * Constructor that creates an AgentPlan from an Agent instance by scanning for all types of
      * annotations.

--- a/plan/src/main/java/org/apache/flink/agents/plan/resourceprovider/PythonResourceProvider.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/resourceprovider/PythonResourceProvider.java
@@ -21,6 +21,7 @@ package org.apache.flink.agents.plan.resourceprovider;
 import org.apache.flink.agents.api.resource.Resource;
 import org.apache.flink.agents.api.resource.ResourceType;
 
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 /**
@@ -30,9 +31,32 @@ import java.util.concurrent.Callable;
  * class, and initialization arguments.
  */
 public class PythonResourceProvider extends ResourceProvider {
+    private final String module;
+    private final String clazz;
+    private final Map<String, Object> kwargs;
 
-    public PythonResourceProvider(String name, ResourceType type) {
+    public PythonResourceProvider(
+            String name,
+            ResourceType type,
+            String module,
+            String clazz,
+            Map<String, Object> kwargs) {
         super(name, type);
+        this.module = module;
+        this.clazz = clazz;
+        this.kwargs = kwargs;
+    }
+
+    public String getModule() {
+        return module;
+    }
+
+    public String getClazz() {
+        return clazz;
+    }
+
+    public Map<String, Object> getKwargs() {
+        return kwargs;
     }
 
     @Override
@@ -42,5 +66,23 @@ public class PythonResourceProvider extends ResourceProvider {
         // resource
         throw new UnsupportedOperationException(
                 "Python resource creation not yet implemented in Java runtime");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PythonResourceProvider that = (PythonResourceProvider) o;
+        return this.getName().equals(that.getName())
+                && this.getType().equals(that.getType())
+                && this.module.equals(that.module)
+                && this.clazz.equals(that.clazz)
+                && this.kwargs.equals(that.kwargs);
     }
 }

--- a/plan/src/main/java/org/apache/flink/agents/plan/resourceprovider/PythonSerializableResourceProvider.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/resourceprovider/PythonSerializableResourceProvider.java
@@ -20,7 +20,9 @@ package org.apache.flink.agents.plan.resourceprovider;
 
 import org.apache.flink.agents.api.resource.Resource;
 import org.apache.flink.agents.api.resource.ResourceType;
+import org.apache.flink.agents.api.resource.SerializableResource;
 
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 /**
@@ -30,10 +32,36 @@ import java.util.concurrent.Callable;
  * resource for later deserialization.
  */
 public class PythonSerializableResourceProvider extends SerializableResourceProvider {
+    private final Map<String, Object> serialized;
+    private SerializableResource resource;
 
     public PythonSerializableResourceProvider(
-            String name, ResourceType type, String module, String clazz) {
+            String name,
+            ResourceType type,
+            String module,
+            String clazz,
+            Map<String, Object> serialized) {
         super(name, type, module, clazz);
+        this.serialized = serialized;
+    }
+
+    public PythonSerializableResourceProvider(
+            String name,
+            ResourceType type,
+            String module,
+            String clazz,
+            Map<String, Object> serialized,
+            SerializableResource resource) {
+        this(name, type, module, clazz, serialized);
+        this.resource = resource;
+    }
+
+    public Map<String, Object> getSerialized() {
+        return serialized;
+    }
+
+    public SerializableResource getResource() {
+        return resource;
     }
 
     @Override
@@ -43,5 +71,23 @@ public class PythonSerializableResourceProvider extends SerializableResourceProv
         // resource
         throw new UnsupportedOperationException(
                 "Python resource deserialization not yet implemented in Java runtime");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PythonSerializableResourceProvider that = (PythonSerializableResourceProvider) o;
+        return this.getName().equals(that.getName())
+                && this.getType().equals(that.getType())
+                && this.getModule().equals(that.getModule())
+                && this.getClazz().equals(that.getClazz())
+                && this.serialized.equals(that.serialized);
     }
 }

--- a/plan/src/main/java/org/apache/flink/agents/plan/resourceprovider/ResourceProvider.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/resourceprovider/ResourceProvider.java
@@ -20,6 +20,10 @@ package org.apache.flink.agents.plan.resourceprovider;
 
 import org.apache.flink.agents.api.resource.Resource;
 import org.apache.flink.agents.api.resource.ResourceType;
+import org.apache.flink.agents.plan.serializer.ResourceProviderJsonDeserializer;
+import org.apache.flink.agents.plan.serializer.ResourceProviderJsonSerializer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.util.concurrent.Callable;
 
@@ -29,6 +33,8 @@ import java.util.concurrent.Callable;
  * <p>Resource providers are responsible for creating resources during agent execution. They carry
  * the necessary metadata and configuration to instantiate resources.
  */
+@JsonSerialize(using = ResourceProviderJsonSerializer.class)
+@JsonDeserialize(using = ResourceProviderJsonDeserializer.class)
 public abstract class ResourceProvider implements java.io.Serializable {
 
     private final String name;

--- a/plan/src/main/java/org/apache/flink/agents/plan/serializer/ResourceProviderJsonDeserializer.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/serializer/ResourceProviderJsonDeserializer.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.plan.serializer;
+
+import org.apache.flink.agents.api.resource.ResourceType;
+import org.apache.flink.agents.plan.resourceprovider.JavaResourceProvider;
+import org.apache.flink.agents.plan.resourceprovider.JavaSerializableResourceProvider;
+import org.apache.flink.agents.plan.resourceprovider.PythonResourceProvider;
+import org.apache.flink.agents.plan.resourceprovider.PythonSerializableResourceProvider;
+import org.apache.flink.agents.plan.resourceprovider.ResourceProvider;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Custom deserializer for {@link ResourceProvider} that handles the deserialization of different
+ * implementation.
+ */
+public class ResourceProviderJsonDeserializer extends StdDeserializer<ResourceProvider> {
+
+    public ResourceProviderJsonDeserializer() {
+        super(ResourceProvider.class);
+    }
+
+    @Override
+    public ResourceProvider deserialize(
+            JsonParser jsonParser, DeserializationContext deserializationContext)
+            throws IOException {
+        JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+        String providerType = node.get("__resource_provider_type__").asText();
+
+        ResourceProvider provider;
+        if (PythonResourceProvider.class.getSimpleName().equals(providerType)) {
+            provider = deserializePythonResourceProvider(node);
+        } else if (PythonSerializableResourceProvider.class.getSimpleName().equals(providerType)) {
+            provider = deserializePythonSerializableResourceProvider(node);
+        } else if (JavaResourceProvider.class.getSimpleName().equals(providerType)) {
+            provider = deserializeJavaResourceProvider(node);
+        } else if (JavaSerializableResourceProvider.class.getSimpleName().equals(providerType)) {
+            provider = deserializeJavaSerializableResourceProvider(node);
+        } else {
+            throw new IOException("Unsupported resource provider type: " + providerType);
+        }
+
+        return provider;
+    }
+
+    private PythonResourceProvider deserializePythonResourceProvider(JsonNode node) {
+        String name = node.get("name").asText();
+        String type = node.get("type").asText();
+        String module = node.get("module").asText();
+        String clazz = node.get("clazz").asText();
+
+        JsonNode kwargsNode = node.get("kwargs");
+        Map<String, Object> kwargs = new HashMap<>();
+        if (kwargsNode != null && kwargsNode.isObject()) {
+            kwargs = (Map<String, Object>) parseJsonNode(kwargsNode);
+        }
+        return new PythonResourceProvider(
+                name, ResourceType.fromValue(type), module, clazz, kwargs);
+    }
+
+    private PythonSerializableResourceProvider deserializePythonSerializableResourceProvider(
+            JsonNode node) {
+        String name = node.get("name").asText();
+        String type = node.get("type").asText();
+        String module = node.get("module").asText();
+        String clazz = node.get("clazz").asText();
+
+        JsonNode serializedNode = node.get("serialized");
+        Map<String, Object> serialized = new HashMap<>();
+        if (serializedNode != null && serializedNode.isObject()) {
+            serialized = (Map<String, Object>) parseJsonNode(serializedNode);
+        }
+        return new PythonSerializableResourceProvider(
+                name, ResourceType.fromValue(type), module, clazz, serialized);
+    }
+
+    private JavaResourceProvider deserializeJavaResourceProvider(JsonNode node) {
+        String name = node.get("name").asText();
+        String type = node.get("type").asText();
+        return new JavaResourceProvider(name, ResourceType.fromValue(type));
+    }
+
+    private JavaSerializableResourceProvider deserializeJavaSerializableResourceProvider(
+            JsonNode node) {
+        String name = node.get("name").asText();
+        String type = node.get("type").asText();
+        String module = node.get("module").asText();
+        String clazz = node.get("clazz").asText();
+        return new JavaSerializableResourceProvider(
+                name, ResourceType.fromValue(type), module, clazz);
+    }
+
+    private Object parseJsonNode(JsonNode node) {
+        if (node.isObject()) {
+            Map<String, Object> map = new HashMap<>();
+            node.fields()
+                    .forEachRemaining(
+                            entry -> map.put(entry.getKey(), parseJsonNode(entry.getValue())));
+            return map;
+        } else if (node.isArray()) {
+            List<Object> list = new ArrayList<>();
+            node.forEach(element -> list.add(parseJsonNode(element)));
+            return list;
+        } else if (node.isValueNode()) {
+            return node.asText();
+        } else {
+            throw new UnsupportedOperationException("Unsupported node type: " + node.getNodeType());
+        }
+    }
+}

--- a/plan/src/main/java/org/apache/flink/agents/plan/serializer/ResourceProviderJsonSerializer.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/serializer/ResourceProviderJsonSerializer.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.plan.serializer;
+
+import org.apache.flink.agents.plan.resourceprovider.JavaResourceProvider;
+import org.apache.flink.agents.plan.resourceprovider.JavaSerializableResourceProvider;
+import org.apache.flink.agents.plan.resourceprovider.PythonResourceProvider;
+import org.apache.flink.agents.plan.resourceprovider.PythonSerializableResourceProvider;
+import org.apache.flink.agents.plan.resourceprovider.ResourceProvider;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializerProvider;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+/**
+ * Custom serializer for {@link ResourceProvider} that handles the serialization of different
+ * implementation.
+ */
+public class ResourceProviderJsonSerializer extends StdSerializer<ResourceProvider> {
+    public ResourceProviderJsonSerializer() {
+        super(ResourceProvider.class);
+    }
+
+    @Override
+    public void serialize(
+            ResourceProvider resourceProvider,
+            JsonGenerator jsonGenerator,
+            SerializerProvider serializerProvider)
+            throws IOException {
+        jsonGenerator.writeStartObject();
+
+        if (resourceProvider instanceof PythonResourceProvider) {
+            serializePythonResourceProvider(
+                    jsonGenerator, (PythonResourceProvider) resourceProvider);
+        } else if (resourceProvider instanceof PythonSerializableResourceProvider) {
+            serializePythonSerializableResourceProvider(
+                    jsonGenerator, (PythonSerializableResourceProvider) resourceProvider);
+        } else if (resourceProvider instanceof JavaResourceProvider) {
+            jsonGenerator.writeStringField("name", resourceProvider.getName());
+            jsonGenerator.writeStringField("type", resourceProvider.getType().getValue());
+        } else if (resourceProvider instanceof JavaSerializableResourceProvider) {
+            jsonGenerator.writeStringField("name", resourceProvider.getName());
+            jsonGenerator.writeStringField("type", resourceProvider.getType().getValue());
+            jsonGenerator.writeStringField(
+                    "module", ((JavaSerializableResourceProvider) resourceProvider).getModule());
+            jsonGenerator.writeStringField(
+                    "clazz", ((JavaSerializableResourceProvider) resourceProvider).getClazz());
+        } else {
+            throw new IllegalArgumentException(
+                    "Unsupported resource provider type: " + resourceProvider.getClass().getName());
+        }
+        jsonGenerator.writeEndObject();
+    }
+
+    private void serializePythonResourceProvider(JsonGenerator gen, PythonResourceProvider provider)
+            throws IOException {
+        gen.writeStringField("name", provider.getName());
+        gen.writeStringField("type", provider.getType().getValue());
+        gen.writeStringField("module", provider.getModule());
+        gen.writeStringField("clazz", provider.getClazz());
+
+        gen.writeFieldName("kwargs");
+        gen.writeStartObject();
+        provider.getKwargs()
+                .forEach(
+                        (name, value) -> {
+                            try {
+                                gen.writeObjectField(name, value);
+                            } catch (IOException e) {
+                                throw new RuntimeException(
+                                        "Error writing kwargs of PythonResourceProvider: " + name,
+                                        e);
+                            }
+                        });
+        gen.writeEndObject();
+
+        gen.writeStringField("__resource_provider_type__", "PythonResourceProvider");
+    }
+
+    private void serializePythonSerializableResourceProvider(
+            JsonGenerator gen, PythonSerializableResourceProvider provider) throws IOException {
+        gen.writeStringField("name", provider.getName());
+        gen.writeStringField("type", provider.getType().getValue());
+        gen.writeStringField("module", provider.getModule());
+        gen.writeStringField("clazz", provider.getClazz());
+
+        gen.writeFieldName("serialized");
+        gen.writeStartObject();
+        provider.getSerialized()
+                .forEach(
+                        (name, value) -> {
+                            try {
+                                gen.writeObjectField(name, value);
+                            } catch (IOException e) {
+                                throw new RuntimeException(
+                                        "Error writing SerializableResource of PythonSerializableResourceProvider: "
+                                                + name,
+                                        e);
+                            }
+                        });
+        gen.writeEndObject();
+
+        gen.writeStringField("__resource_provider_type__", "PythonSerializableResourceProvider");
+    }
+}

--- a/plan/src/test/java/org/apache/flink/agents/plan/serializer/ActionJsonDeserializerTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/serializer/ActionJsonDeserializerTest.java
@@ -27,8 +27,6 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMap
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -37,28 +35,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /** Test for {@link ActionJsonDeserializer}. */
 public class ActionJsonDeserializerTest {
 
-    /**
-     * Reads a JSON file from the resources directory.
-     *
-     * @param resourcePath the path to the resource file
-     * @return the content of the file as a string
-     * @throws IOException if an I/O error occurs
-     */
-    private String readJsonFromResource(String resourcePath) throws IOException {
-        try (InputStream inputStream =
-                getClass().getClassLoader().getResourceAsStream(resourcePath)) {
-            if (inputStream == null) {
-                throw new IOException("Resource not found: " + resourcePath);
-            }
-            byte[] bytes = inputStream.readAllBytes();
-            return new String(bytes, StandardCharsets.UTF_8);
-        }
-    }
-
     @Test
     public void testDeserializeJavaFunction() throws Exception {
         // Read JSON for an Action with JavaFunction from resource file
-        String json = readJsonFromResource("actions/action_java_function.json");
+        String json = Utils.readJsonFromResource("actions/action_java_function.json");
 
         // Deserialize the JSON to an Action
         ObjectMapper mapper = new ObjectMapper();
@@ -80,7 +60,7 @@ public class ActionJsonDeserializerTest {
     @Test
     public void testDeserializePythonFunction() throws IOException {
         // Read JSON for an Action with PythonFunction from resource file
-        String json = readJsonFromResource("actions/action_python_function.json");
+        String json = Utils.readJsonFromResource("actions/action_python_function.json");
 
         // Deserialize the JSON to an Action
         ObjectMapper mapper = new ObjectMapper();
@@ -99,7 +79,7 @@ public class ActionJsonDeserializerTest {
     @Test
     public void testDeserializeInvalidFunctionType() throws IOException {
         // Read JSON with an invalid function type from resource file
-        String json = readJsonFromResource("actions/action_invalid_function_type.json");
+        String json = Utils.readJsonFromResource("actions/action_invalid_function_type.json");
 
         // Attempt to deserialize the JSON
         ObjectMapper mapper = new ObjectMapper();
@@ -109,7 +89,7 @@ public class ActionJsonDeserializerTest {
     @Test
     public void testDeserializeMissingFields() throws IOException {
         // Read JSON with missing fields from resource file
-        String json = readJsonFromResource("actions/action_missing_fields.json");
+        String json = Utils.readJsonFromResource("actions/action_missing_fields.json");
 
         // Attempt to deserialize the JSON
         ObjectMapper mapper = new ObjectMapper();
@@ -119,7 +99,7 @@ public class ActionJsonDeserializerTest {
     @Test
     public void testDeserializeInvalidEventType() throws IOException {
         // Read JSON with an invalid event type from resource file
-        String json = readJsonFromResource("actions/action_invalid_event_type.json");
+        String json = Utils.readJsonFromResource("actions/action_invalid_event_type.json");
 
         // Attempt to deserialize the JSON
         ObjectMapper mapper = new ObjectMapper();

--- a/plan/src/test/java/org/apache/flink/agents/plan/serializer/AgentPlanJsonDeserializerTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/serializer/AgentPlanJsonDeserializerTest.java
@@ -27,9 +27,6 @@ import org.apache.flink.agents.plan.JavaFunction;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,7 +37,7 @@ public class AgentPlanJsonDeserializerTest {
     @Test
     public void testDeserialize() throws Exception {
         // Read JSON for an Action with JavaFunction from resource file
-        String json = readJsonFromResource("agent_plans/agent_plan.json");
+        String json = Utils.readJsonFromResource("agent_plans/agent_plan.json");
         AgentPlan agentPlan = new ObjectMapper().readValue(json, AgentPlan.class);
         assertEquals(2, agentPlan.getActions().size());
 
@@ -66,24 +63,6 @@ public class AgentPlanJsonDeserializerTest {
                 agentPlan.getActionsByEvent().get(InputEvent.class.getName()));
         assertEquals(
                 List.of(secondAction), agentPlan.getActionsByEvent().get(MyEvent.class.getName()));
-    }
-
-    /**
-     * Reads a JSON file from the resources directory.
-     *
-     * @param resourcePath the path to the resource file
-     * @return the content of the file as a string
-     * @throws IOException if an I/O error occurs
-     */
-    private String readJsonFromResource(String resourcePath) throws IOException {
-        try (InputStream inputStream =
-                getClass().getClassLoader().getResourceAsStream(resourcePath)) {
-            if (inputStream == null) {
-                throw new IOException("Resource not found: " + resourcePath);
-            }
-            byte[] bytes = inputStream.readAllBytes();
-            return new String(bytes, StandardCharsets.UTF_8);
-        }
     }
 
     private static class MyEvent extends Event {}

--- a/plan/src/test/java/org/apache/flink/agents/plan/serializer/ResourceProviderDeserializerTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/serializer/ResourceProviderDeserializerTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.plan.serializer;
+
+import org.apache.flink.agents.api.resource.ResourceType;
+import org.apache.flink.agents.plan.resourceprovider.PythonResourceProvider;
+import org.apache.flink.agents.plan.resourceprovider.PythonSerializableResourceProvider;
+import org.apache.flink.agents.plan.resourceprovider.ResourceProvider;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/** Test for {@link ResourceProviderJsonDeserializer}. */
+public class ResourceProviderDeserializerTest {
+    @Test
+    public void testDeserializePythonResourceProvider() throws Exception {
+        // Read JSON for an Action with JavaFunction from resource file
+        String json =
+                Utils.readJsonFromResource("resource_providers/python_resource_provider.json");
+
+        // Deserialize the JSON to an Action
+        ObjectMapper mapper = new ObjectMapper();
+        ResourceProvider provider = mapper.readValue(json, ResourceProvider.class);
+        assertInstanceOf(PythonResourceProvider.class, provider);
+
+        PythonResourceProvider pythonResourceProvider = (PythonResourceProvider) provider;
+        assertEquals("my_chat_model", pythonResourceProvider.getName());
+        assertEquals(ResourceType.CHAT_MODEL, pythonResourceProvider.getType());
+        assertEquals(
+                "flink_agents.plan.tests.test_resource_provider",
+                pythonResourceProvider.getModule());
+        assertEquals("MockChatModelImpl", pythonResourceProvider.getClazz());
+
+        Map<String, Object> kwargs = new HashMap<>();
+        kwargs.put("host", "8.8.8.8");
+        kwargs.put("desc", "mock chat model");
+
+        assertEquals(kwargs, pythonResourceProvider.getKwargs());
+    }
+
+    @Test
+    public void testDeserializePythonSerializableResourceProvider() throws Exception {
+        // Read JSON for an Action with JavaFunction from resource file
+        String json =
+                Utils.readJsonFromResource(
+                        "resource_providers/python_serializable_resource_provider.json");
+
+        // Deserialize the JSON to an Action
+        ObjectMapper mapper = new ObjectMapper();
+        ResourceProvider provider = mapper.readValue(json, ResourceProvider.class);
+
+        Map<String, Object> serialized = new HashMap<>();
+        serialized.put("name", "add");
+
+        // construct arguments schema
+        Map<String, String> a = new HashMap<>();
+        a.put("description", "The first operand");
+        a.put("title", "A");
+        a.put("type", "integer");
+
+        Map<String, String> b = new HashMap<>();
+        b.put("description", "The second operand");
+        b.put("title", "B");
+        b.put("type", "integer");
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("a", a);
+        properties.put("b", b);
+
+        Map<String, Object> argsSchema = new HashMap<>();
+        argsSchema.put("properties", properties);
+        argsSchema.put("required", List.of("a", "b"));
+        argsSchema.put("title", "add");
+        argsSchema.put("type", "object");
+
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("name", "add");
+        metadata.put("description", "Calculate the sum of a and b.\n");
+        metadata.put("args_schema", argsSchema);
+
+        serialized.put("metadata", metadata);
+
+        Map<String, String> func = new HashMap<>();
+        func.put("func_type", "PythonFunction");
+        func.put("module", "flink_agents.runtime.tests.test_built_in_actions");
+        func.put("qualname", "MyAgent.add");
+        serialized.put("func", func);
+
+        assertInstanceOf(PythonSerializableResourceProvider.class, provider);
+        PythonSerializableResourceProvider pythonSerializableResourceProvider =
+                (PythonSerializableResourceProvider) provider;
+        assertEquals("add", pythonSerializableResourceProvider.getName());
+        assertEquals(ResourceType.TOOL, pythonSerializableResourceProvider.getType());
+        assertEquals(
+                "flink_agents.plan.tools.function_tool",
+                pythonSerializableResourceProvider.getModule());
+        assertEquals("FunctionTool", pythonSerializableResourceProvider.getClazz());
+        assertEquals(serialized, pythonSerializableResourceProvider.getSerialized());
+    }
+}

--- a/plan/src/test/java/org/apache/flink/agents/plan/serializer/ResourceProviderSerializerTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/serializer/ResourceProviderSerializerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.plan.serializer;
+
+import org.apache.flink.agents.api.resource.ResourceType;
+import org.apache.flink.agents.plan.resourceprovider.PythonResourceProvider;
+import org.apache.flink.agents.plan.resourceprovider.PythonSerializableResourceProvider;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializationFeature;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Test for {@link ResourceProviderJsonSerializer}. */
+public class ResourceProviderSerializerTest {
+    /**
+     * Reads a JSON file from the resources' directory.
+     *
+     * @param resourcePath the path to the resource file
+     * @return the content of the file as a string
+     * @throws IOException if an I/O error occurs
+     */
+    private String readJsonFromResource(String resourcePath) throws IOException {
+        try (InputStream inputStream =
+                getClass().getClassLoader().getResourceAsStream(resourcePath)) {
+            if (inputStream == null) {
+                throw new IOException("Resource not found: " + resourcePath);
+            }
+            byte[] bytes = inputStream.readAllBytes();
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+    }
+
+    @Test
+    public void testSerializePythonResourceProvider() throws IOException {
+        Map<String, Object> kwargs = new HashMap<>();
+        kwargs.put("host", "8.8.8.8");
+        kwargs.put("desc", "mock chat model");
+        // Create a resource provider.
+        PythonResourceProvider provider =
+                new PythonResourceProvider(
+                        "my_chat_model",
+                        ResourceType.CHAT_MODEL,
+                        "flink_agents.plan.tests.test_resource_provider",
+                        "MockChatModelImpl",
+                        kwargs);
+
+        // Serialize the resource provider to JSON
+        String json =
+                new ObjectMapper()
+                        .enable(SerializationFeature.INDENT_OUTPUT)
+                        .writeValueAsString(provider);
+        // Deserialize the json to map.
+        ObjectMapper mapper = new ObjectMapper();
+        Map<?, ?> actual = mapper.readValue(json, Map.class);
+
+        String expectedJson =
+                readJsonFromResource("resource_providers/python_resource_provider.json");
+        Map<?, ?> expect = mapper.readValue(expectedJson, Map.class);
+        assertEquals(expect, actual);
+    }
+
+    @Test
+    public void testSerializePythonSerializableResourceProvider() throws IOException {
+        Map<String, Object> serialized = new HashMap<>();
+        serialized.put("name", "add");
+
+        // construct arguments schema
+        Map<String, String> a = new HashMap<>();
+        a.put("description", "The first operand");
+        a.put("title", "A");
+        a.put("type", "integer");
+
+        Map<String, String> b = new HashMap<>();
+        b.put("description", "The second operand");
+        b.put("title", "B");
+        b.put("type", "integer");
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("a", a);
+        properties.put("b", b);
+
+        Map<String, Object> argsSchema = new HashMap<>();
+        argsSchema.put("properties", properties);
+        argsSchema.put("required", List.of("a", "b"));
+        argsSchema.put("title", "add");
+        argsSchema.put("type", "object");
+
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("name", "add");
+        metadata.put("description", "Calculate the sum of a and b.\n");
+        metadata.put("args_schema", argsSchema);
+
+        serialized.put("metadata", metadata);
+
+        Map<String, String> func = new HashMap<>();
+        func.put("func_type", "PythonFunction");
+        func.put("module", "flink_agents.runtime.tests.test_built_in_actions");
+        func.put("qualname", "MyAgent.add");
+        serialized.put("func", func);
+        // Create a resource provider.
+        PythonSerializableResourceProvider provider =
+                new PythonSerializableResourceProvider(
+                        "add",
+                        ResourceType.TOOL,
+                        "flink_agents.plan.tools.function_tool",
+                        "FunctionTool",
+                        serialized);
+
+        // Serialize the resource provider to JSON
+        String json =
+                new ObjectMapper()
+                        .enable(SerializationFeature.INDENT_OUTPUT)
+                        .writeValueAsString(provider);
+        // Deserialize the json to map.
+        ObjectMapper mapper = new ObjectMapper();
+        Map<?, ?> actual = mapper.readValue(json, Map.class);
+
+        String expectedJson =
+                readJsonFromResource(
+                        "resource_providers/python_serializable_resource_provider.json");
+        Map<?, ?> expect = mapper.readValue(expectedJson, Map.class);
+        assertEquals(expect, actual);
+    }
+}

--- a/plan/src/test/java/org/apache/flink/agents/plan/serializer/Utils.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/serializer/Utils.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.plan.serializer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public class Utils {
+    /**
+     * Reads a JSON file from the resources' directory.
+     *
+     * @param resourcePath the path to the resource file
+     * @return the content of the file as a string
+     * @throws IOException if an I/O error occurs
+     */
+    public static String readJsonFromResource(String resourcePath) throws IOException {
+        try (InputStream inputStream =
+                Utils.class.getClassLoader().getResourceAsStream(resourcePath)) {
+            if (inputStream == null) {
+                throw new IOException("Resource not found: " + resourcePath);
+            }
+            byte[] bytes = inputStream.readAllBytes();
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/plan/src/test/resources/agent_plans/agent_plan_with_python_resource_providers.json
+++ b/plan/src/test/resources/agent_plans/agent_plan_with_python_resource_providers.json
@@ -1,0 +1,127 @@
+{
+  "actions": {
+    "first_action": {
+      "name": "first_action",
+      "exec": {
+        "func_type": "PythonFunction",
+        "module": "flink_agents.plan.tests.compatibility.python_agent_plan_compatibility_test_agent",
+        "qualname": "PythonAgentPlanCompatibilityTestAgent.first_action"
+      },
+      "listen_event_types": [
+        "flink_agents.api.events.event.InputEvent"
+      ]
+    },
+    "second_action": {
+      "name": "second_action",
+      "exec": {
+        "func_type": "PythonFunction",
+        "module": "flink_agents.plan.tests.compatibility.python_agent_plan_compatibility_test_agent",
+        "qualname": "PythonAgentPlanCompatibilityTestAgent.second_action"
+      },
+      "listen_event_types": [
+        "flink_agents.api.events.event.InputEvent",
+        "flink_agents.plan.tests.compatibility.python_agent_plan_compatibility_test_agent.MyEvent"
+      ]
+    },
+    "chat_model_action": {
+      "name": "chat_model_action",
+      "exec": {
+        "func_type": "PythonFunction",
+        "module": "flink_agents.plan.actions.chat_model_action",
+        "qualname": "process_chat_request_or_tool_response"
+      },
+      "listen_event_types": [
+        "flink_agents.api.events.chat_event.ChatRequestEvent",
+        "flink_agents.api.events.tool_event.ToolResponseEvent"
+      ]
+    },
+    "tool_call_action": {
+      "name": "tool_call_action",
+      "exec": {
+        "func_type": "PythonFunction",
+        "module": "flink_agents.plan.actions.tool_call_action",
+        "qualname": "process_tool_request"
+      },
+      "listen_event_types": [
+        "flink_agents.api.events.tool_event.ToolRequestEvent"
+      ]
+    }
+  },
+  "actions_by_event": {
+    "flink_agents.api.events.event.InputEvent": [
+      "first_action",
+      "second_action"
+    ],
+    "flink_agents.plan.tests.compatibility.python_agent_plan_compatibility_test_agent.MyEvent": [
+      "second_action"
+    ],
+    "flink_agents.api.events.chat_event.ChatRequestEvent": [
+      "chat_model_action"
+    ],
+    "flink_agents.api.events.tool_event.ToolResponseEvent": [
+      "chat_model_action"
+    ],
+    "flink_agents.api.events.tool_event.ToolRequestEvent": [
+      "tool_call_action"
+    ]
+  },
+  "resource_providers": {
+    "chat_model": {
+      "chat_model": {
+        "name": "chat_model",
+        "type": "chat_model",
+        "module": "flink_agents.plan.tests.compatibility.python_agent_plan_compatibility_test_agent",
+        "clazz": "MockChatModel",
+        "kwargs": {
+          "name": "chat_model",
+          "prompt": "prompt",
+          "tools": [
+            "add"
+          ]
+        },
+        "__resource_provider_type__": "PythonResourceProvider"
+      }
+    },
+    "tool": {
+      "add": {
+        "name": "add",
+        "type": "tool",
+        "module": "flink_agents.plan.tools.function_tool",
+        "clazz": "FunctionTool",
+        "serialized": {
+          "name": "add",
+          "metadata": {
+            "name": "add",
+            "description": "Calculate the sum of a and b.\n",
+            "args_schema": {
+              "properties": {
+                "a": {
+                  "description": "The first operand",
+                  "title": "A",
+                  "type": "integer"
+                },
+                "b": {
+                  "description": "The second operand",
+                  "title": "B",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "a",
+                "b"
+              ],
+              "title": "add",
+              "type": "object"
+            }
+          },
+          "func": {
+            "func_type": "PythonFunction",
+            "module": "flink_agents.plan.tests.compatibility.python_agent_plan_compatibility_test_agent",
+            "qualname": "PythonAgentPlanCompatibilityTestAgent.add"
+          }
+        },
+        "__resource_provider_type__": "PythonSerializableResourceProvider"
+      }
+    }
+  }
+}

--- a/plan/src/test/resources/resource_providers/python_resource_provider.json
+++ b/plan/src/test/resources/resource_providers/python_resource_provider.json
@@ -1,0 +1,11 @@
+{
+  "name" : "my_chat_model",
+  "type" : "chat_model",
+  "module" : "flink_agents.plan.tests.test_resource_provider",
+  "clazz" : "MockChatModelImpl",
+  "kwargs" : {
+    "host" : "8.8.8.8",
+    "desc" : "mock chat model"
+  },
+  "__resource_provider_type__" : "PythonResourceProvider"
+}

--- a/plan/src/test/resources/resource_providers/python_serializable_resource_provider.json
+++ b/plan/src/test/resources/resource_providers/python_serializable_resource_provider.json
@@ -1,0 +1,39 @@
+{
+  "name": "add",
+  "type": "tool",
+  "module": "flink_agents.plan.tools.function_tool",
+  "clazz": "FunctionTool",
+  "serialized": {
+    "name": "add",
+    "metadata": {
+      "name": "add",
+      "description": "Calculate the sum of a and b.\n",
+      "args_schema": {
+        "properties": {
+          "a": {
+            "description": "The first operand",
+            "title": "A",
+            "type": "integer"
+          },
+          "b": {
+            "description": "The second operand",
+            "title": "B",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "a",
+          "b"
+        ],
+        "title": "add",
+        "type": "object"
+      }
+    },
+    "func": {
+      "func_type": "PythonFunction",
+      "module": "flink_agents.runtime.tests.test_built_in_actions",
+      "qualname": "MyAgent.add"
+    }
+  },
+  "__resource_provider_type__": "PythonSerializableResourceProvider"
+}

--- a/python/flink_agents/examples/my_agent.py
+++ b/python/flink_agents/examples/my_agent.py
@@ -23,8 +23,9 @@ from typing import Any, Optional
 from pydantic import BaseModel
 
 from flink_agents.api.agent import Agent
-from flink_agents.api.decorators import action
+from flink_agents.api.decorators import action, tool
 from flink_agents.api.events.event import Event, InputEvent, OutputEvent
+from flink_agents.api.resource import ResourceType
 from flink_agents.api.runner_context import RunnerContext
 
 
@@ -58,6 +59,23 @@ class DataStreamAgent(Agent):
     define this class directly in example.py for module name will be set
     to __main__.
     """
+
+    @tool
+    @staticmethod
+    def my_tool(input: str) -> str:
+        """Mark call tool.
+
+        Parameters
+        ----------
+        input : str
+            The input string
+
+        Returns:
+        -------
+        str:
+            The return string
+        """
+        return input + " call my tool"
 
     @action(InputEvent)
     @staticmethod
@@ -97,6 +115,8 @@ class DataStreamAgent(Agent):
 
         content = copy.deepcopy(input)
         content.review += " second action"
+        tool = ctx.get_resource("my_tool", ResourceType.TOOL)
+        content.review = tool.call(content.review)
         content.memory_info = memory_info
         ctx.send_event(OutputEvent(output=content))
 

--- a/python/flink_agents/plan/resource_provider.py
+++ b/python/flink_agents/plan/resource_provider.py
@@ -20,7 +20,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from flink_agents.api.resource import (
     Resource,
@@ -108,7 +108,7 @@ class PythonSerializableResourceProvider(SerializableResourceProvider):
     """
 
     serialized: Dict[str, Any]
-    resource: Optional[SerializableResource] = None
+    resource: Optional[SerializableResource] = Field(exclude=True, default=None)
 
     @staticmethod
     def from_resource(
@@ -129,7 +129,7 @@ class PythonSerializableResourceProvider(SerializableResourceProvider):
         if self.resource is None:
             module = importlib.import_module(self.module)
             clazz = getattr(module, self.clazz)
-            self.resource = clazz.model_validate(**self.serialized)
+            self.resource = clazz.model_validate(self.serialized)
         return self.resource
 
 

--- a/python/flink_agents/plan/tests/compatibility/generate_agent_plan_json.py
+++ b/python/flink_agents/plan/tests/compatibility/generate_agent_plan_json.py
@@ -31,6 +31,5 @@ if __name__ == "__main__":
     json_path = sys.argv[1]
     agent_plan = AgentPlan.from_agent(PythonAgentPlanCompatibilityTestAgent())
     json_value = agent_plan.model_dump_json(serialize_as_any=True, indent=4)
-
     with Path(json_path).open("w") as f:
         f.write(json_value)

--- a/python/flink_agents/plan/tests/compatibility/python_agent_plan_compatibility_test_agent.py
+++ b/python/flink_agents/plan/tests/compatibility/python_agent_plan_compatibility_test_agent.py
@@ -15,8 +15,12 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 #################################################################################
+from typing import Any, Dict, Sequence, Tuple, Type
+
 from flink_agents.api.agent import Agent
-from flink_agents.api.decorators import action
+from flink_agents.api.chat_message import ChatMessage
+from flink_agents.api.chat_models.chat_model import BaseChatModel
+from flink_agents.api.decorators import action, chat_model, tool
 from flink_agents.api.events.event import Event, InputEvent
 from flink_agents.api.runner_context import RunnerContext
 
@@ -24,6 +28,11 @@ from flink_agents.api.runner_context import RunnerContext
 class MyEvent(Event):
     """Test event."""
 
+class MockChatModel(BaseChatModel):
+    """Mock ChatModel for testing integrating prompt and tool."""
+
+    def chat(self, messages: Sequence[ChatMessage]) -> ChatMessage:
+        """Only for test plan compatibility."""
 
 class PythonAgentPlanCompatibilityTestAgent(Agent):
     """Agent for generating python agent plan json."""
@@ -37,3 +46,32 @@ class PythonAgentPlanCompatibilityTestAgent(Agent):
     @staticmethod
     def second_action(event: InputEvent, ctx: RunnerContext) -> None:
         """Test implementation."""
+
+    @chat_model
+    @staticmethod
+    def chat_model() -> Tuple[Type[BaseChatModel], Dict[str, Any]]:
+        """ChatModel can be used in action."""
+        return MockChatModel, {
+            "name": "chat_model",
+            "prompt": "prompt",
+            "tools": ["add"],
+        }
+
+    @tool
+    @staticmethod
+    def add(a: int, b: int) -> int:
+        """Calculate the sum of a and b.
+
+        Parameters
+        ----------
+        a : int
+            The first operand
+        b : int
+            The second operand
+
+        Returns:
+        -------
+        int:
+            The sum of a and b
+        """
+        return a + b

--- a/python/flink_agents/plan/tests/resources/serializable_resource_provider.json
+++ b/python/flink_agents/plan/tests/resources/serializable_resource_provider.json
@@ -1,0 +1,39 @@
+{
+    "name": "add",
+    "type": "tool",
+    "module": "flink_agents.plan.tools.function_tool",
+    "clazz": "FunctionTool",
+    "serialized": {
+        "name": "add",
+        "metadata": {
+            "name": "add",
+            "description": "Calculate the sum of a and b.\n",
+            "args_schema": {
+                "properties": {
+                    "a": {
+                        "description": "The first operand",
+                        "title": "A",
+                        "type": "integer"
+                    },
+                    "b": {
+                        "description": "The second operand",
+                        "title": "B",
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "a",
+                    "b"
+                ],
+                "title": "add",
+                "type": "object"
+            }
+        },
+        "func": {
+            "func_type": "PythonFunction",
+            "module": "flink_agents.runtime.tests.test_built_in_actions",
+            "qualname": "MyAgent.add"
+        }
+    },
+    "__resource_provider_type__": "PythonSerializableResourceProvider"
+}


### PR DESCRIPTION


Linked issue: #104 

### Purpose of change

Support serialize and deserialize AgentPlan with python resource providers.

### Tests

unit test and end-to-end test

### API

No

### Documentation

No
