### PR TITLE
[example][java] Add ReAct agent example

### DIFF
--- a/examples/src/main/java/org/apache/flink/agents/examples/ReActAgentExample.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/ReActAgentExample.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.examples;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.agents.api.AgentsExecutionEnvironment;
+import org.apache.flink.agents.api.agents.ReActAgent;
+import org.apache.flink.agents.api.annotation.Prompt;
+import org.apache.flink.agents.api.annotation.Tool;
+import org.apache.flink.agents.api.annotation.ToolParam;
+import org.apache.flink.agents.api.resource.ResourceDescriptor;
+import org.apache.flink.agents.api.resource.ResourceType;
+import org.apache.flink.agents.examples.agents.CustomTypesAndResources;
+import org.apache.flink.agents.integrations.chatmodels.ollama.OllamaChatModelSetup;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.connector.file.src.FileSource;
+import org.apache.flink.connector.file.src.reader.TextLineFormat;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.types.Row;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Objects;
+
+import static org.apache.flink.agents.api.resource.ResourceType.TOOL;
+
+/**
+ * Java example demonstrating the ReActAgent for product review analysis and shipping notification.
+ *
+ * <p>This example demonstrates how to use the Flink Agents to analyze product reviews and record
+ * shipping questions in a streaming pipeline. The pipeline reads product reviews from a source,
+ * deserializes each review, and uses an LLM agent to extract review scores and unsatisfied reasons.
+ * If the unsatisfied reasons are related to shipping, the agent will notify the shipping manager.
+ * This serves as a minimal, end-to-end example of integrating LLM-powered react agent with Flink
+ * streaming jobs.
+ */
+public class ReActAgentExample {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Tool for notifying the shipping manager when product received a negative review due to
+     * shipping damage.
+     *
+     * @param id The id of the product that received a negative review due to shipping damage
+     * @param review The negative review content
+     */
+    @Tool(
+            description =
+                    "Notify the shipping manager when product received a negative review due to shipping damage.")
+    public static void notifyShippingManager(
+            @ToolParam(name = "id") String id, @ToolParam(name = "review") String review) {
+        org.apache.flink.agents.examples.agents.CustomTypesAndResources.notifyShippingManager(
+                id, review);
+    }
+
+    @Prompt
+    public static org.apache.flink.agents.api.prompt.Prompt reviewAnalysisReactPrompt() {
+        return CustomTypesAndResources.REVIEW_ANALYSIS_REACT_PROMPT;
+    }
+
+    /** Runs the example pipeline. */
+    public static void main(String[] args) throws Exception {
+        // Set up the Flink streaming environment and the Agents execution environment.
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        AgentsExecutionEnvironment agentsEnv =
+                AgentsExecutionEnvironment.getExecutionEnvironment(env);
+
+        // Add Ollama chat model connection and record shipping question tool to be used
+        // by the Agent.
+        agentsEnv
+                .addResource(
+                        "ollamaChatModelConnection",
+                        ResourceType.CHAT_MODEL_CONNECTION,
+                        CustomTypesAndResources.OLLAMA_SERVER_DESCRIPTOR)
+                .addResource(
+                        "notifyShippingManager",
+                        TOOL,
+                        org.apache.flink.agents.api.tools.Tool.fromMethod(
+                                ReActAgentExample.class.getMethod(
+                                        "notifyShippingManager", String.class, String.class)));
+
+        // Read product reviews from input_data.txt file as a streaming source.
+        // Each element represents a ProductReview.
+        DataStream<Row> productReviewStream =
+                env.fromSource(
+                                FileSource.forRecordStreamFormat(
+                                                new TextLineFormat(),
+                                                new Path(
+                                                        Objects.requireNonNull(
+                                                                        ReActAgentExample.class
+                                                                                .getClassLoader()
+                                                                                .getResource(
+                                                                                        "input_data.txt"))
+                                                                .getPath()))
+                                        .monitorContinuously(Duration.ofMinutes(1))
+                                        .build(),
+                                WatermarkStrategy.noWatermarks(),
+                                "react-agent-example")
+                        .map(
+                                inputStr -> {
+                                    Row row = Row.withNames();
+                                    CustomTypesAndResources.ProductReview productReview =
+                                            MAPPER.readValue(
+                                                    inputStr,
+                                                    CustomTypesAndResources.ProductReview.class);
+                                    row.setField("id", productReview.getId());
+                                    row.setField("review", productReview.getReview());
+                                    return row;
+                                });
+
+        // Create react agent
+        ReActAgent reviewAnalysisReactAgent = getReActAgent();
+
+        // Use the ReAct agent to analyze each product review and
+        // record shipping question.
+        DataStream<Object> reviewAnalysisResStream =
+                agentsEnv
+                        .fromDataStream(productReviewStream)
+                        .apply(reviewAnalysisReactAgent)
+                        .toDataStream();
+
+        // Print the analysis results to stdout.
+        reviewAnalysisResStream.print();
+
+        // Execute the Flink pipeline.
+        agentsEnv.execute();
+    }
+
+    // Create ReAct agent.
+    private static ReActAgent getReActAgent() {
+        return new ReActAgent(
+                ResourceDescriptor.Builder.newBuilder(OllamaChatModelSetup.class.getName())
+                        .addInitialArgument("connection", "ollamaChatModelConnection")
+                        .addInitialArgument("model", "qwen3:8b")
+                        .addInitialArgument(
+                                "tools", Collections.singletonList("notifyShippingManager"))
+                        .build(),
+                reviewAnalysisReactPrompt(),
+                CustomTypesAndResources.ProductReviewAnalysisRes.class);
+    }
+}

--- a/examples/src/main/java/org/apache/flink/agents/examples/WorkflowMultipleAgentExample.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/WorkflowMultipleAgentExample.java
@@ -131,8 +131,8 @@ public class WorkflowMultipleAgentExample {
         // Add Ollama chat model connection to be used by the ReviewAnalysisAgent
         // and ProductSuggestionAgent.
         agentsEnv.addResource(
-                "ollama_server",
-                ResourceType.CHAT_MODEL,
+                "ollamaChatModelConnection",
+                ResourceType.CHAT_MODEL_CONNECTION,
                 CustomTypesAndResources.OLLAMA_SERVER_DESCRIPTOR);
 
         // Read product reviews from input_data.txt file as a streaming source.

--- a/examples/src/main/java/org/apache/flink/agents/examples/WorkflowSingleAgentExample.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/WorkflowSingleAgentExample.java
@@ -51,8 +51,8 @@ public class WorkflowSingleAgentExample {
 
         // Add Ollama chat model connection to be used by the ReviewAnalysisAgent.
         agentsEnv.addResource(
-                "ollama_server",
-                ResourceType.CHAT_MODEL,
+                "ollamaChatModelConnection",
+                ResourceType.CHAT_MODEL_CONNECTION,
                 CustomTypesAndResources.OLLAMA_SERVER_DESCRIPTOR);
 
         // Read product reviews from input_data.txt file as a streaming source.

--- a/examples/src/main/java/org/apache/flink/agents/examples/agents/CustomTypesAndResources.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/agents/CustomTypesAndResources.java
@@ -67,7 +67,8 @@ public class CustomTypesAndResources {
                     Arrays.asList(
                             new ChatMessage(MessageRole.SYSTEM, REVIEW_ANALYSIS_SYSTEM_PROMPT_STR),
                             new ChatMessage(
-                                    MessageRole.USER, "\"id\": {id},\n" + "\"review\": {review}")));
+                                    MessageRole.USER,
+                                    "{\"id\": \"{id}\",\n" + "\"review\": \"{review}\"}")));
 
     // Prompt for product suggestion agent
     public static final String PRODUCT_SUGGESTION_PROMPT_STR =
@@ -111,7 +112,8 @@ public class CustomTypesAndResources {
     // Ollama chat model connection descriptor
     public static final ResourceDescriptor OLLAMA_SERVER_DESCRIPTOR =
             ResourceDescriptor.Builder.newBuilder(OllamaChatModelConnection.class.getName())
-                    .addInitialArgument("request_timeout", "120")
+                    .addInitialArgument("requestTimeout", 120)
+                    .addInitialArgument("endpoint", "http://localhost:11434")
                     .build();
 
     /** Data model representing a product review. */
@@ -157,6 +159,12 @@ public class CustomTypesAndResources {
             this.id = id;
             this.score = score;
             this.reasons = reasons;
+        }
+
+        public ProductReviewAnalysisRes() {
+            id = null;
+            score = 0;
+            reasons = List.of();
         }
 
         public String getId() {

--- a/examples/src/main/java/org/apache/flink/agents/examples/agents/ProductSuggestionAgent.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/agents/ProductSuggestionAgent.java
@@ -24,7 +24,6 @@ import org.apache.flink.agents.api.Agent;
 import org.apache.flink.agents.api.InputEvent;
 import org.apache.flink.agents.api.OutputEvent;
 import org.apache.flink.agents.api.annotation.Action;
-import org.apache.flink.agents.api.annotation.ChatModelConnection;
 import org.apache.flink.agents.api.annotation.ChatModelSetup;
 import org.apache.flink.agents.api.annotation.Prompt;
 import org.apache.flink.agents.api.chat.messages.ChatMessage;
@@ -34,7 +33,6 @@ import org.apache.flink.agents.api.event.ChatRequestEvent;
 import org.apache.flink.agents.api.event.ChatResponseEvent;
 import org.apache.flink.agents.api.resource.ResourceDescriptor;
 import org.apache.flink.agents.examples.agents.CustomTypesAndResources.ProductReviewSummary;
-import org.apache.flink.agents.integrations.chatmodels.ollama.OllamaChatModelConnection;
 import org.apache.flink.agents.integrations.chatmodels.ollama.OllamaChatModelSetup;
 
 import java.util.ArrayList;
@@ -56,13 +54,6 @@ public class ProductSuggestionAgent extends Agent {
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final String ID = "id";
     private static final String SCORE_HIST = "score_hist";
-
-    @ChatModelConnection
-    public static ResourceDescriptor ollamaChatModelConnection() {
-        return ResourceDescriptor.Builder.newBuilder(OllamaChatModelConnection.class.getName())
-                .addInitialArgument("endpoint", "http://localhost:11434")
-                .build();
-    }
 
     @ChatModelSetup
     public static ResourceDescriptor generateSuggestionModel() {

--- a/examples/src/main/java/org/apache/flink/agents/examples/agents/ReviewAnalysisAgent.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/agents/ReviewAnalysisAgent.java
@@ -24,7 +24,6 @@ import org.apache.flink.agents.api.Agent;
 import org.apache.flink.agents.api.InputEvent;
 import org.apache.flink.agents.api.OutputEvent;
 import org.apache.flink.agents.api.annotation.Action;
-import org.apache.flink.agents.api.annotation.ChatModelConnection;
 import org.apache.flink.agents.api.annotation.ChatModelSetup;
 import org.apache.flink.agents.api.annotation.Prompt;
 import org.apache.flink.agents.api.annotation.Tool;
@@ -35,7 +34,6 @@ import org.apache.flink.agents.api.context.RunnerContext;
 import org.apache.flink.agents.api.event.ChatRequestEvent;
 import org.apache.flink.agents.api.event.ChatResponseEvent;
 import org.apache.flink.agents.api.resource.ResourceDescriptor;
-import org.apache.flink.agents.integrations.chatmodels.ollama.OllamaChatModelConnection;
 import org.apache.flink.agents.integrations.chatmodels.ollama.OllamaChatModelSetup;
 
 import java.util.ArrayList;
@@ -55,13 +53,6 @@ import static org.apache.flink.agents.examples.agents.CustomTypesAndResources.RE
 public class ReviewAnalysisAgent extends Agent {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
-
-    @ChatModelConnection
-    public static ResourceDescriptor ollamaChatModelConnection() {
-        return ResourceDescriptor.Builder.newBuilder(OllamaChatModelConnection.class.getName())
-                .addInitialArgument("endpoint", "http://localhost:11434")
-                .build();
-    }
 
     @Prompt
     public static org.apache.flink.agents.api.prompt.Prompt reviewAnalysisPrompt() {

--- a/integrations/chat-models/ollama/src/main/java/org/apache/flink/agents/integrations/chatmodels/ollama/OllamaChatModelConnection.java
+++ b/integrations/chat-models/ollama/src/main/java/org/apache/flink/agents/integrations/chatmodels/ollama/OllamaChatModelConnection.java
@@ -68,6 +68,7 @@ import java.util.stream.Collectors;
 public class OllamaChatModelConnection extends BaseChatModelConnection {
     private final OllamaAPI client;
     private final Pattern pattern;
+
     /**
      * Creates a new ollama chat model connection.
      *
@@ -86,6 +87,8 @@ public class OllamaChatModelConnection extends BaseChatModelConnection {
         Integer maxChatToolCallRetries = descriptor.getArgument("maxChatToolCallRetries");
         this.client.setMaxChatToolCallRetries(
                 maxChatToolCallRetries != null ? maxChatToolCallRetries : 10);
+        Integer requestTimeout = descriptor.getArgument("requestTimeout");
+        this.client.setRequestTimeoutSeconds(requestTimeout != null ? requestTimeout : 10);
         this.pattern = Pattern.compile("<think>(.*?)</think>", Pattern.DOTALL);
     }
 

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStore.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStore.java
@@ -336,8 +336,8 @@ public class KafkaActionStateStore implements ActionStateStore {
     private Properties createProducerProp() {
         Properties producerProps = new Properties();
         producerProps.putAll(createCommonKafkaConfig());
-        producerProps.put(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-        producerProps.put(VALUE_SERIALIZER_CLASS_CONFIG, ActionStateKafkaSeder.class.getName());
+        producerProps.put(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        producerProps.put(VALUE_SERIALIZER_CLASS_CONFIG, ActionStateKafkaSeder.class);
         producerProps.put(ProducerConfig.ACKS_CONFIG, "all");
         producerProps.put(
                 PARTITIONER_CLASS_CONFIG,


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #229 

### Purpose of change

<!-- What is the purpose of this change? -->
This change added a example for the ReAct agent quickstart guide in Java similar to what python did. In this change, we are made a couple improvement to the existing single and multiple agent example to remove unused connection setup.

### Tests

<!-- How is this change verified? -->

```
❯ cd examples; java --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.text=ALL-UNNAMED --add-opens java.desktop/java.awt.font=ALL-UNNAMED -cp "target/classes:$(mvn dependency:build-classpath -q -Dmdep.outputFile=/dev/stdout)" org.apache.flink.agents.examples.ReActAgentExample; cd ..
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.esotericsoftware.kryo.util.UnsafeUtil (file:/Users/ljiang/.m2/repository/com/esotericsoftware/kryo/kryo/2.24.0/kryo-2.24.0.jar) to constructor java.nio.DirectByteBuffer(long,int,java.lang.Object)
WARNING: Please consider reporting this to the maintainers of com.esotericsoftware.kryo.util.UnsafeUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
8> ProductReviewAnalysisRes{id='B009MA34NY', score=5, reasons=[good support, comfortable, lightweight, well-made, long lasting]}
4> ProductReviewAnalysisRes{id='B009MA34NY', score=5, reasons=[]}
1> ProductReviewAnalysisRes{id='B000YFSR5G', score=2, reasons=[did not fit well, not comfortable]}
5> ProductReviewAnalysisRes{id='B009MA34NY', score=5, reasons=[]}
7> ProductReviewAnalysisRes{id='B001IKJOLW', score=5, reasons=[]}
9> ProductReviewAnalysisRes{id='B000YFSR4W', score=5, reasons=[]}
6> ProductReviewAnalysisRes{id='B010RRWKT4', score=5, reasons=[]}
11> ProductReviewAnalysisRes{id='B000YFSR5G', score=5, reasons=[]}
10> ProductReviewAnalysisRes{id='B010RRWKT4', score=5, reasons=[comfortable]}
12> ProductReviewAnalysisRes{id='B014IBJKNO', score=5, reasons=[]}
3> ProductReviewAnalysisRes{id='B0092UF54A', score=5, reasons=[excellent product quality]}
8> ProductReviewAnalysisRes{id='B010RRWKT4', score=5, reasons=[]}
2> ProductReviewAnalysisRes{id='B000YFSR4W', score=1, reasons=[damaged product upon delivery]}
4> ProductReviewAnalysisRes{id='B000KPIHQ4', score=5, reasons=[]}
1> ProductReviewAnalysisRes{id='B0058YEJ5K', score=5, reasons=[comfortable]}
5> ProductReviewAnalysisRes{id='B005AGO4LU', score=5, reasons=[comfortable, great for weight training]}
7> ProductReviewAnalysisRes{id='B0058YEJ5K', score=2, reasons=[poor quality, overpriced]}
```

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Should this change be covered by the user documentation?-->
