### PR TITLE
[doc] fix: wrong branch name in doc

### DIFF
--- a/docs/content/docs/get-started/installation.md
+++ b/docs/content/docs/get-started/installation.md
@@ -124,7 +124,7 @@ Clone the repository and checkout the release tag:
 git clone https://github.com/apache/flink-agents.git
 cd flink-agents
 # Checkout the release tag
-git checkout release-0.1.0
+git checkout release-0.1
 ```
 {{< /tab >}}
 


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #xxx

### Purpose of change

<!-- What is the purpose of this change? -->
Wrong branch name in doc, should be `release-0.1`
```
❯ git checkout release-0.1.0                                                                         
error: pathspec 'release-0.1.0' did not match any file(s) known to git

```

### Tests

<!-- How is this change verified? -->

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Should this change be covered by the user documentation?-->
