### PR TITLE
[hotfix] Fix the inconsistency of the MemoryObject get method in Local and Flink modes

### DIFF
--- a/python/flink_agents/e2e_tests/my_agent.py
+++ b/python/flink_agents/e2e_tests/my_agent.py
@@ -101,7 +101,7 @@ class DataStreamAgent(Agent):
         content.memory_info = {"total_reviews": total}
 
         data_ref = stm.set(f"processed_items.item_{content.id}", content)
-        ctx.send_event(MyEvent(value=data_ref.model_dump()))
+        ctx.send_event(MyEvent(value=data_ref))
 
     @action(MyEvent)
     @staticmethod

--- a/python/flink_agents/runtime/flink_memory_object.py
+++ b/python/flink_agents/runtime/flink_memory_object.py
@@ -43,8 +43,8 @@ class FlinkMemoryObject(MemoryObject):
         """
         try:
             path_to_get: str
-            if isinstance(path_or_ref, dict) and 'path' in path_or_ref:
-                path_to_get = path_or_ref['path']
+            if isinstance(path_or_ref, MemoryRef):
+                path_to_get = path_or_ref.path
             elif isinstance(path_or_ref, str):
                 path_to_get = path_or_ref
             j_result = self._j_memory_object.get(path_to_get)


### PR DESCRIPTION
### Purpose of change
Fix the inconsistency of the MemoryObject get method in Local and Flink modes
<!-- What is the purpose of this change? -->

### Tests

<!-- How is this change verified? -->

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Should this change be covered by the user documentation?-->
