### PR TITLE
[hotfix] improve build.sh script

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -51,6 +51,7 @@ cp "${PROJECT_ROOT}/dist/target/flink-agents-dist-${PROJECT_VERSION}.jar" ${PYTH
 
 # build python
 cd python
+rm -rf dist/  # Clean old build artifacts before building
 pip install uv
 uv sync --extra dev
 uv run python -m build


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #xxx

### Purpose of change

<!-- What is the purpose of this change? -->

Users may encounter the following error when running `tools/build.sh` multiple times across different branches (e.g., switching between `main` and `release-0.1`):

```
removing build/bdist.macosx-11.0-arm64/wheel
Successfully built flink_agents-0.2.dev0.tar.gz and flink_agents-0.2.dev0-py3-none-any.whl
error: Requirements contain conflicting URLs for package `flink-agents`:
- file:///Users/alazhang/Workspaces/Java/flink-agents/python/dist/flink_agents-0.1.0-py3-none-any.whl
- file:///Users/alazhang/Workspaces/Java/flink-agents/python/dist/flink_agents-0.2.dev0-py3-none-any.whl
```

This occurs because old wheel files from previous builds accumulate in `python/dist/`, causing version conflicts during installation. The fix cleans the `dist/` directory before building to ensure only the current version's artifacts are present.

### Tests

<!-- How is this change verified? -->
Test the changes locally

### API

<!-- Does this change touches any public APIs? -->
n/a

### Documentation

<!-- Should this change be covered by the user documentation?-->
n/a
