### PR TITLE
[Bug] Add missing close function in MCPServer

### DIFF
--- a/python/flink_agents/api/tools/mcp.py
+++ b/python/flink_agents/api/tools/mcp.py
@@ -307,3 +307,7 @@ class MCPServer(SerializableResource, ABC):
                     raise TypeError(err_msg)
 
         return chat_messages
+
+    def close(self) -> None:
+        """Close the MCP server connection and clean up resources."""
+        asyncio.run(self._cleanup_connection())

--- a/python/flink_agents/e2e_tests/mcp/__init__.py
+++ b/python/flink_agents/e2e_tests/mcp/__init__.py
@@ -1,0 +1,17 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################

--- a/python/flink_agents/e2e_tests/mcp/mcp_example.py
+++ b/python/flink_agents/e2e_tests/mcp/mcp_example.py
@@ -1,0 +1,155 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+################################################################################
+"""Example demonstrating MCP (Model Context Protocol) integration with Flink Agents.
+
+This example shows how to:
+1. Define an MCP server connection
+2. Use MCP prompts in chat model setups
+3. Use MCP tools in actions
+
+Prerequisites:
+- Run the MCP server first: mcp_server.py
+"""
+import multiprocessing
+import os
+import runpy
+import time
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from flink_agents.api.agent import Agent
+from flink_agents.api.chat_message import ChatMessage, MessageRole
+from flink_agents.api.decorators import (
+    action,
+    chat_model_connection,
+    chat_model_setup,
+    mcp_server,
+)
+from flink_agents.api.events.chat_event import ChatRequestEvent, ChatResponseEvent
+from flink_agents.api.events.event import InputEvent, OutputEvent
+from flink_agents.api.execution_environment import AgentsExecutionEnvironment
+from flink_agents.api.resource import ResourceDescriptor
+from flink_agents.api.runner_context import RunnerContext
+from flink_agents.api.tools.mcp import MCPServer
+from flink_agents.integrations.chat_models.ollama_chat_model import (
+    OllamaChatModelConnection,
+    OllamaChatModelSetup,
+)
+
+OLLAMA_MODEL = os.environ.get("OLLAMA_CHAT_MODEL", "qwen3:8b")
+MCP_SERVER_ENDPOINT = "http://127.0.0.1:8000/mcp"
+
+
+class CalculationInput(BaseModel):
+    """Input for calculation requests."""
+
+    a: int
+    b: int
+
+
+class MyMCPAgent(Agent):
+    """Example agent demonstrating MCP prompts and tools integration."""
+
+    @mcp_server
+    @staticmethod
+    def my_mcp_server() -> MCPServer:
+        """Define MCP server connection."""
+        return MCPServer(endpoint=MCP_SERVER_ENDPOINT)
+
+    @chat_model_connection
+    @staticmethod
+    def ollama_connection() -> ResourceDescriptor:
+        """ChatModelConnection for Ollama."""
+        return ResourceDescriptor(clazz=OllamaChatModelConnection)
+
+    @chat_model_setup
+    @staticmethod
+    def math_chat_model() -> ResourceDescriptor:
+        """ChatModel using MCP prompt and tool."""
+        return ResourceDescriptor(
+            clazz=OllamaChatModelSetup,
+            connection="ollama_connection",
+            model=OLLAMA_MODEL,
+            prompt="ask_sum",  # MCP prompt registered from my_mcp_server
+            tools=["add"],  # MCP tool registered from my_mcp_server
+            extract_reasoning=True,
+        )
+
+    @action(InputEvent)
+    @staticmethod
+    def process_input(event: InputEvent, ctx: RunnerContext) -> None:
+        """Process input and send chat request using MCP prompt.
+
+        The MCP prompt "ask_sum" accepts parameters {a} and {b}.
+        """
+        input_data: CalculationInput = event.input
+
+        # Send chat request with MCP prompt variables
+        # The prompt template will be filled with a and b values
+        msg = ChatMessage(
+            role=MessageRole.USER,
+            extra_args={"a": str(input_data.a), "b": str(input_data.b)},
+        )
+
+        ctx.send_event(ChatRequestEvent(model="math_chat_model", messages=[msg]))
+
+    @action(ChatResponseEvent)
+    @staticmethod
+    def process_chat_response(event: ChatResponseEvent, ctx: RunnerContext) -> None:
+        """Process chat response and output result."""
+        response = event.response
+        if response and response.content:
+            ctx.send_event(OutputEvent(output=response.content))
+
+
+def run_mcp_server() -> None:
+    """Run the MCP server in a separate process."""
+    runpy.run_path(f"{current_dir}/mcp_server.py")
+
+
+current_dir = Path(__file__).parent
+
+if __name__ == "__main__":
+    # Start MCP server in background
+    print("Starting MCP server...")
+    server_process = multiprocessing.Process(target=run_mcp_server)
+    server_process.start()
+    time.sleep(5)
+
+    print(f"\nRunning MyMCPAgent with Ollama model: {OLLAMA_MODEL}")
+    print(f"MCP server endpoint: {MCP_SERVER_ENDPOINT}\n")
+
+    env = AgentsExecutionEnvironment.get_execution_environment()
+    input_list = []
+    agent = MyMCPAgent()
+
+    output_list = env.from_list(input_list).apply(agent).to_list()
+
+    # Add test inputs
+    input_list.append({"key": "calc1", "value": CalculationInput(a=1, b=2)})
+    input_list.append({"key": "calc2", "value": CalculationInput(a=12, b=34)})
+
+    env.execute()
+
+    print("Results:")
+    for output in output_list:
+        for key, value in output.items():
+            print(f"{key}: {value}")
+
+    server_process.kill()

--- a/python/flink_agents/e2e_tests/mcp/mcp_server.py
+++ b/python/flink_agents/e2e_tests/mcp/mcp_server.py
@@ -1,0 +1,60 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+################################################################################
+"""MCP server providing prompts and tools for calculation tasks."""
+import dotenv
+from mcp.server.fastmcp import FastMCP
+
+dotenv.load_dotenv()
+
+# Create MCP server
+mcp = FastMCP("MathServer")
+
+
+@mcp.prompt()
+def ask_sum(a: int, b: int) -> str:
+    """Generate a prompt asking to calculate the sum of two numbers.
+
+    This prompt will be used by chat models to request calculations.
+
+    Args:
+        a: The first operand
+        b: The second operand
+
+    Returns:
+        A formatted prompt string
+    """
+    return f"Calculate the sum of {a} and {b}?"
+
+
+@mcp.tool()
+async def add(a: int, b: int) -> int:
+    """Calculate the sum of two numbers.
+
+    This tool can be called by chat models to perform the actual calculation.
+
+    Args:
+        a: The first operand
+        b: The second operand
+
+    Returns:
+        The sum of a and b
+    """
+    return a + b
+
+
+mcp.run("streamable-http")


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #246

### Purpose of change

<!-- What is the purpose of this change? -->
Add missing close function in MCPServer and add an e2e example

### Tests

<!-- How is this change verified? -->
Test with an e2e example

```
2025-10-03 10:44:30,517 - INFO - HTTP Request: POST http://localhost:11434/api/chat "HTTP/1.1 200 OK"
2025-10-03 10:44:30,518 - INFO - key: calc2, send_event: id=UUID('0a78e7ab-1d42-4cf4-8f44-62c8ac90674f') request_id=UUID('a288572b-689c-4d4c-8239-b67e36ecbc03') response=ChatMessage(role=<MessageRole.ASSISTANT: 'assistant'>, content='The sum of 12 and 34 is 46.', tool_calls=[], extra_args={'reasoning': "Okay, let me see. The user asked to calculate the sum of 12 and 34. I remember from the tools provided that there's a function called add which takes two integers, a and b. So I need to call that function with a=12 and b=34. The function should return the sum, which is 46. I should make sure to format the tool call correctly within the XML tags. Let me double-check the parameters to ensure they are integers. Yep, both are integers. Alright, the response should be straightforward."})
2025-10-03 10:44:30,518 - INFO - key: calc2, performing action: process_chat_response
2025-10-03 10:44:30,518 - INFO - key: calc2, send_event: id=UUID('5977c3a6-edd2-4372-bc18-95cee184b479') output='The sum of 12 and 34 is 46.'
Results:
calc1: The sum of 1 and 2 is 3.
calc2: The sum of 12 and 34 is 46.
```

### API

<!-- Does this change touches any public APIs? -->
- Add a new `close` method

### Documentation

<!-- Should this change be covered by the user documentation?-->
n/a
