### PR TITLE
[hotfix] Fix incorrect import path of flink_agents

### DIFF
--- a/python/flink_agents/plan/tests/test_function.py
+++ b/python/flink_agents/plan/tests/test_function.py
@@ -35,7 +35,7 @@ from flink_agents.plan.function import (
 )
 
 if TYPE_CHECKING:
-    from python.flink_agents.plan.function import Function
+    from flink_agents.plan.function import Function
 
 
 def check_class(input_event: InputEvent, output_event: OutputEvent) -> None:  # noqa: D103

--- a/python/flink_agents/runtime/flink_memory_object.py
+++ b/python/flink_agents/runtime/flink_memory_object.py
@@ -17,9 +17,8 @@
 #################################################################################
 from typing import Any, Dict, List, Union
 
-from python.flink_agents.api.memory_reference import MemoryRef
-
 from flink_agents.api.memory_object import MemoryObject
+from flink_agents.api.memory_reference import MemoryRef
 
 
 class FlinkMemoryObject(MemoryObject):


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #xxx

### Purpose of change

Fix the incorrect import path of flink_agents. The import path should not prefix with `python`.

### Tests

<!-- How is this change verified? -->

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Should this change be covered by the user documentation?-->
