### PR TITLE
[runtime] Only persist memory changes to flink state when action is finished

### DIFF
--- a/runtime/src/main/java/org/apache/flink/agents/runtime/context/RunnerContextImpl.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/context/RunnerContextImpl.java
@@ -26,9 +26,9 @@ import org.apache.flink.agents.api.resource.Resource;
 import org.apache.flink.agents.api.resource.ResourceType;
 import org.apache.flink.agents.plan.AgentPlan;
 import org.apache.flink.agents.plan.utils.JsonUtils;
+import org.apache.flink.agents.runtime.memory.CachedMemoryStore;
 import org.apache.flink.agents.runtime.memory.MemoryObjectImpl;
 import org.apache.flink.agents.runtime.metrics.FlinkAgentsMetricGroupImpl;
-import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.flink.util.Preconditions;
 
@@ -44,7 +44,7 @@ import java.util.Map;
 public class RunnerContextImpl implements RunnerContext {
 
     protected final List<Event> pendingEvents = new ArrayList<>();
-    protected final MapState<String, MemoryObjectImpl.MemoryItem> store;
+    protected final CachedMemoryStore store;
     protected final FlinkAgentsMetricGroupImpl agentMetricGroup;
     protected final Runnable mailboxThreadChecker;
     protected final AgentPlan agentPlan;
@@ -52,7 +52,7 @@ public class RunnerContextImpl implements RunnerContext {
     protected String actionName;
 
     public RunnerContextImpl(
-            MapState<String, MemoryObjectImpl.MemoryItem> store,
+            CachedMemoryStore store,
             FlinkAgentsMetricGroupImpl agentMetricGroup,
             Runnable mailboxThreadChecker,
             AgentPlan agentPlan) {
@@ -146,5 +146,9 @@ public class RunnerContextImpl implements RunnerContext {
 
     public String getActionName() {
         return actionName;
+    }
+
+    public void persistMemory() throws Exception {
+        store.persistCache();
     }
 }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/memory/CachedMemoryStore.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/memory/CachedMemoryStore.java
@@ -55,5 +55,6 @@ public class CachedMemoryStore implements MemoryStore {
         for (Map.Entry<String, MemoryObjectImpl.MemoryItem> entry : cache.entrySet()) {
             store.put(entry.getKey(), entry.getValue());
         }
+        cache.clear();
     }
 }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/memory/CachedMemoryStore.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/memory/CachedMemoryStore.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.memory;
+
+import org.apache.flink.api.common.state.MapState;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CachedMemoryStore implements MemoryStore {
+
+    private final Map<String, MemoryObjectImpl.MemoryItem> cache;
+    private final MapState<String, MemoryObjectImpl.MemoryItem> store;
+
+    public CachedMemoryStore(MapState<String, MemoryObjectImpl.MemoryItem> store) {
+        this.store = store;
+        this.cache = new HashMap<>();
+    }
+
+    @Override
+    public MemoryObjectImpl.MemoryItem get(String key) throws Exception {
+        if (cache.containsKey(key)) {
+            return cache.get(key);
+        }
+
+        return store.get(key);
+    }
+
+    @Override
+    public void put(String key, MemoryObjectImpl.MemoryItem value) throws Exception {
+        cache.put(key, value);
+    }
+
+    @Override
+    public boolean contains(String key) throws Exception {
+        return cache.containsKey(key) || store.contains(key);
+    }
+
+    public void persistCache() throws Exception {
+        for (Map.Entry<String, MemoryObjectImpl.MemoryItem> entry : cache.entrySet()) {
+            store.put(entry.getKey(), entry.getValue());
+        }
+    }
+}

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/memory/MemoryObjectImpl.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/memory/MemoryObjectImpl.java
@@ -20,7 +20,6 @@ package org.apache.flink.agents.runtime.memory;
 import org.apache.flink.agents.api.context.MemoryObject;
 import org.apache.flink.agents.api.context.MemoryRef;
 import org.apache.flink.agents.api.context.MemoryUpdate;
-import org.apache.flink.api.common.state.MapState;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -41,19 +40,18 @@ public class MemoryObjectImpl implements MemoryObject {
     public static final String ROOT_KEY = "";
     private static final String SEPARATOR = ".";
 
-    private final MapState<String, MemoryItem> store;
+    private final MemoryStore store;
     private final List<MemoryUpdate> memoryUpdates;
     private final String prefix;
     private final Runnable mailboxThreadChecker;
 
-    public MemoryObjectImpl(
-            MapState<String, MemoryItem> store, String prefix, List<MemoryUpdate> memoryUpdates)
+    public MemoryObjectImpl(MemoryStore store, String prefix, List<MemoryUpdate> memoryUpdates)
             throws Exception {
         this(store, prefix, () -> {}, memoryUpdates);
     }
 
     public MemoryObjectImpl(
-            MapState<String, MemoryItem> store,
+            MemoryStore store,
             String prefix,
             Runnable mailboxThreadChecker,
             List<MemoryUpdate> memoryUpdates)

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/memory/MemoryStore.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/memory/MemoryStore.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.memory;
+
+import org.apache.flink.agents.runtime.memory.MemoryObjectImpl.MemoryItem;
+
+/** MemoryStore to put and get MemoryItems. */
+public interface MemoryStore {
+
+    /**
+     * Get a MemoryItem by key.
+     *
+     * @param key the key of the MemoryItem
+     * @return the MemoryItem
+     */
+    MemoryItem get(String key) throws Exception;
+
+    /**
+     * Put a MemoryItem by key.
+     *
+     * @param key the key of the MemoryItem
+     * @param value the MemoryItem
+     */
+    void put(String key, MemoryItem value) throws Exception;
+
+    /**
+     * Check if a MemoryItem exists by key.
+     *
+     * @param key the key of the MemoryItem
+     * @return true if the MemoryItem exists, false otherwise
+     */
+    boolean contains(String key) throws Exception;
+}

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/context/PythonRunnerContextImpl.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/context/PythonRunnerContextImpl.java
@@ -21,10 +21,9 @@ import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.api.context.RunnerContext;
 import org.apache.flink.agents.plan.AgentPlan;
 import org.apache.flink.agents.runtime.context.RunnerContextImpl;
-import org.apache.flink.agents.runtime.memory.MemoryObjectImpl;
+import org.apache.flink.agents.runtime.memory.CachedMemoryStore;
 import org.apache.flink.agents.runtime.metrics.FlinkAgentsMetricGroupImpl;
 import org.apache.flink.agents.runtime.python.event.PythonEvent;
-import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -34,7 +33,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 public class PythonRunnerContextImpl extends RunnerContextImpl {
 
     public PythonRunnerContextImpl(
-            MapState<String, MemoryObjectImpl.MemoryItem> store,
+            CachedMemoryStore store,
             FlinkAgentsMetricGroupImpl agentMetricGroup,
             Runnable mailboxThreadChecker,
             AgentPlan agentPlan) {

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/memory/CachedMapStateTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/memory/CachedMapStateTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.memory;
+
+import org.apache.flink.agents.runtime.memory.MemoryObjectImpl.MemoryItem;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CachedMapStateTest {
+
+    @Test
+    void testPutAndGet() throws Exception {
+        ForTestMemoryMapState<MemoryItem> store = new ForTestMemoryMapState<>();
+        CachedMemoryStore cachedStore = new CachedMemoryStore(store);
+
+        MemoryItem v1 = new MemoryItem();
+        MemoryItem v2 = new MemoryItem(10);
+        cachedStore.put("k1", v1);
+        cachedStore.put("k2", v2);
+
+        assertThat(cachedStore.get("k1")).isEqualTo(v1);
+        assertThat(cachedStore.get("k2")).isEqualTo(v2);
+    }
+
+    @Test
+    void testPutToCache() throws Exception {
+        ForTestMemoryMapState<MemoryItem> store = new ForTestMemoryMapState<>();
+        MemoryItem v1 = new MemoryItem();
+        MemoryItem v2 = new MemoryItem();
+        store.put("k1", v1);
+        store.put("k2", v2);
+
+        CachedMemoryStore cachedStore = new CachedMemoryStore(store);
+
+        MemoryItem v11 = new MemoryItem();
+        cachedStore.put("k1", v11);
+
+        assertThat(cachedStore.get("k1")).isEqualTo(v11);
+        assertThat(cachedStore.get("k2")).isEqualTo(v2);
+    }
+
+    @Test
+    void testContains() throws Exception {
+        ForTestMemoryMapState<MemoryItem> store = new ForTestMemoryMapState<>();
+        MemoryItem v1 = new MemoryItem();
+        store.put("k1", v1);
+
+        CachedMemoryStore cachedStore = new CachedMemoryStore(store);
+        assertThat(cachedStore.contains("k1")).isTrue();
+        assertThat(cachedStore.contains("k2")).isFalse();
+
+        MemoryItem v2 = new MemoryItem();
+        cachedStore.put("k2", v2);
+        assertThat(cachedStore.contains("k2")).isTrue();
+    }
+
+    @Test
+    void testPersistCache() throws Exception {
+        ForTestMemoryMapState<MemoryItem> store = new ForTestMemoryMapState<>();
+        MemoryItem v1 = new MemoryItem();
+        MemoryItem v2 = new MemoryItem(10);
+        store.put("k1", v1);
+        store.put("k2", v2);
+
+        CachedMemoryStore cachedStore = new CachedMemoryStore(store);
+        MemoryItem v11 = new MemoryItem();
+        cachedStore.put("k1", v11);
+
+        cachedStore.persistCache();
+
+        assertThat(store.get("k1")).isEqualTo(v11);
+        assertThat(store.get("k2")).isEqualTo(v2);
+    }
+}

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/memory/CachedMemoryStoreTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/memory/CachedMemoryStoreTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class CachedMapStateTest {
+class CachedMemoryStoreTest {
 
     @Test
     void testPutAndGet() throws Exception {

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/memory/ForTestMemoryMapState.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/memory/ForTestMemoryMapState.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.memory;
+
+import org.apache.flink.api.common.state.MapState;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/** Simple, non-serialized HashMap implementation. */
+class ForTestMemoryMapState<V> implements MapState<String, V> {
+
+    private final Map<String, V> fortest = new HashMap<>();
+
+    @Override
+    public V get(String key) {
+        return fortest.get(key);
+    }
+
+    @Override
+    public void put(String key, V value) {
+        fortest.put(key, value);
+    }
+
+    @Override
+    public void putAll(Map<String, V> map) {
+        fortest.putAll(map);
+    }
+
+    @Override
+    public void remove(String key) {
+        fortest.remove(key);
+    }
+
+    @Override
+    public boolean contains(String key) {
+        return fortest.containsKey(key);
+    }
+
+    @Override
+    public Iterable<Map.Entry<String, V>> entries() {
+        return fortest.entrySet();
+    }
+
+    @Override
+    public Iterable<String> keys() {
+        return fortest.keySet();
+    }
+
+    @Override
+    public Iterable<V> values() {
+        return fortest.values();
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, V>> iterator() {
+        return fortest.entrySet().iterator();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return fortest.isEmpty();
+    }
+
+    @Override
+    public void clear() {
+        fortest.clear();
+    }
+}

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/memory/MemoryObjectTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/memory/MemoryObjectTest.java
@@ -19,7 +19,6 @@ package org.apache.flink.agents.runtime.memory;
 
 import org.apache.flink.agents.api.context.MemoryObject;
 import org.apache.flink.agents.api.context.MemoryUpdate;
-import org.apache.flink.api.common.state.MapState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -62,7 +61,9 @@ public class MemoryObjectTest {
     void setUp() throws Exception {
         ForTestMemoryMapState<MemoryObjectImpl.MemoryItem> mapState = new ForTestMemoryMapState<>();
         memoryUpdates = new LinkedList<>();
-        memory = new MemoryObjectImpl(mapState, MemoryObjectImpl.ROOT_KEY, memoryUpdates);
+        memory =
+                new MemoryObjectImpl(
+                        new CachedMemoryStore(mapState), MemoryObjectImpl.ROOT_KEY, memoryUpdates);
     }
 
     @Test
@@ -178,66 +179,5 @@ public class MemoryObjectTest {
                         new MemoryUpdate("str.new_str", null),
                         new MemoryUpdate("str.new_str.int", 42),
                         new MemoryUpdate("str.new_str.str", "world"));
-    }
-}
-
-/** Simple, non-serialized HashMap implementation. */
-class ForTestMemoryMapState<V> implements MapState<String, V> {
-
-    private final Map<String, V> fortest = new HashMap<>();
-
-    @Override
-    public V get(String key) {
-        return fortest.get(key);
-    }
-
-    @Override
-    public void put(String key, V value) {
-        fortest.put(key, value);
-    }
-
-    @Override
-    public void putAll(Map<String, V> map) {
-        fortest.putAll(map);
-    }
-
-    @Override
-    public void remove(String key) {
-        fortest.remove(key);
-    }
-
-    @Override
-    public boolean contains(String key) {
-        return fortest.containsKey(key);
-    }
-
-    @Override
-    public Iterable<Map.Entry<String, V>> entries() {
-        return fortest.entrySet();
-    }
-
-    @Override
-    public Iterable<String> keys() {
-        return fortest.keySet();
-    }
-
-    @Override
-    public Iterable<V> values() {
-        return fortest.values();
-    }
-
-    @Override
-    public Iterator<Map.Entry<String, V>> iterator() {
-        return fortest.entrySet().iterator();
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return fortest.isEmpty();
-    }
-
-    @Override
-    public void clear() {
-        fortest.clear();
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/memory/MemoryRefTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/memory/MemoryRefTest.java
@@ -110,7 +110,11 @@ public class MemoryRefTest {
     @BeforeEach
     void setUp() throws Exception {
         ForTestMemoryMapState<MemoryObjectImpl.MemoryItem> mapState = new ForTestMemoryMapState<>();
-        memory = new MemoryObjectImpl(mapState, MemoryObjectImpl.ROOT_KEY, new LinkedList<>());
+        memory =
+                new MemoryObjectImpl(
+                        new CachedMemoryStore(mapState),
+                        MemoryObjectImpl.ROOT_KEY,
+                        new LinkedList<>());
     }
 
     @Test


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #185

### Purpose of change

This PR updates the `ActionExecutionOperator` to only persist memory changes to flink state when the action is finished. 

### Tests

<!-- How is this change verified? -->

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Should this change be covered by the user documentation?-->
