### PR TITLE
[api][python] Separate the abstraction of ChatModel to connection and settings

### DIFF
--- a/python/flink_agents/api/agent.py
+++ b/python/flink_agents/api/agent.py
@@ -18,7 +18,10 @@
 from abc import ABC
 from typing import Any, Callable, Dict, List, Tuple, Type
 
-from flink_agents.api.chat_models.chat_model import BaseChatModel
+from flink_agents.api.chat_models.chat_model import (
+    BaseChatModelServer,
+    ChatModel,
+)
 from flink_agents.api.events.event import Event
 from flink_agents.api.prompts.prompt import Prompt
 
@@ -39,10 +42,17 @@ class Agent(ABC):
                 def my_action(event: Event, ctx: RunnerContext) -> None:
                     action logic
 
+                @chat_model_server
+                @staticmethod
+                def my_server() -> Tuple[Type[BaseChatModelServer], Dict[str, Any]]:
+                    return OllamaChatModelServer, {"name": "my_server",
+                                                   "model": "qwen2:7b",
+                                                   "base_url": "http://localhost:11434"}
+
                 @chat_model
                 @staticmethod
-                def my_chat_model() -> Tuple[Type[BaseChatModel], Dict[str, Any]]:
-                    return ChatModel, {"name": xxx, "arg1": xxx}
+                def my_chat_model() -> Tuple[Type[ChatModel], Dict[str, Any]]:
+                    return OllamaChatModel, {"name": "model", "server": "my_server"}
         * Add actions and resources to an Agent instance
         ::
 
@@ -50,23 +60,31 @@ class Agent(ABC):
             my_agent.add_action(name="my_action",
                                 events=[InputEvent],
                                 func=action_function)
+                    .add_chat_model_server(name="my_server",
+                                              server=OllamaChatModelServer,
+                                              arg1=xxx)
                     .add_chat_model(name="my_chat_model",
-                                    chat_model=ChatModel
-                                    arg1=xxx)
+                                    chat_model=OllamaChatModel,
+                                    server="my_server")
     """
+
     _actions: Dict[str, Tuple[List[Type[Event]], Callable]]
     _prompts: Dict[str, Prompt]
     _tools: Dict[str, Callable]
-    _chat_models: Dict[str, Tuple[Type[BaseChatModel], Dict[str, Any]]]
+    _chat_model_servers: Dict[str, Tuple[Type[BaseChatModelServer], Dict[str, Any]]]
+    _chat_models: Dict[str, Tuple[Type[ChatModel], Dict[str, Any]]]
 
     def __init__(self) -> None:
         """Init method."""
         self._actions = {}
         self._prompts = {}
         self._tools = {}
+        self._chat_model_servers = {}
         self._chat_models = {}
 
-    def add_action(self, name: str, events: List[Type[Event]], func: Callable) -> "Agent":
+    def add_action(
+        self, name: str, events: List[Type[Event]], func: Callable
+    ) -> "Agent":
         """Add action to agent.
 
         Parameters
@@ -131,7 +149,35 @@ class Agent(ABC):
         self._tools[name] = func
         return self
 
-    def add_chat_model(self, name: str, chat_model: Type[BaseChatModel], **kwargs: Any) -> "Agent":
+    def add_chat_model_server(
+        self, name: str, server: Type[BaseChatModelServer], **kwargs: Any
+    ) -> "Agent":
+        """Add chat model server to agent.
+
+        Parameters
+        ----------
+        name : str
+            The name of the chat model server, should be unique in the same Agent.
+        server: Type[BaseChatModelServer]
+            The type of chat model server.
+        **kwargs: Any
+            Initialize keyword arguments passed to the chat model server.
+
+        Returns:
+        -------
+        Agent
+            The modified Agent instance.
+        """
+        if name in self._chat_model_servers:
+            msg = f"Chat model server {name} already defined"
+            raise ValueError(msg)
+        kwargs["name"] = name
+        self._chat_model_servers[name] = (server, kwargs)
+        return self
+
+    def add_chat_model(
+        self, name: str, chat_model: Type[ChatModel], **kwargs: Any
+    ) -> "Agent":
         """Add chat model to agent.
 
         Parameters

--- a/python/flink_agents/api/agent.py
+++ b/python/flink_agents/api/agent.py
@@ -19,8 +19,8 @@ from abc import ABC
 from typing import Any, Callable, Dict, List, Tuple, Type
 
 from flink_agents.api.chat_models.chat_model import (
-    BaseChatModelServer,
-    ChatModel,
+    BaseChatModelConnection,
+    BaseChatModelSetup,
 )
 from flink_agents.api.events.event import Event
 from flink_agents.api.prompts.prompt import Prompt
@@ -71,8 +71,8 @@ class Agent(ABC):
     _actions: Dict[str, Tuple[List[Type[Event]], Callable]]
     _prompts: Dict[str, Prompt]
     _tools: Dict[str, Callable]
-    _chat_model_servers: Dict[str, Tuple[Type[BaseChatModelServer], Dict[str, Any]]]
-    _chat_models: Dict[str, Tuple[Type[ChatModel], Dict[str, Any]]]
+    _chat_model_servers: Dict[str, Tuple[Type[BaseChatModelConnection], Dict[str, Any]]]
+    _chat_models: Dict[str, Tuple[Type[BaseChatModelSetup], Dict[str, Any]]]
 
     def __init__(self) -> None:
         """Init method."""
@@ -150,7 +150,7 @@ class Agent(ABC):
         return self
 
     def add_chat_model_server(
-        self, name: str, server: Type[BaseChatModelServer], **kwargs: Any
+        self, name: str, server: Type[BaseChatModelConnection], **kwargs: Any
     ) -> "Agent":
         """Add chat model server to agent.
 
@@ -158,7 +158,7 @@ class Agent(ABC):
         ----------
         name : str
             The name of the chat model server, should be unique in the same Agent.
-        server: Type[BaseChatModelServer]
+        server: Type[BaseChatModelConnection]
             The type of chat model server.
         **kwargs: Any
             Initialize keyword arguments passed to the chat model server.
@@ -176,7 +176,7 @@ class Agent(ABC):
         return self
 
     def add_chat_model(
-        self, name: str, chat_model: Type[ChatModel], **kwargs: Any
+        self, name: str, chat_model: Type[BaseChatModelSetup], **kwargs: Any
     ) -> "Agent":
         """Add chat model to agent.
 

--- a/python/flink_agents/api/chat_models/chat_model.py
+++ b/python/flink_agents/api/chat_models/chat_model.py
@@ -16,29 +16,87 @@
 # limitations under the License.
 #################################################################################
 from abc import ABC, abstractmethod
-from typing import List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
+from pydantic import Field
 from typing_extensions import override
 
 from flink_agents.api.chat_message import ChatMessage
 from flink_agents.api.prompts.prompt import Prompt
 from flink_agents.api.resource import Resource, ResourceType
+from flink_agents.api.tools.tool import BaseTool
 
 
-class BaseChatModel(Resource, ABC):
-    """Base abstract class for chat models.
+class BaseChatModelServer(Resource, ABC):
+    """Base abstract class for chat model server.
 
-    Attributes:
-    ----------
-    prompt : Optional[Union[Prompt, str]] = None
-        Used for generating prompt filling by input messages. Could be Prompt object
-        or str indicate the Prompt resource in Agent.
-    tools : Optional[List[str]] = None
-        Tools name can be call by the ChatModel.
+    Responsible for managing model service connection configurations, such as:
+    - Service address (base_url)
+    - API key (api_key)
+    - Connection timeout (timeout)
+    - Model name (model_name)
+    - Authentication information, etc.
+
+    Provides the basic chat interface for direct communication with model services.
+
+    One server can be shared in multiple chat models.
     """
 
+    @classmethod
+    @override
+    def resource_type(cls) -> ResourceType:
+        """Return resource type of class."""
+        return ResourceType.CHAT_MODEL_SERVER
+
+    @abstractmethod
+    def chat(
+        self,
+        messages: Sequence[ChatMessage],
+        tools: Optional[List[BaseTool]] = None,
+        **kwargs: Any,
+    ) -> ChatMessage:
+        """Direct communication with model service for chat conversation.
+
+        Parameters
+        ----------
+        messages : Sequence[ChatMessage]
+            Input message sequence
+        tools : Optional[List]
+            List of tools that can be called by the model
+        **kwargs : Any
+            Additional parameters passed to the model service (e.g., temperature,
+            max_tokens, etc.)
+
+        Returns:
+        -------
+        ChatMessage
+            Model response message
+        """
+
+
+class ChatModel(Resource):
+    """Chat model implementation.
+
+    Responsible for managing chat configurations, such as:
+    - Prompt templates (prompt)
+    - Available tools (tools)
+    - Generation parameters (temperature, max_tokens, etc.)
+    - Context management
+
+    Internally calls ChatModelServer to perform actual communication with llm.
+
+    Different chat models can call the same chat model server with different chat
+    arguments.
+    """
+
+    server: str = Field(description="Name of the referenced server.")
     prompt: Optional[Union[Prompt, str]] = None
     tools: Optional[List[str]] = None
+
+    @property
+    @abstractmethod
+    def model_kwargs(self) -> Dict[str, Any]:
+        """Return chat model settings."""
 
     @classmethod
     @override
@@ -46,17 +104,51 @@ class BaseChatModel(Resource, ABC):
         """Return resource type of class."""
         return ResourceType.CHAT_MODEL
 
-    @abstractmethod
-    def chat(self, messages: Sequence[ChatMessage]) -> ChatMessage:
-        """Process a sequence of messages, and return a response.
+    def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatMessage:
+        """Execute chat conversation.
+
+        1. Apply prompt template (if any)
+        2. Bind tools (if any)
+        3. Call ChatModelConnection to perform actual communication
+        4. Process response
 
         Parameters
         ----------
         messages : Sequence[ChatMessage]
-            Sequence of chat messages.
+            Input message sequence
+        **kwargs : Any
+            Additional parameters passed to the model service
 
         Returns:
         -------
         ChatMessage
-            Response from the ChatModel.
+            Model response message
         """
+        # Get model connection
+        server = self.get_resource(self.server, ResourceType.CHAT_MODEL_SERVER)
+
+        # Apply prompt template
+        if self.prompt is not None:
+            if isinstance(self.prompt, str):
+                # Get prompt resource if it's a string
+                prompt = self.get_resource(self.prompt, ResourceType.PROMPT)
+            else:
+                prompt = self.prompt
+
+            input_variable = {}
+            for msg in messages:
+                input_variable.update(msg.extra_args)
+            messages = prompt.format_messages(**input_variable)
+
+        # Bind tools
+        tools = None
+        if self.tools is not None:
+            tools = [
+                self.get_resource(tool_name, ResourceType.TOOL)
+                for tool_name in self.tools
+            ]
+
+        # Call server to execute chat
+        merged_kwargs = self.model_kwargs.copy()
+        merged_kwargs.update(kwargs)
+        return server.chat(messages, tools=tools, **merged_kwargs)

--- a/python/flink_agents/api/decorators.py
+++ b/python/flink_agents/api/decorators.py
@@ -52,6 +52,24 @@ def action(*listen_events: Type[Event]) -> Callable:
     return decorator
 
 
+def chat_model_server(func: Callable) -> Callable:
+    """Decorator for marking a function declaring a chat model server.
+
+    Parameters
+    ----------
+    func : Callable
+        Function to be decorated.
+
+    Returns:
+    -------
+    Callable
+        Decorator function that marks the target function declare a chat model
+        connection.
+    """
+    func._is_chat_model_server = True
+    return func
+
+
 def chat_model(func: Callable) -> Callable:
     """Decorator for marking a function declaring a chat model.
 

--- a/python/flink_agents/api/events/event.py
+++ b/python/flink_agents/api/events/event.py
@@ -54,8 +54,8 @@ class Event(BaseModel, ABC, extra="allow"):
     def model_dump_json(self, **kwargs: Any) -> str:
         """Override model_dump_json to handle Row objects using fallback."""
         # Set fallback if not provided in kwargs
-        if 'fallback' not in kwargs:
-            kwargs['fallback'] = self.__serialize_unknown
+        if "fallback" not in kwargs:
+            kwargs["fallback"] = self.__serialize_unknown
         return super().model_dump_json(**kwargs)
 
     @model_validator(mode="after")

--- a/python/flink_agents/api/resource.py
+++ b/python/flink_agents/api/resource.py
@@ -29,7 +29,7 @@ class ResourceType(Enum):
     """
 
     CHAT_MODEL = "chat_model"
-    CHAT_MODEL_SERVER = "chat_model_server"
+    CHAT_MODEL_CONNECTION = "chat_model_connection"
     TOOL = "tool"
     # EMBEDDING_MODEL = "embedding_model"
     PROMPT = "prompt"

--- a/python/flink_agents/api/resource.py
+++ b/python/flink_agents/api/resource.py
@@ -25,10 +25,11 @@ from pydantic import BaseModel, Field, model_validator
 class ResourceType(Enum):
     """Type enum of resource.
 
-    Currently, only support chat_model, tool and prompt.
+    Currently, support chat_model, chat_model_server, tool and prompt.
     """
 
     CHAT_MODEL = "chat_model"
+    CHAT_MODEL_SERVER = "chat_model_server"
     TOOL = "tool"
     # EMBEDDING_MODEL = "embedding_model"
     PROMPT = "prompt"

--- a/python/flink_agents/api/tests/test_event.py
+++ b/python/flink_agents/api/tests/test_event.py
@@ -77,6 +77,7 @@ def test_efficient_row_serialization_with_fallback() -> None:
 
     json_str = event.model_dump_json()
     import json
+
     parsed = json.loads(json_str)
 
     assert parsed["input"]["type"] == "Row"
@@ -98,16 +99,19 @@ def test_efficient_row_serialization_with_fallback() -> None:
 
 def test_event_with_mixed_serializable_types() -> None:
     """Test event with mix of normal and Row types."""
-    event = InputEvent(input={
-        "normal_data": {"key": "value"},
-        "row_data": Row({"test": "data"}),
-        "list_data": [1, 2, 3],
-        "nested_row": {"inner": Row({"nested": True})}
-    })
+    event = InputEvent(
+        input={
+            "normal_data": {"key": "value"},
+            "row_data": Row({"test": "data"}),
+            "list_data": [1, 2, 3],
+            "nested_row": {"inner": Row({"nested": True})},
+        }
+    )
 
     json_str = event.model_dump_json()
 
     import json
+
     parsed = json.loads(json_str)
 
     # Normal data should be serialized normally
@@ -121,4 +125,3 @@ def test_event_with_mixed_serializable_types() -> None:
 
 def test_input_event_ignore_row_unserializable() -> None:  # noqa D103
     InputEvent(input=Row({"a": 1}))
-

--- a/python/flink_agents/api/tools/tool.py
+++ b/python/flink_agents/api/tools/tool.py
@@ -98,16 +98,14 @@ class ToolMetadata(BaseModel):
         }
         return parameters
 
-    def to_openai_tool(self, skip_length_check: bool = False) -> typing.Dict[str, Any]: # noqa:FBT001
+    def to_openai_tool(self, skip_length_check: bool = False) -> typing.Dict[str, Any]:  # noqa:FBT001
         """To OpenAI tool."""
         if not skip_length_check and len(self.description) > 1024:
             msg = (
                 "Tool description exceeds maximum length of 1024 characters. "
                 "Please shorten your description or move it to the prompt."
             )
-            raise ValueError(
-                msg
-            )
+            raise ValueError(msg)
         return {
             "type": "function",
             "function": {

--- a/python/flink_agents/examples/chat_ollama_exmaple.py
+++ b/python/flink_agents/examples/chat_ollama_exmaple.py
@@ -21,8 +21,8 @@ from typing import Any, Dict, Tuple, Type
 from flink_agents.api.agent import Agent
 from flink_agents.api.chat_message import ChatMessage, MessageRole
 from flink_agents.api.chat_models.chat_model import (
-    BaseChatModelServer,
-    ChatModel,
+    BaseChatModelConnection,
+    BaseChatModelSetup,
 )
 from flink_agents.api.decorators import action, chat_model, chat_model_server, tool
 from flink_agents.api.events.chat_event import ChatRequestEvent, ChatResponseEvent
@@ -33,8 +33,8 @@ from flink_agents.api.events.event import (
 from flink_agents.api.execution_environment import AgentsExecutionEnvironment
 from flink_agents.api.runner_context import RunnerContext
 from flink_agents.integrations.chat_models.ollama_chat_model import (
-    OllamaChatModel,
-    OllamaChatModelServer,
+    OllamaChatModelConnection,
+    OllamaChatModelSetup,
 )
 
 model = os.environ.get("OLLAMA_CHAT_MODEL", "qwen3:8b")
@@ -45,18 +45,18 @@ class MyAgent(Agent):
 
     @chat_model_server
     @staticmethod
-    def ollama_server() -> Tuple[Type[BaseChatModelServer], Dict[str, Any]]:
+    def ollama_server() -> Tuple[Type[BaseChatModelConnection], Dict[str, Any]]:
         """ChatModelServer responsible for model service connection."""
-        return OllamaChatModelServer, {
+        return OllamaChatModelConnection, {
             "name": "ollama_server",
             "model": model,
         }
 
     @chat_model
     @staticmethod
-    def math_chat_model() -> Tuple[Type[ChatModel], Dict[str, Any]]:
+    def math_chat_model() -> Tuple[Type[BaseChatModelSetup], Dict[str, Any]]:
         """ChatModel which focus on math, and reuse ChatModelServer."""
-        return OllamaChatModel, {
+        return OllamaChatModelSetup, {
             "name": "math_chat_model",
             "server": "ollama_server",
             "tools": ["add"],
@@ -64,9 +64,9 @@ class MyAgent(Agent):
 
     @chat_model
     @staticmethod
-    def creative_chat_model() -> Tuple[Type[ChatModel], Dict[str, Any]]:
+    def creative_chat_model() -> Tuple[Type[BaseChatModelSetup], Dict[str, Any]]:
         """ChatModel which focus on text generate, and reuse ChatModelServer."""
-        return OllamaChatModel, {
+        return OllamaChatModelSetup, {
             "name": "creative_chat_model",
             "server": "ollama_server",
         }

--- a/python/flink_agents/examples/chat_ollama_exmaple.py
+++ b/python/flink_agents/examples/chat_ollama_exmaple.py
@@ -20,8 +20,11 @@ from typing import Any, Dict, Tuple, Type
 
 from flink_agents.api.agent import Agent
 from flink_agents.api.chat_message import ChatMessage, MessageRole
-from flink_agents.api.chat_models.chat_model import BaseChatModel
-from flink_agents.api.decorators import action, chat_model, tool
+from flink_agents.api.chat_models.chat_model import (
+    BaseChatModelServer,
+    ChatModel,
+)
+from flink_agents.api.decorators import action, chat_model, chat_model_server, tool
 from flink_agents.api.events.chat_event import ChatRequestEvent, ChatResponseEvent
 from flink_agents.api.events.event import (
     InputEvent,
@@ -29,22 +32,43 @@ from flink_agents.api.events.event import (
 )
 from flink_agents.api.execution_environment import AgentsExecutionEnvironment
 from flink_agents.api.runner_context import RunnerContext
-from flink_agents.integrations.chat_models.ollama_chat_model import OllamaChatModel
+from flink_agents.integrations.chat_models.ollama_chat_model import (
+    OllamaChatModel,
+    OllamaChatModelServer,
+)
 
 model = os.environ.get("OLLAMA_CHAT_MODEL", "qwen3:8b")
 
 
 class MyAgent(Agent):
-    """Mock agent for testing chat ollama in agent."""
+    """Example agent demonstrating the new ChatModel architecture."""
+
+    @chat_model_server
+    @staticmethod
+    def ollama_server() -> Tuple[Type[BaseChatModelServer], Dict[str, Any]]:
+        """ChatModelServer responsible for model service connection."""
+        return OllamaChatModelServer, {
+            "name": "ollama_server",
+            "model": model,
+        }
 
     @chat_model
     @staticmethod
-    def chat_model() -> Tuple[Type[BaseChatModel], Dict[str, Any]]:
-        """ChatModel can be used in action."""
+    def math_chat_model() -> Tuple[Type[ChatModel], Dict[str, Any]]:
+        """ChatModel which focus on math, and reuse ChatModelServer."""
         return OllamaChatModel, {
-            "name": "chat_model",
-            "model": model,
+            "name": "math_chat_model",
+            "server": "ollama_server",
             "tools": ["add"],
+        }
+
+    @chat_model
+    @staticmethod
+    def creative_chat_model() -> Tuple[Type[ChatModel], Dict[str, Any]]:
+        """ChatModel which focus on text generate, and reuse ChatModelServer."""
+        return OllamaChatModel, {
+            "name": "creative_chat_model",
+            "server": "ollama_server",
         }
 
     @tool
@@ -73,11 +97,20 @@ class MyAgent(Agent):
 
         In this action, we will send ChatRequestEvent to trigger built-in actions.
         """
-        input = event.input
+        """Choose different sessions based on input content."""
+        input_text = event.input.lower()
+
+        if "calculate" in input_text or "sum" in input_text:
+            # Use math_session for calculations
+            model_name = "math_chat_model"
+        else:
+            # Use creative_session for other tasks
+            model_name = "creative_chat_model"
+
         ctx.send_event(
             ChatRequestEvent(
-                model="chat_model",
-                messages=[ChatMessage(role=MessageRole.USER, content=input)],
+                model=model_name,
+                messages=[ChatMessage(role=MessageRole.USER, content=event.input)],
             )
         )
 
@@ -88,18 +121,21 @@ class MyAgent(Agent):
         input = event.response
         ctx.send_event(OutputEvent(output=input.content))
 
+
 # Should manually start ollama server before run this example.
 if __name__ == "__main__":
     env = AgentsExecutionEnvironment.get_execution_environment()
 
     input_list = []
-    agent = MyAgent()
+    agent = MyAgent()  # Or use NewArchitectureAgent() to test new architecture
 
     output_list = env.from_list(input_list).apply(agent).to_list()
 
     input_list.append({"key": "0001", "value": "calculate the sum of 1 and 2."})
+    input_list.append({"key": "0002", "value": "Can you tell a joke about cat."})
 
     env.execute()
 
-    for key, value in output_list[0].items():
-        print(f"{key}: {value}")
+    for output in output_list:
+        for key, value in output.items():
+            print(f"{key}: {value}")

--- a/python/flink_agents/integrations/chat_models/ollama_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/ollama_chat_model.py
@@ -17,21 +17,21 @@
 #################################################################################
 import re
 import uuid
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from ollama import Client, Message
 from pydantic import Field
 
 from flink_agents.api.chat_message import ChatMessage, MessageRole
-from flink_agents.api.chat_models.chat_model import BaseChatModel
-from flink_agents.api.resource import ResourceType
+from flink_agents.api.chat_models.chat_model import BaseChatModelServer, ChatModel
+from flink_agents.api.tools.tool import BaseTool
 
 DEFAULT_CONTEXT_WINDOW = 2048
 DEFAULT_REQUEST_TIMEOUT = 30.0
 
 
-class OllamaChatModel(BaseChatModel):
-    """Ollama ChatModel.
+class OllamaChatModelServer(BaseChatModelServer):
+    """Ollama ChatModelServer whichs manage the connection to the Ollama server.
 
     Visit https://ollama.com/ to download and install Ollama.
 
@@ -45,73 +45,27 @@ class OllamaChatModel(BaseChatModel):
         description="Base url the model is hosted under.",
     )
     model: str = Field(description="Model name to use.")
-    temperature: float = Field(
-        default=0.75,
-        description="The temperature to use for sampling.",
-        ge=0.0,
-        le=1.0,
-    )
-    num_ctx: int = Field(
-        default=DEFAULT_CONTEXT_WINDOW,
-        description="The maximum number of context tokens for the model.",
-        gt=0,
-    )
     request_timeout: float = Field(
         default=DEFAULT_REQUEST_TIMEOUT,
         description="The timeout for making http request to Ollama API server",
     )
-    additional_kwargs: Dict[str, Any] = Field(
-        default_factory=dict,
-        description="Additional model parameters for the Ollama API.",
-    )
-    keep_alive: Optional[Union[float, str]] = Field(
-        default="5m",
-        description="controls how long the model will stay loaded into memory following the request(default: 5m)",
-    )
-    extract_reasoning: bool = Field(
-        default=False,
-        description="If True, extracts content within <think></think> tags from the response and stores it in additional_kwargs.",
-    )
 
     __client: Client = None
-    __tools: Sequence[Mapping[str, Any]] = []
 
     def __init__(
         self,
         model: str,
         base_url: str = "http://localhost:11434",
-        temperature: float = 0.75,
-        num_ctx: int = DEFAULT_CONTEXT_WINDOW,
         request_timeout: Optional[float] = DEFAULT_REQUEST_TIMEOUT,
-        additional_kwargs: Optional[Dict[str, Any]] = None,
-        keep_alive: Optional[Union[float, str]] = None,
-        extract_reasoning: Optional[bool] = False,
         **kwargs: Any,
     ) -> None:
         """Init method."""
-        if additional_kwargs is None:
-            additional_kwargs = {}
         super().__init__(
             model=model,
             base_url=base_url,
-            temperature=temperature,
-            num_ctx=num_ctx,
             request_timeout=request_timeout,
-            additional_kwargs=additional_kwargs,
-            keep_alive=keep_alive,
-            extract_reasoning=extract_reasoning,
             **kwargs,
         )
-        # bind tools
-        if self.tools is not None:
-            tools = [
-                self.get_resource(tool_name, ResourceType.TOOL)
-                for tool_name in self.tools
-            ]
-            self.__tools = [tool.metadata.to_openai_tool() for tool in tools]
-        # bind prompt
-        if self.prompt is not None and isinstance(self.prompt, str):
-            self.prompt = self.get_resource(self.prompt, ResourceType.PROMPT)
 
     @property
     def client(self) -> Client:
@@ -119,18 +73,6 @@ class OllamaChatModel(BaseChatModel):
         if self.__client is None:
             self.__client = Client(host=self.base_url, timeout=self.request_timeout)
         return self.__client
-
-    @property
-    def model_kwargs(self) -> Dict[str, Any]:
-        """Return ollama model configuration."""
-        base_kwargs = {
-            "temperature": self.temperature,
-            "num_ctx": self.num_ctx,
-        }
-        return {
-            **base_kwargs,
-            **self.additional_kwargs,
-        }
 
     @staticmethod
     def __extract_think_tags(content: str) -> Tuple[str, Optional[str]]:
@@ -154,27 +96,33 @@ class OllamaChatModel(BaseChatModel):
         cleaned_content = re.sub(think_pattern, "", content, flags=re.DOTALL)
 
         # Clean up any extra whitespace that might have been created
-        cleaned_content = re.sub(r'\n{3,}', '\n\n', cleaned_content)
-        cleaned_content = re.sub(r' {2,}', ' ', cleaned_content)
+        cleaned_content = re.sub(r"\n{3,}", "\n\n", cleaned_content)
+        cleaned_content = re.sub(r" {2,}", " ", cleaned_content)
         cleaned_content = cleaned_content.strip()
 
         return cleaned_content, reasoning
 
-    def chat(self, messages: Sequence[ChatMessage]) -> ChatMessage:
+    def chat(
+        self,
+        messages: Sequence[ChatMessage],
+        tools: Optional[List[BaseTool]] = None,
+        **kwargs: Any,
+    ) -> ChatMessage:
         """Process a sequence of messages, and return a response."""
-        if self.prompt is not None:
-            input_variable = {}
-            for msg in messages:
-                input_variable.update(msg.additional_kwargs)
-            messages = self.prompt.format_messages(**input_variable)
         ollama_messages = self.__convert_to_ollama_messages(messages)
+
+        # Convert tool format
+        ollama_tools = None
+        if tools is not None:
+            ollama_tools = [tool.metadata.to_openai_tool() for tool in tools]
+
         response = self.client.chat(
             model=self.model,
             messages=ollama_messages,
             stream=False,
-            tools=self.__tools,
-            options=self.model_kwargs,
-            keep_alive=self.keep_alive,
+            tools=ollama_tools,
+            options=kwargs,
+            keep_alive=kwargs.get("keep_alive", False),
         )
 
         ollama_tool_calls = response.message.tool_calls
@@ -196,7 +144,7 @@ class OllamaChatModel(BaseChatModel):
         extra_args = {}
 
         # Process reasoning if extract_reasoning is enabled
-        if self.extract_reasoning and content:
+        if kwargs.get("extract_reasoning") and content:
             cleaned_content, reasoning = self.__extract_think_tags(content)
             content = cleaned_content
             if reasoning:
@@ -228,3 +176,73 @@ class OllamaChatModel(BaseChatModel):
                 ollama_message.tool_calls = ollama_tool_calls
             ollama_messages.append(ollama_message)
         return ollama_messages
+
+
+class OllamaChatModel(ChatModel):
+    """Ollama chat model which manages chat configuration and will internally
+    call ollama chat model server to do chat.
+    """
+
+    temperature: float = Field(
+        default=0.75,
+        description="The temperature to use for sampling.",
+        ge=0.0,
+        le=1.0,
+    )
+
+    num_ctx: int = Field(
+        default=DEFAULT_CONTEXT_WINDOW,
+        description="The maximum number of context tokens for the model.",
+        gt=0,
+    )
+    additional_kwargs: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional model parameters for the Ollama API.",
+    )
+    keep_alive: Optional[Union[float, str]] = Field(
+        default="5m",
+        description="controls how long the model will stay loaded into memory following the request(default: 5m)",
+    )
+    extract_reasoning: bool = Field(
+        default=False,
+        description="If True, extracts content within <think></think> tags from the response and stores it in additional_kwargs.",
+    )
+
+    def __init__(
+        self,
+        server: str,
+        temperature: float = 0.75,
+        num_ctx: int = DEFAULT_CONTEXT_WINDOW,
+        request_timeout: Optional[float] = DEFAULT_REQUEST_TIMEOUT,
+        additional_kwargs: Optional[Dict[str, Any]] = None,
+        keep_alive: Optional[Union[float, str]] = None,
+        extract_reasoning: Optional[bool] = False,
+        **kwargs: Any,
+    ) -> None:
+        """Init method."""
+        if additional_kwargs is None:
+            additional_kwargs = {}
+        super().__init__(
+            server=server,
+            temperature=temperature,
+            num_ctx=num_ctx,
+            request_timeout=request_timeout,
+            additional_kwargs=additional_kwargs,
+            keep_alive=keep_alive,
+            extract_reasoning=extract_reasoning,
+            **kwargs,
+        )
+
+    @property
+    def model_kwargs(self) -> Dict[str, Any]:
+        """Return ollama model configuration."""
+        base_kwargs = {
+            "temperature": self.temperature,
+            "num_ctx": self.num_ctx,
+            "keep_alive": self.keep_alive,
+            "extract_reasoning": self.extract_reasoning,
+        }
+        return {
+            **base_kwargs,
+            **self.additional_kwargs,
+        }

--- a/python/flink_agents/plan/tests/compatibility/python_agent_plan_compatibility_test_agent.py
+++ b/python/flink_agents/plan/tests/compatibility/python_agent_plan_compatibility_test_agent.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, Sequence, Tuple, Type
 
 from flink_agents.api.agent import Agent
 from flink_agents.api.chat_message import ChatMessage
-from flink_agents.api.chat_models.chat_model import ChatModel
+from flink_agents.api.chat_models.chat_model import BaseChatModelSetup
 from flink_agents.api.decorators import action, chat_model, tool
 from flink_agents.api.events.event import Event, InputEvent
 from flink_agents.api.runner_context import RunnerContext
@@ -28,7 +28,8 @@ from flink_agents.api.runner_context import RunnerContext
 class MyEvent(Event):
     """Test event."""
 
-class MockChatModel(ChatModel):
+
+class MockChatModel(BaseChatModelSetup):
     """Mock ChatModel for testing integrating prompt and tool."""
 
     @property
@@ -38,6 +39,7 @@ class MockChatModel(ChatModel):
 
     def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatMessage:
         """Only for test plan compatibility."""
+
 
 class PythonAgentPlanCompatibilityTestAgent(Agent):
     """Agent for generating python agent plan json."""
@@ -54,7 +56,7 @@ class PythonAgentPlanCompatibilityTestAgent(Agent):
 
     @chat_model
     @staticmethod
-    def chat_model() -> Tuple[Type[ChatModel], Dict[str, Any]]:
+    def chat_model() -> Tuple[Type[BaseChatModelSetup], Dict[str, Any]]:
         """ChatModel can be used in action."""
         return MockChatModel, {
             "name": "chat_model",

--- a/python/flink_agents/plan/tests/compatibility/python_agent_plan_compatibility_test_agent.py
+++ b/python/flink_agents/plan/tests/compatibility/python_agent_plan_compatibility_test_agent.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, Sequence, Tuple, Type
 
 from flink_agents.api.agent import Agent
 from flink_agents.api.chat_message import ChatMessage
-from flink_agents.api.chat_models.chat_model import BaseChatModel
+from flink_agents.api.chat_models.chat_model import ChatModel
 from flink_agents.api.decorators import action, chat_model, tool
 from flink_agents.api.events.event import Event, InputEvent
 from flink_agents.api.runner_context import RunnerContext
@@ -28,10 +28,15 @@ from flink_agents.api.runner_context import RunnerContext
 class MyEvent(Event):
     """Test event."""
 
-class MockChatModel(BaseChatModel):
+class MockChatModel(ChatModel):
     """Mock ChatModel for testing integrating prompt and tool."""
 
-    def chat(self, messages: Sequence[ChatMessage]) -> ChatMessage:
+    @property
+    def model_kwargs(self) -> Dict[str, Any]:
+        """Only for testing."""
+        return {}
+
+    def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatMessage:
         """Only for test plan compatibility."""
 
 class PythonAgentPlanCompatibilityTestAgent(Agent):
@@ -49,7 +54,7 @@ class PythonAgentPlanCompatibilityTestAgent(Agent):
 
     @chat_model
     @staticmethod
-    def chat_model() -> Tuple[Type[BaseChatModel], Dict[str, Any]]:
+    def chat_model() -> Tuple[Type[ChatModel], Dict[str, Any]]:
         """ChatModel can be used in action."""
         return MockChatModel, {
             "name": "chat_model",

--- a/python/flink_agents/plan/tests/resources/agent_plan.json
+++ b/python/flink_agents/plan/tests/resources/agent_plan.json
@@ -75,7 +75,8 @@
                 "kwargs": {
                     "name": "mock",
                     "host": "8.8.8.8",
-                    "desc": "mock resource just for testing."
+                    "desc": "mock resource just for testing.",
+                    "server": "mock"
                 },
                 "__resource_provider_type__": "PythonResourceProvider"
             }

--- a/python/flink_agents/plan/tests/resources/agent_plan.json
+++ b/python/flink_agents/plan/tests/resources/agent_plan.json
@@ -76,7 +76,7 @@
                     "name": "mock",
                     "host": "8.8.8.8",
                     "desc": "mock resource just for testing.",
-                    "server": "mock"
+                    "connection": "mock"
                 },
                 "__resource_provider_type__": "PythonResourceProvider"
             }

--- a/python/flink_agents/plan/tests/test_agent_plan.py
+++ b/python/flink_agents/plan/tests/test_agent_plan.py
@@ -23,7 +23,7 @@ import pytest
 
 from flink_agents.api.agent import Agent
 from flink_agents.api.chat_message import ChatMessage, MessageRole
-from flink_agents.api.chat_models.chat_model import ChatModel
+from flink_agents.api.chat_models.chat_model import BaseChatModelSetup
 from flink_agents.api.decorators import action, chat_model
 from flink_agents.api.events.event import Event, InputEvent, OutputEvent
 from flink_agents.api.resource import Resource, ResourceType
@@ -73,7 +73,7 @@ class MyEvent(Event):
     """Event for testing purposes."""
 
 
-class MockChatModelImpl(ChatModel):  # noqa: D101
+class MockChatModelImpl(BaseChatModelSetup):  # noqa: D101
     host: str
     desc: str
 
@@ -100,7 +100,7 @@ class MyAgent(Agent):  # noqa: D101
             "name": "mock",
             "host": "8.8.8.8",
             "desc": "mock resource just for testing.",
-            "server": "mock",
+            "connection": "mock",
         }
 
     @action(InputEvent)
@@ -160,7 +160,7 @@ def test_add_action_and_resource_to_agent() -> None:  # noqa: D103
         chat_model=MockChatModelImpl,
         host="8.8.8.8",
         desc="mock resource just for testing.",
-        server="mock",
+        connection="mock",
     )
     agent_plan = AgentPlan.from_agent(my_agent)
     json_value = agent_plan.model_dump_json(serialize_as_any=True, indent=4)

--- a/python/flink_agents/runtime/tests/test_built_in_actions.py
+++ b/python/flink_agents/runtime/tests/test_built_in_actions.py
@@ -16,50 +16,42 @@
 # limitations under the License.
 #################################################################################
 import uuid
-from typing import Any, Dict, List, Sequence, Tuple, Type
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
 
 from flink_agents.api.agent import Agent
 from flink_agents.api.chat_message import ChatMessage, MessageRole
-from flink_agents.api.chat_models.chat_model import BaseChatModel
-from flink_agents.api.decorators import action, chat_model, prompt, tool
-from flink_agents.api.events.chat_event import ChatRequestEvent, ChatResponseEvent
-from flink_agents.api.events.event import (
-    InputEvent,
-    OutputEvent,
+from flink_agents.api.chat_models.chat_model import BaseChatModelServer, ChatModel
+from flink_agents.api.decorators import (
+    action,
+    chat_model,
+    chat_model_server,
+    prompt,
+    tool,
 )
+from flink_agents.api.events.chat_event import ChatRequestEvent, ChatResponseEvent
+from flink_agents.api.events.event import InputEvent, OutputEvent
 from flink_agents.api.execution_environment import AgentsExecutionEnvironment
 from flink_agents.api.prompts.prompt import Prompt
 from flink_agents.api.resource import ResourceType
 from flink_agents.api.runner_context import RunnerContext
-from flink_agents.api.tools.tool import ToolMetadata, ToolType
+from flink_agents.api.tools.tool import ToolType
 
 
-class MockChatModel(BaseChatModel):
+class MockChatModelServer(BaseChatModelServer):
     """Mock ChatModel for testing integrating prompt and tool."""
 
-    __tools: List[ToolMetadata]
-
-    def __init__(self, /, **kwargs: Any) -> None:
-        """Init method of MockChatModel."""
-        super().__init__(**kwargs)
-        # bind tools
-        if self.tools is not None:
-            tools = [
-                self.get_resource(tool_name, ResourceType.TOOL)
-                for tool_name in self.tools
-            ]
-            self.__tools = [tool.metadata for tool in tools]
-        # bind prompt
-        if self.prompt is not None and isinstance(self.prompt, str):
-            self.prompt = self.get_resource(self.prompt, ResourceType.PROMPT)
-
-    def chat(self, messages: Sequence[ChatMessage]) -> ChatMessage:
+    def chat(
+        self,
+        messages: Sequence[ChatMessage],
+        tools: Optional[List] = None,
+        **kwargs: Any,
+    ) -> ChatMessage:
         """Generate tool call or response according to input."""
-        # generate tool call
+        # Generate tool call
         if "sum" in messages[-1].content:
-            input = self.prompt.format_string(**messages[-1].extra_args)
-            # validate bind_tools
-            assert self.__tools[0].name == "add"
+            input = messages[-1].content
+            # Validate bind_tools
+            assert tools[0].name == "add"
             function = {"name": "add", "arguments": {"a": 1, "b": 2}}
             tool_call = {
                 "id": uuid.uuid4(),
@@ -69,10 +61,49 @@ class MockChatModel(BaseChatModel):
             return ChatMessage(
                 role=MessageRole.ASSISTANT, content=input, tool_calls=[tool_call]
             )
-        # generate response including tool call context
+        # Generate response including tool call context
         else:
             content = "\n".join([message.content for message in messages])
             return ChatMessage(role=MessageRole.ASSISTANT, content=content)
+
+
+class MockChatModel(ChatModel):
+    """Mock ChatModel for testing integrating prompt and tool."""
+
+    @property
+    def model_kwargs(self) -> Dict[str, Any]:
+        """Return model kwargs."""
+        return {}
+
+    def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatMessage:
+        """Execute chat conversation."""
+        # Get model connection
+        server = self.get_resource(self.server, ResourceType.CHAT_MODEL_SERVER)
+
+        # Apply prompt template
+        if self.prompt is not None:
+            if isinstance(self.prompt, str):
+                # Get prompt resource if it's a string
+                prompt = self.get_resource(self.prompt, ResourceType.PROMPT)
+            else:
+                prompt = self.prompt
+
+            if "sum" in messages[-1].content:
+                input_variable = {}
+                for msg in messages:
+                    input_variable.update(msg.extra_args)
+                messages = prompt.format_messages(**input_variable)
+
+        # Bind tools
+        tools = None
+        if self.tools is not None:
+            tools = [
+                self.get_resource(tool_name, ResourceType.TOOL)
+                for tool_name in self.tools
+            ]
+
+        # Call server to execute chat
+        return server.chat(messages, tools=tools, **kwargs)
 
 
 class MyAgent(Agent):
@@ -87,12 +118,21 @@ class MyAgent(Agent):
             text="Please call the appropriate tool to do the following task: {task}",
         )
 
+    @chat_model_server
+    @staticmethod
+    def mock_server() -> Tuple[Type[BaseChatModelServer], Dict[str, Any]]:
+        """Chat model server can be used by ChatModel."""
+        return MockChatModelServer, {
+            "name": "mock_server",
+        }
+
     @chat_model
     @staticmethod
-    def chat_model() -> Tuple[Type[BaseChatModel], Dict[str, Any]]:
-        """ChatModel can be used in action."""
+    def mock_chat_model() -> Tuple[Type[ChatModel], Dict[str, Any]]:
+        """Chat model can be used in action."""
         return MockChatModel, {
-            "name": "chat_model",
+            "name": "mock_chat_model",
+            "server": "mock_server",
             "prompt": "prompt",
             "tools": ["add"],
         }
@@ -126,7 +166,7 @@ class MyAgent(Agent):
         input = event.input
         ctx.send_event(
             ChatRequestEvent(
-                model="chat_model",
+                model="mock_chat_model",
                 messages=[
                     ChatMessage(
                         role=MessageRole.USER, content=input, extra_args={"task": input}

--- a/python/flink_agents/runtime/tests/test_built_in_actions.py
+++ b/python/flink_agents/runtime/tests/test_built_in_actions.py
@@ -20,7 +20,10 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
 
 from flink_agents.api.agent import Agent
 from flink_agents.api.chat_message import ChatMessage, MessageRole
-from flink_agents.api.chat_models.chat_model import BaseChatModelServer, ChatModel
+from flink_agents.api.chat_models.chat_model import (
+    BaseChatModelConnection,
+    BaseChatModelSetup,
+)
 from flink_agents.api.decorators import (
     action,
     chat_model,
@@ -37,7 +40,7 @@ from flink_agents.api.runner_context import RunnerContext
 from flink_agents.api.tools.tool import ToolType
 
 
-class MockChatModelServer(BaseChatModelServer):
+class MockChatModelConnection(BaseChatModelConnection):
     """Mock ChatModel for testing integrating prompt and tool."""
 
     def chat(
@@ -67,7 +70,7 @@ class MockChatModelServer(BaseChatModelServer):
             return ChatMessage(role=MessageRole.ASSISTANT, content=content)
 
 
-class MockChatModel(ChatModel):
+class MockChatModel(BaseChatModelSetup):
     """Mock ChatModel for testing integrating prompt and tool."""
 
     @property
@@ -78,7 +81,7 @@ class MockChatModel(ChatModel):
     def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatMessage:
         """Execute chat conversation."""
         # Get model connection
-        server = self.get_resource(self.server, ResourceType.CHAT_MODEL_SERVER)
+        server = self.get_resource(self.connection, ResourceType.CHAT_MODEL_CONNECTION)
 
         # Apply prompt template
         if self.prompt is not None:
@@ -120,19 +123,19 @@ class MyAgent(Agent):
 
     @chat_model_server
     @staticmethod
-    def mock_server() -> Tuple[Type[BaseChatModelServer], Dict[str, Any]]:
+    def mock_connection() -> Tuple[Type[BaseChatModelConnection], Dict[str, Any]]:
         """Chat model server can be used by ChatModel."""
-        return MockChatModelServer, {
-            "name": "mock_server",
+        return MockChatModelConnection, {
+            "name": "mock_connection",
         }
 
     @chat_model
     @staticmethod
-    def mock_chat_model() -> Tuple[Type[ChatModel], Dict[str, Any]]:
+    def mock_chat_model() -> Tuple[Type[BaseChatModelSetup], Dict[str, Any]]:
         """Chat model can be used in action."""
         return MockChatModel, {
             "name": "mock_chat_model",
-            "server": "mock_server",
+            "connection": "mock_connection",
             "prompt": "prompt",
             "tools": ["add"],
         }

--- a/python/flink_agents/runtime/tests/test_get_resource_in_action.py
+++ b/python/flink_agents/runtime/tests/test_get_resource_in_action.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, Sequence, Tuple, Type
 
 from flink_agents.api.agent import Agent
 from flink_agents.api.chat_message import ChatMessage, MessageRole
-from flink_agents.api.chat_models.chat_model import BaseChatModel
+from flink_agents.api.chat_models.chat_model import ChatModel
 from flink_agents.api.decorators import action, chat_model, tool
 from flink_agents.api.events.event import InputEvent, OutputEvent
 from flink_agents.api.execution_environment import AgentsExecutionEnvironment
@@ -27,11 +27,15 @@ from flink_agents.api.resource import Resource, ResourceType
 from flink_agents.api.runner_context import RunnerContext
 
 
-class MockChatModelImpl(BaseChatModel):  # noqa: D101
+class MockChatModelImpl(ChatModel):  # noqa: D101
     host: str
     desc: str
 
-    def chat(self, messages: Sequence[ChatMessage]) -> ChatMessage: # noqa: D102
+    @property
+    def model_kwargs(self) -> Dict[str, Any]:  # noqa: D102
+        return {}
+
+    def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatMessage:  # noqa: D102
         return ChatMessage(
             role=MessageRole.ASSISTANT,
             content=f"{messages[0].content} {self.host} {self.desc}",
@@ -46,6 +50,7 @@ class MyAgent(Agent):  # noqa: D101
             "name": "mock_chat_model",
             "host": "8.8.8.8",
             "desc": "mock chat model just for testing.",
+            "server": "mock",
         }
 
     @tool

--- a/python/flink_agents/runtime/tests/test_get_resource_in_action.py
+++ b/python/flink_agents/runtime/tests/test_get_resource_in_action.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, Sequence, Tuple, Type
 
 from flink_agents.api.agent import Agent
 from flink_agents.api.chat_message import ChatMessage, MessageRole
-from flink_agents.api.chat_models.chat_model import ChatModel
+from flink_agents.api.chat_models.chat_model import BaseChatModelSetup
 from flink_agents.api.decorators import action, chat_model, tool
 from flink_agents.api.events.event import InputEvent, OutputEvent
 from flink_agents.api.execution_environment import AgentsExecutionEnvironment
@@ -27,7 +27,7 @@ from flink_agents.api.resource import Resource, ResourceType
 from flink_agents.api.runner_context import RunnerContext
 
 
-class MockChatModelImpl(ChatModel):  # noqa: D101
+class MockChatModelImpl(BaseChatModelSetup):  # noqa: D101
     host: str
     desc: str
 
@@ -50,7 +50,7 @@ class MyAgent(Agent):  # noqa: D101
             "name": "mock_chat_model",
             "host": "8.8.8.8",
             "desc": "mock chat model just for testing.",
-            "server": "mock",
+            "connection": "mock",
         }
 
     @tool


### PR DESCRIPTION

Linked issue: #112 

### Purpose of change

By splitting ChatModel into ChatModelServer (managing the connection) and ChatModel (managing tools, prompts, and invocation settings), different ChatModels can reuse the same Server.

### Tests

ut

### API

Yes, revise the API of ChatModel

### Documentation

No
