### PR TITLE
[api] Support loading Flink legacy yaml config file

### DIFF
--- a/python/flink_agents/runtime/remote_execution_environment.py
+++ b/python/flink_agents/runtime/remote_execution_environment.py
@@ -296,19 +296,18 @@ class RemoteExecutionEnvironment(AgentsExecutionEnvironment):
         Path | None
             Path to the config file if found, None otherwise.
         """
-        # Try primary config file name
+        # Try legacy config file name first
+        legacy_config_path = Path(flink_conf_dir).joinpath(_LEGACY_CONFIG_FILE_NAME)
+        if legacy_config_path.exists():
+            logging.warning(
+                f"Using legacy config file {_LEGACY_CONFIG_FILE_NAME}"
+            )
+            return legacy_config_path
+
+        # Try new config file name as fallback
         primary_config_path = Path(flink_conf_dir).joinpath(_CONFIG_FILE_NAME)
         if primary_config_path.exists():
             return primary_config_path
-
-        # Try legacy config file name
-        logging.warning(
-            f"Config file {primary_config_path} not found, "
-            f"using legacy config file {_LEGACY_CONFIG_FILE_NAME} instead"
-        )
-        legacy_config_path = Path(flink_conf_dir).joinpath(_LEGACY_CONFIG_FILE_NAME)
-        if legacy_config_path.exists():
-            return legacy_config_path
 
         return None
 


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #296 

### Purpose of change

Support loading Flink legacy yaml config file

### Tests
- test_remote_execution_environment.test_remote_execution_environment_load_config_file
- test_remote_execution_environment.test_remote_execution_environment_load_legacy_config_file
- test_remote_execution_environment.test_remote_execution_environment_prioritizes_legacy_config

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Should this change be covered by the user documentation?-->
