### PR TITLE
[doc] Add instructions for java in Prompt, Tool and ChatModel doc.

### DIFF
--- a/docs/content/docs/development/chat_models.md
+++ b/docs/content/docs/development/chat_models.md
@@ -32,9 +32,9 @@ Chat models enable agents to communicate with Large Language Models (LLMs) for n
 
 To use chat models in your agents, you need to define both a connection and setup using decorators/annotations, then interact with the model through events.
 
-### Resource Decorators/Annotations
+### Resource Declaration
 
-Flink Agents provides decorators to simplify chat model setup within agents:
+Flink Agents provides decorators in python and annotations in java to simplify chat model setup within agents:
 
 #### @chat_model_connection/@ChatModelConnection
 
@@ -147,7 +147,7 @@ public class MyAgent extends Agent {
 Anthropic provides cloud-based chat models featuring the Claude family, known for their strong reasoning, coding, and safety capabilities.
 
 {{< hint warning >}}
-Anthropic is only supported in python.
+Anthropic is only supported in python currently.
 {{< /hint >}}
 
 #### Prerequisites
@@ -362,7 +362,7 @@ Model availability and specifications may change. Always check the official Olla
 OpenAI provides cloud-based chat models with state-of-the-art performance for a wide range of natural language tasks.
 
 {{< hint warning >}}
-OpenAI is only supported in python.
+OpenAI is only supported in python currently.
 {{< /hint >}}
 
 #### Prerequisites
@@ -445,7 +445,7 @@ Model availability and specifications may change. Always check the official Open
 Tongyi provides cloud-based chat models from Alibaba Cloud, offering powerful Chinese and English language capabilities.
 
 {{< hint warning >}}
-Tongyi is only supported in python.
+Tongyi is only supported in python currently.
 {{< /hint >}}
 
 #### Prerequisites

--- a/docs/content/docs/development/prompts.md
+++ b/docs/content/docs/development/prompts.md
@@ -41,7 +41,7 @@ Local prompts are templates defined directly in your code. They support variable
 MCP (Model Context Protocol) prompts are managed by external MCP servers. They enable dynamic prompt retrieval, centralized prompt management, and integration with external prompt repositories.
 
 {{< hint warning >}}
-MCP Prompt is only supported in python.
+MCP Prompt is only supported in python currently.
 {{< /hint >}}
 ## Local Prompt
 
@@ -189,7 +189,7 @@ Prompt reviewAnalysisPrompt =
 
 ### Using Prompts in Agents
 
-Register a prompt as an agent resource using the `@prompt` decorator/annotation:
+Register a prompt as an agent resource using the `@prompt` decorator in python (or `@Prompt` annotation in java):
 
 {{< tabs "Using Prompts in Agents" >}}
 
@@ -336,7 +336,7 @@ MCP (Model Context Protocol) is a standardized protocol for integrating AI appli
 {{< /hint >}}
 
 {{< hint warning >}}
-MCP Prompt is only supported in python.
+MCP Prompt is only supported in python currently.
 {{< /hint >}}
 
 MCP prompts are managed by external MCP servers and automatically discovered when you define an MCP server connection in your agent.

--- a/docs/content/docs/development/tool_use.md
+++ b/docs/content/docs/development/tool_use.md
@@ -28,15 +28,15 @@ Flink Agents provides a flexible and extensible tool use mechanism. Developers c
 
 ## Local Function as Tool
 
-Developer can define the tool as a local Python function, and there are two ways to define and register an local function as a tool:
+Developer can define the tool as a local Python/Java function, and there are two ways to define and register a local function as a tool:
 
 {{< hint info >}}
-Flink Agents uses the docstring of the tool function to generate the tool metadata. The docstring of the python function should accurately describe the tool's purpose, parameters, and return value, so that the LLM can understand the tool and use it effectively.
+Flink Agents uses the docstring of the python tool function to generate the tool metadata. The docstring of the python function should accurately describe the tool's purpose, parameters, and return value, so that the LLM can understand the tool and use it effectively.
 {{< /hint >}}
 
 ### Define Tool as Static Method in Agent Class
 
-Developer can define the tool as a static method in the agent class while defining the workflow agent, and use the `@tool` annotation to mark the method as a tool. The tool can be referenced by its name in the `tools` list of the `ResourceDescriptor` when creating the chat model in the agent.
+Developer can define the tool as a static method in the agent class while defining the workflow agent, and use the `@tool` decorator to mark the function as a tool in python (or `@Tool` annotation in java). The tool can be referenced by its name in the `tools` list of the `ResourceDescriptor` when creating the chat model in the agent.
 
 {{< tabs "Define Tool as Static Method in Agent Class" >}}
 
@@ -100,7 +100,7 @@ public class ReviewAnalysisAgent extends Agent {
 {{< /tabs >}}
 
 **Key points:**
-- Use `@tool` decorator/annotation to define the tool
+- Use `@tool` decorator to define the tool in python (or `@Tool` annotation in java)
 - Reference the tool by its name in the `tools` list of the `ResourceDescriptor`
 
 
@@ -186,7 +186,7 @@ MCP (Model Context Protocol) is a standardized protocol for integrating AI appli
 {{< /hint >}}
 
 {{< hint warning >}}
-MCP Tool is only supported in python.
+MCP Tool is only supported in python currently.
 {{< /hint >}}
 
 MCP tools are managed by external MCP servers and automatically discovered when you define an MCP server connection in your agent.


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->


### Purpose of change

Add instructions for java in Prompt, Tool and ChatModel doc.

### Tests

No
### API

No

### Documentation

Yes