### PR TITLE
[Improvement] Add inherited parameters to ChatModelSetup/EmbeddingModelSetup docstrings

### DIFF
--- a/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
@@ -210,6 +210,12 @@ class AnthropicChatModelSetup(BaseChatModelSetup):
 
     Attributes:
     ----------
+    connection : str
+        Name of the referenced connection. (Inherited from BaseChatModelSetup)
+    prompt : Optional[Union[Prompt, str]
+        Prompt template or string for the model. (Inherited from BaseChatModelSetup)
+    tools : Optional[List[str]]
+        List of available tools to use in the chat. (Inherited from BaseChatModelSetup)
     model : str
         Specifies the Anthropic model to use. Defaults to claude-sonnet-4-20250514.
     max_tokens: int

--- a/python/flink_agents/integrations/chat_models/ollama_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/ollama_chat_model.py
@@ -167,6 +167,12 @@ class OllamaChatModelSetup(BaseChatModelSetup):
 
     Attributes:
     ----------
+    connection : str
+        Name of the referenced connection. (Inherited from BaseChatModelSetup)
+    prompt : Optional[Union[Prompt, str]
+        Prompt template or string for the model. (Inherited from BaseChatModelSetup)
+    tools : Optional[List[str]]
+        List of available tools to use in the chat. (Inherited from BaseChatModelSetup)
     temperature : float
         The temperature to use for sampling.
     num_ctx : int

--- a/python/flink_agents/integrations/chat_models/openai/openai_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/openai/openai_chat_model.py
@@ -184,6 +184,12 @@ class OpenAIChatModelSetup(BaseChatModelSetup):
 
     Attributes:
     ----------
+    connection : str
+        Name of the referenced connection. (Inherited from BaseChatModelSetup)
+    prompt : Optional[Union[Prompt, str]
+        Prompt template or string for the model. (Inherited from BaseChatModelSetup)
+    tools : Optional[List[str]]
+        List of available tools to use in the chat. (Inherited from BaseChatModelSetup)
     model : str
         The OpenAI model to use.
     temperature : float

--- a/python/flink_agents/integrations/chat_models/tongyi_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/tongyi_chat_model.py
@@ -211,6 +211,12 @@ class TongyiChatModelSetup(BaseChatModelSetup):
 
     Attributes:
     ----------
+    connection : str
+        Name of the referenced connection. (Inherited from BaseChatModelSetup)
+    prompt : Optional[Union[Prompt, str]
+        Prompt template or string for the model. (Inherited from BaseChatModelSetup)
+    tools : Optional[List[str]]
+        List of available tools to use in the chat. (Inherited from BaseChatModelSetup)
     temperature : float
         The temperature to use for sampling.
     additional_kwargs : Dict[str, Any]

--- a/python/flink_agents/integrations/embedding_models/local/ollama_embedding_model.py
+++ b/python/flink_agents/integrations/embedding_models/local/ollama_embedding_model.py
@@ -101,6 +101,10 @@ class OllamaEmbeddingModelSetup(BaseEmbeddingModelSetup):
 
     Attributes:
     ----------
+    connection : str
+        Name of the referenced connection. (Inherited from BaseEmbeddingModelSetup)
+    model : str
+        Name of the embedding model to use. (Inherited from BaseEmbeddingModelSetup)
     truncate : bool
         Controls what happens if input text exceeds model's maximum length
         (default: True).

--- a/python/flink_agents/integrations/embedding_models/openai_embedding_model.py
+++ b/python/flink_agents/integrations/embedding_models/openai_embedding_model.py
@@ -135,6 +135,10 @@ class OpenAIEmbeddingModelSetup(BaseEmbeddingModelSetup):
 
     Attributes:
     ----------
+    connection : str
+        Name of the referenced connection. (Inherited from BaseEmbeddingModelSetup)
+    model : str
+        Name of the embedding model to use. (Inherited from BaseEmbeddingModelSetup)
     encoding_format : str
         The format to return the embeddings in (default: "float").
         Can be either "float" or "base64".


### PR DESCRIPTION

<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #134 

### Purpose of change
Updated the docstrings for all `ChatModelSetup` and `EmbeddingModelSetup` classes to explicitly document parameters inherited from parent classes (e.g., `prompt`, `tools`, etc.). This ensures public API documentation reflects the full set of available arguments, improving clarity and consistency.
<!-- What is the purpose of this change? -->

### Tests

<!-- How is this change verified? -->

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Should this change be covered by the user documentation?-->
