### PR TITLE
[hotfix] Fix coredump when close async thread pool.

### DIFF
--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutor.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutor.java
@@ -169,8 +169,10 @@ public class PythonActionExecutor {
     }
 
     public void close() throws Exception {
-        interpreter.invoke(
-                CLOSE_ASYNC_THREAD_POOL, interpreter.get(pythonAsyncThreadPoolObjectName));
+        if (pythonAsyncThreadPoolObjectName != null) {
+            interpreter.invoke(
+                    CLOSE_ASYNC_THREAD_POOL, interpreter.get(pythonAsyncThreadPoolObjectName));
+        }
     }
 
     /** Failed to execute Python action. */


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

If exception occurs before set pythonAsyncThreadPoolObjectName to PythonInterpreter, the process will core dump when close PythonActionExecutor for  pythonAsyncThreadPoolObjectName is null.
