### PR TITLE
[integration][python] Anthropic Chat Model APIs Integration

### DIFF
--- a/python/flink_agents/api/chat_message.py
+++ b/python/flink_agents/api/chat_message.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 #################################################################################
 from enum import Enum
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 from pydantic import BaseModel, Field
 
@@ -61,7 +61,7 @@ class ChatMessage(BaseModel):
     """
 
     role: MessageRole = MessageRole.USER
-    content: str = Field(default_factory=str)
+    content: Union[str, List[Any]] = Field(default_factory=str)
     tool_calls: List[Dict[str, Any]] = Field(default_factory=list)
     extra_args: Dict[str, Any] = Field(default_factory=dict)
 

--- a/python/flink_agents/api/chat_message.py
+++ b/python/flink_agents/api/chat_message.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 #################################################################################
 from enum import Enum
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
 
 from pydantic import BaseModel, Field
 
@@ -61,7 +61,7 @@ class ChatMessage(BaseModel):
     """
 
     role: MessageRole = MessageRole.USER
-    content: Union[str, List[Any]] = Field(default_factory=str)
+    content: str = Field(default_factory=str)
     tool_calls: List[Dict[str, Any]] = Field(default_factory=list)
     extra_args: Dict[str, Any] = Field(default_factory=dict)
 

--- a/python/flink_agents/api/events/tool_event.py
+++ b/python/flink_agents/api/events/tool_event.py
@@ -30,7 +30,8 @@ class ToolRequestEvent(Event):
     kwargs : dict
         The arguments passed to the tool.
     external_id : Optional[str]
-        Optional identifier for storing original tool call IDs from external systems (e.g., Anthropic tool_use_id).
+        Optional identifier for storing original tool call IDs from external systems
+        (e.g., Anthropic tool_use_id).
     """
 
     tool: str

--- a/python/flink_agents/integrations/chat_models/anthropic/__init__.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/__init__.py
@@ -15,39 +15,3 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 #################################################################################
-from typing import Any, Optional
-
-from flink_agents.api.events.event import Event
-
-
-class ToolRequestEvent(Event):
-    """Event representing a tool call request.
-
-    Attributes:
-    ----------
-    tool : str
-        The name of the tool to be called.
-    kwargs : dict
-        The arguments passed to the tool.
-    external_id : Optional[str]
-        Optional identifier for storing original tool call IDs from external systems (e.g., Anthropic tool_use_id).
-    """
-
-    tool: str
-    kwargs: dict
-    external_id: Optional[str] = None
-
-
-class ToolResponseEvent(Event):
-    """Event representing a result from tool call.
-
-    Attributes:
-    ----------
-    request : ToolRequestEvent
-        The correspond request of the response.
-    response : Any
-        The response from the tool.
-    """
-
-    request: ToolRequestEvent
-    response: Any

--- a/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
@@ -15,18 +15,17 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 #################################################################################
-import typing
 import uuid
+from typing import Sequence, Optional, List, Any, Dict
 
+from anthropic import Anthropic
+from anthropic._types import NOT_GIVEN
+from anthropic.types import MessageParam, ToolParam, TextBlockParam
 from pydantic import Field, PrivateAttr
-from typing import Sequence, Optional, List, Any, Dict, Iterable
 
 from flink_agents.api.chat_message import ChatMessage, MessageRole
 from flink_agents.api.chat_models.chat_model import BaseChatModelConnection, BaseChatModelSetup
 from flink_agents.api.tools.tool import BaseTool, ToolMetadata
-from anthropic import Anthropic
-from anthropic.types import MessageParam, ToolParam, TextBlockParam
-from anthropic._types import NOT_GIVEN
 
 
 def to_anthropic_tool(*, metadata: ToolMetadata, skip_length_check: bool = False) -> ToolParam:
@@ -74,10 +73,10 @@ def convert_to_anthropic_system_prompts(messages: Sequence[ChatMessage]) -> List
     """Convert system messages to Anthropic system prompts: https://docs.anthropic.com/en/api/messages#body-system"""
     system_messages = [message for message in messages if message.role == MessageRole.SYSTEM]
     return [
-        {
-            "type": "text",
-            "text": message.content
-        }
+        TextBlockParam(
+            type="text",
+            text=message.content
+        )
         for message in system_messages
     ]
 
@@ -169,11 +168,12 @@ class AnthropicChatModelConnection(BaseChatModelConnection):
                 tool_calls=tool_calls
             )
         else:
+            # TODO: handle other stop_reason values according to Anthropic API:
+            #  https://docs.anthropic.com/en/api/messages#response-stop-reason
             return ChatMessage(
                 role=MessageRole(message.role),
                 content=message.content[0].text,
             )
-
 
 
 DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-20250514"

--- a/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
@@ -42,7 +42,7 @@ def to_anthropic_tool(*, metadata: ToolMetadata, skip_length_check: bool = False
     return {
         "name": metadata.name,
         "description": metadata.description,
-        "input_schema": metadata._ToolMetadata__get_parameters_dict()
+        "input_schema": metadata.get_parameters_dict()
     }
 
 

--- a/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
@@ -1,0 +1,232 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+import typing
+import uuid
+
+from pydantic import Field, PrivateAttr
+from typing import Sequence, Optional, List, Any, Dict, Iterable
+
+from flink_agents.api.chat_message import ChatMessage, MessageRole
+from flink_agents.api.chat_models.chat_model import BaseChatModelConnection, BaseChatModelSetup
+from flink_agents.api.tools.tool import BaseTool, ToolMetadata
+from anthropic import Anthropic
+from anthropic.types import MessageParam, ToolParam, TextBlockParam
+from anthropic._types import NOT_GIVEN
+
+
+def to_anthropic_tool(*, metadata: ToolMetadata, skip_length_check: bool = False) -> ToolParam:
+    """Convert to Anthropic tool: https://docs.anthropic.com/en/api/messages#body-tools"""
+    if not skip_length_check and len(metadata.description) > 1024:
+        msg = (
+            "Tool description exceeds maximum length of 1024 characters. "
+            "Please shorten your description or move it to the prompt."
+        )
+        raise ValueError(msg)
+    return {
+        "name": metadata.name,
+        "description": metadata.description,
+        "input_schema": metadata._ToolMetadata__get_parameters_dict()
+    }
+
+
+def convert_to_anthropic_message(message: ChatMessage) -> MessageParam:
+    if message.role == MessageRole.TOOL:
+        return {
+            "role": MessageRole.USER.value,
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": message.extra_args.get("external_id"),
+                    "content": message.content,
+                }
+            ],
+        }
+    else:
+        return {
+            "role": message.role.value,
+            "content": message.content,
+        }
+
+
+def convert_to_anthropic_messages(messages: Sequence[ChatMessage]) -> List[MessageParam]:
+    """Convert user/assistant messages to Anthropic input messages:
+    https://docs.anthropic.com/en/api/messages#body-messages"""
+    return [convert_to_anthropic_message(message) for message in messages if
+            message.role in [MessageRole.USER, MessageRole.ASSISTANT, MessageRole.TOOL]]
+
+
+def convert_to_anthropic_system_prompts(messages: Sequence[ChatMessage]) -> List[TextBlockParam]:
+    """Convert system messages to Anthropic system prompts: https://docs.anthropic.com/en/api/messages#body-system"""
+    system_messages = [message for message in messages if message.role == MessageRole.SYSTEM]
+    return [
+        {
+            "type": "text",
+            "text": message.content
+        }
+        for message in system_messages
+    ]
+
+
+class AnthropicChatModelConnection(BaseChatModelConnection):
+    """Manages the connection to the Anthropic AI models for chat interactions.
+
+    Attributes:
+    ----------
+    api_key : str
+        The Anthropic API key.
+    max_retries : int
+        The number of times to retry the API call upon failure.
+    timeout : float
+        The number of seconds to wait for an API call before it times out.
+    reuse_client : bool
+        Whether to reuse the Anthropic client between requests.
+    """
+
+    api_key: str = Field(default=None, description="The Anthropic API key.")
+
+    max_retries: int = Field(
+        default=3,
+        description="The number of times to retry the API call upon failure.",
+        ge=0,
+    )
+    timeout: float = Field(
+        default=60.0,
+        description="The number of seconds to wait for an API call before it times out.",
+        ge=0,
+    )
+
+    def __init__(
+            self,
+            api_key: Optional[str] = None,
+            max_retries: int = 3,
+            timeout: float = 60.0,
+            **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            api_key=api_key,
+            max_retries=max_retries,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    _client: Optional[Anthropic] = PrivateAttr(default=None)
+
+    @property
+    def client(self) -> Anthropic:
+        if self._client is None:
+            self._client = Anthropic(api_key=self.api_key, max_retries=self.max_retries, timeout=self.timeout)
+        return self._client
+
+    def chat(self, messages: Sequence[ChatMessage], tools: Optional[List[BaseTool]] = None,
+             **kwargs: Any) -> ChatMessage:
+        """Direct communication with Anthropic model service for chat conversation."""
+        anthropic_tools = None
+        if tools is not None:
+            anthropic_tools = [to_anthropic_tool(metadata=tool.metadata) for tool in tools]
+
+        anthropic_system = convert_to_anthropic_system_prompts(messages)
+        anthropic_messages = convert_to_anthropic_messages(messages)
+
+        message = self.client.messages.create(
+            messages=anthropic_messages,
+            tools=anthropic_tools or NOT_GIVEN,
+            system=anthropic_system or NOT_GIVEN,
+            **kwargs,
+        )
+
+        if message.stop_reason == "tool_use":
+            tool_calls = []
+            for content_block in message.content:
+                if content_block.type == 'tool_use':
+                    tool_calls.append({
+                        "id": uuid.uuid4(),
+                        "type": "function",
+                        "function": {
+                            "name": content_block.name,
+                            "arguments": content_block.input,
+                        },
+                        "original_id": content_block.id,
+                    })
+
+            return ChatMessage(
+                role=MessageRole(message.role),
+                content=message.content,
+                tool_calls=tool_calls
+            )
+        else:
+            return ChatMessage(
+                role=MessageRole(message.role),
+                content=message.content[0].text,
+            )
+
+
+
+DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-20250514"
+DEFAULT_MAX_TOKENS = 1024
+DEFAULT_TEMPERATURE = 0.1
+
+
+class AnthropicChatModelSetup(BaseChatModelSetup):
+    """The settings for Anthropic Chat Model.
+
+    Attributes:
+    ----------
+    model : str
+        Specifies the Anthropic model to use. Defaults to claude-sonnet-4-20250514.
+    max_tokens: int
+        The maximum number of tokens to generate before stopping. Defaults to 1024.
+    temperature : float
+        Amount of randomness injected into the response.
+    """
+
+    model: str = Field(
+        default=DEFAULT_ANTHROPIC_MODEL, description="Specifies the Anthropic model to use. Defaults to "
+                                                     "claude-sonnet-4-20250514."
+    )
+    max_tokens: int = Field(
+        default=DEFAULT_MAX_TOKENS,
+        description="The maximum number of tokens to generate before stopping. Defaults to 1024.",
+        ge=1,
+    )
+    temperature: float = Field(
+        default=DEFAULT_TEMPERATURE,
+        description="Amount of randomness injected into the response. Defaults to 0.1",
+        ge=0.0,
+        le=1.0,
+    )
+
+    def __init__(
+            self,
+            connection: str,
+            model: str = DEFAULT_ANTHROPIC_MODEL,
+            max_tokens: int = DEFAULT_MAX_TOKENS,
+            temperature: float = DEFAULT_TEMPERATURE,
+            **kwargs: Any,
+    ) -> None:
+        """Init method."""
+        super().__init__(
+            connection=connection,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            **kwargs,
+        )
+
+    @property
+    def model_kwargs(self) -> Dict[str, Any]:
+        return {"model": self.model, "max_tokens": self.max_tokens, "temperature": self.temperature}

--- a/python/flink_agents/integrations/chat_models/anthropic/tests/__init__.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/tests/__init__.py
@@ -1,0 +1,17 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################

--- a/python/flink_agents/integrations/chat_models/anthropic/tests/test_anthropic_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/tests/test_anthropic_chat_model.py
@@ -1,0 +1,98 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+import os
+import pytest
+
+from flink_agents.api.chat_message import ChatMessage, MessageRole
+from flink_agents.api.resource import ResourceType, Resource
+from flink_agents.integrations.chat_models.anthropic.anthropic_chat_model import (
+    AnthropicChatModelConnection,
+    AnthropicChatModelSetup,
+)
+from flink_agents.plan.tools.function_tool import from_callable
+
+
+test_model = os.environ.get("TEST_MODEL")
+api_key = os.environ.get("TEST_API_KEY")
+
+
+@pytest.mark.skipif(api_key is None, reason="TEST_API_KEY is not set")
+def test_anthropic_chat_model() -> None:  # noqa: D103
+    connection = AnthropicChatModelConnection(
+        name="anthropic_server", api_key=api_key
+    )
+
+    def get_resource(name: str, type: ResourceType) -> Resource:
+        if type == ResourceType.CHAT_MODEL_CONNECTION:
+            return connection
+        else:
+            return get_resource(name, ResourceType.TOOL)
+
+    chat_model = AnthropicChatModelSetup(
+        name="anthropic", model=test_model, connection="anthropic_server", get_resource=get_resource
+    )
+    response = chat_model.chat([ChatMessage(role=MessageRole.USER, content="Hello!")])
+    assert response is not None
+    assert str(response).strip() != ""
+
+
+def add(a: int, b: int) -> int:
+    """Calculate the sum of a and b.
+
+    Parameters
+    ----------
+    a : int
+        The first operand
+    b : int
+        The second operand
+
+    Returns:
+    -------
+    int:
+        The sum of a and b
+    """
+    return a + b
+
+
+@pytest.mark.skipif(api_key is None, reason="TEST_API_KEY is not set")
+def test_anthropic_chat_with_tools() -> None:  # noqa : D103
+    connection = AnthropicChatModelConnection(
+        name="anthropic_server", api_key=api_key
+    )
+
+    def get_resource(name: str, type: ResourceType) -> Resource:
+        if type == ResourceType.CHAT_MODEL_CONNECTION:
+            return connection
+        else:
+            return from_callable(name=name, func=add)
+
+    chat_model = AnthropicChatModelSetup(
+        name="anthropic",
+        model=test_model,
+        connection="anthropic_server",
+        tools=["add"],
+        get_resource=get_resource,
+    )
+    response = chat_model.chat(
+        [ChatMessage(role=MessageRole.USER, content="What is 1 + 1?")]
+    )
+    tool_calls = response.tool_calls
+    assert len(tool_calls) == 1
+    tool_call = tool_calls[0]
+    assert add(**tool_call["function"]["arguments"]) == 2
+    assert tool_call.get("original_id") is not None

--- a/python/flink_agents/integrations/chat_models/anthropic/tests/test_anthropic_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/tests/test_anthropic_chat_model.py
@@ -16,16 +16,16 @@
 # limitations under the License.
 #################################################################################
 import os
+
 import pytest
 
 from flink_agents.api.chat_message import ChatMessage, MessageRole
-from flink_agents.api.resource import ResourceType, Resource
+from flink_agents.api.resource import Resource, ResourceType
 from flink_agents.integrations.chat_models.anthropic.anthropic_chat_model import (
     AnthropicChatModelConnection,
     AnthropicChatModelSetup,
 )
 from flink_agents.plan.tools.function_tool import from_callable
-
 
 test_model = os.environ.get("TEST_MODEL")
 api_key = os.environ.get("TEST_API_KEY")

--- a/python/flink_agents/plan/actions/chat_model_action.py
+++ b/python/flink_agents/plan/actions/chat_model_action.py
@@ -57,6 +57,7 @@ def process_chat_request_or_tool_response(event: Event, ctx: RunnerContext) -> N
                         id=tool_call_id,
                         tool=tool_call["function"]["name"],
                         kwargs=tool_call["function"]["arguments"],
+                        external_id=tool_call.get("original_id"),
                     )
                 )
 
@@ -73,7 +74,11 @@ def process_chat_request_or_tool_response(event: Event, ctx: RunnerContext) -> N
                 # get the specific tool call context from short term memory
                 specific_tool_ctx = tool_context.pop(tool_call_id)
                 specific_tool_ctx.messages.append(
-                    ChatMessage(role=MessageRole.TOOL, content=str(event.response))
+                    ChatMessage(
+                        role=MessageRole.TOOL, 
+                        content=str(event.response),
+                        extra_args={"external_id": event.request.external_id} if event.request.external_id else {}
+                    )
                 )
                 ctx.send_event(specific_tool_ctx)
                 # update short term memory to remove the specific tool call context

--- a/python/flink_agents/plan/actions/chat_model_action.py
+++ b/python/flink_agents/plan/actions/chat_model_action.py
@@ -75,7 +75,7 @@ def process_chat_request_or_tool_response(event: Event, ctx: RunnerContext) -> N
                 specific_tool_ctx = tool_context.pop(tool_call_id)
                 specific_tool_ctx.messages.append(
                     ChatMessage(
-                        role=MessageRole.TOOL, 
+                        role=MessageRole.TOOL,
                         content=str(event.response),
                         extra_args={"external_id": event.request.external_id} if event.request.external_id else {}
                     )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -50,7 +50,8 @@ dependencies = [
     #TODO: Seperate integration dependencies from project
     "ollama==0.4.8",
     "dashscope~=1.24.2",
-    "openai>=1.66.3"
+    "openai>=1.66.3",
+    "anthropic>=0.64.0",
 ]
 
 # Optional dependencies (dependency groups)


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #129

### Purpose of change

<!-- What is the purpose of this change? -->
Integrate Anthropic Chat Model APIs.

### Tests

Unit tests, also use `chat_model_example` as template to verify the Anthropic APIs.

```
2025-09-02 11:37:31,357 - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
2025-09-02 11:37:31,359 - INFO - key: 0002, send_event: id=UUID('5445c578-d209-4520-b0d1-ec9b44667df1') request=ChatRequestEvent(id=UUID('3f708c50-7d06-4326-ab54-b58091be8b3b'), model='creative_chat_model', messages=[ChatMessage(role=<MessageRole.USER: 'user'>, content='Tell me a joke about cats.', tool_calls=[], extra_args={})]) response=ChatMessage(role=<MessageRole.ASSISTANT: 'assistant'>, content="Why don't cats play poker in the jungle?\n\nToo many cheetahs! 🐱", tool_calls=[], extra_args={})
2025-09-02 11:37:31,360 - INFO - key: 0002, performing action: process_chat_response
2025-09-02 11:37:31,360 - INFO - key: 0002, send_event: id=UUID('6c29e9dc-f5e7-4602-84ce-44e2d0f6686c') output="Why don't cats play poker in the jungle?\n\nToo many cheetahs! 🐱"
0001: The sum of 1 and 2 is 3.
0002: Why don't cats play poker in the jungle?

Too many cheetahs! 🐱
```
### API

  - ToolRequestEvent: Added optional external_id field for storing original tool call IDs from external systems
  (e.g., Anthropic tool_use_id)

### Documentation

<!-- Should this change be covered by the user documentation?-->
n/a
