### PR TITLE
[hotfix] toolCallContext not updated in ChatModelAction, causing data loss

### DIFF
--- a/plan/src/main/java/org/apache/flink/agents/plan/actions/ChatModelAction.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/actions/ChatModelAction.java
@@ -83,6 +83,7 @@ public class ChatModelAction {
                     new ArrayList<>((List<ChatMessage>) toolCallContext.get(initialRequestId));
 
             messageContext.add(response);
+            toolCallContext.put(initialRequestId, messageContext);
             stm.set(TOOL_CALL_CONTEXT, toolCallContext);
 
             ToolRequestEvent toolRequestEvent =
@@ -182,6 +183,7 @@ public class ChatModelAction {
                                     extraArgs));
                 }
             }
+            toolCallContext.put(initialRequestId, messages);
             // overwrite tool call context
             stm.set(TOOL_CALL_CONTEXT, toolCallContext);
 


### PR DESCRIPTION
Linked issue: #288

### Purpose of change
This fix ensures that the updated `messageContext` is properly stored in `toolCallContext` before setting it in the ShortTermMemory.
<!-- What is the purpose of this change? -->

### Tests

<!-- How is this change verified? -->

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Should this change be covered by the user documentation?-->

### Cherrypick
No
<!-- Should this change be cherry-picked to another branch?-->

