### PR TITLE
[runtime] Bump flink version to 1.20.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,12 +41,12 @@ under the License.
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
         <spotless.version>2.27.1</spotless.version>
         <spotless.skip>false</spotless.skip>
-        <flink.version>1.20.1</flink.version>
+        <flink.version>1.20.3</flink.version>
         <kafka.version>4.0.0</kafka.version>
         <junit5.version>5.10.1</junit5.version>
         <flink.shaded.version>17.0</flink.shaded.version>
         <flink.shaded.jackson.version>2.14.2</flink.shaded.jackson.version>
-        <pemja.version>0.6.0</pemja.version>
+        <pemja.version>0.5.5</pemja.version>
         <log4j2.version>2.23.1</log4j2.version>
         <slf4j.version>1.7.36</slf4j.version>
         <assertj.version>3.23.1</assertj.version>

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "apache-flink==1.20.1",
+    "apache-flink==1.20.3",
     "pydantic==2.11.4",
     "docstring-parser==0.16",
     "pyyaml==6.0.2",

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -105,22 +105,10 @@ under the License.
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.alibaba</groupId>
-            <artifactId>pemja</artifactId>
-            <version>${pemja.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-python</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.alibaba</groupId>
-                    <artifactId>pemja</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- kafka client -->
         <dependency>


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #215

### Purpose of change

Bump flink version to 1.20.3

### Tests

<!-- How is this change verified? -->

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Should this change be covered by the user documentation?-->
