### PR TITLE
[runtime] Move PythonActionExecutor to PythonRunnerContextImpl

### DIFF
--- a/python/flink_agents/e2e_tests/integrate_datastream_with_agent_example.py
+++ b/python/flink_agents/e2e_tests/integrate_datastream_with_agent_example.py
@@ -17,7 +17,7 @@
 #################################################################################
 from pathlib import Path
 
-from pyflink.common import Duration, WatermarkStrategy
+from pyflink.common import Configuration, Duration, WatermarkStrategy
 from pyflink.datastream import (
     KeySelector,
     RuntimeExecutionMode,
@@ -43,8 +43,11 @@ current_dir = Path(__file__).parent
 # PYTHONPATH like "os.environ["PYTHONPATH"] = ($VENV_HOME/lib/$PYTHON_VERSION/
 # site-packages) in this file.
 if __name__ == "__main__":
-    env = StreamExecutionEnvironment.get_execution_environment()
-
+    config = Configuration()
+    config.set_string("state.backend.type", "rocksdb")
+    config.set_string("checkpointing.interval", "1s")
+    config.set_string("restart-strategy.type", "disable")
+    env = StreamExecutionEnvironment.get_execution_environment(config)
     env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
     env.set_parallelism(1)
 

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -641,7 +641,7 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
             return new JavaActionTask(
                     key, event, action, getRuntimeContext().getUserCodeClassLoader());
         } else if (action.getExec() instanceof PythonFunction) {
-            return new PythonActionTask(key, event, action, pythonActionExecutor);
+            return new PythonActionTask(key, event, action);
         } else {
             throw new IllegalStateException(
                     "Unsupported action type: " + action.getExec().getClass());
@@ -669,7 +669,8 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
                             new CachedMemoryStore(shortTermMemState),
                             metricGroup,
                             this::checkMailboxThread,
-                            agentPlan);
+                            agentPlan,
+                            pythonActionExecutor);
         } else {
             throw new IllegalStateException(
                     "Unsupported action type: " + actionTask.action.getExec().getClass());

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/context/PythonRunnerContextImpl.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/context/PythonRunnerContextImpl.java
@@ -24,6 +24,7 @@ import org.apache.flink.agents.runtime.context.RunnerContextImpl;
 import org.apache.flink.agents.runtime.memory.CachedMemoryStore;
 import org.apache.flink.agents.runtime.metrics.FlinkAgentsMetricGroupImpl;
 import org.apache.flink.agents.runtime.python.event.PythonEvent;
+import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -32,12 +33,16 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public class PythonRunnerContextImpl extends RunnerContextImpl {
 
+    private final PythonActionExecutor pythonActionExecutor;
+
     public PythonRunnerContextImpl(
             CachedMemoryStore store,
             FlinkAgentsMetricGroupImpl agentMetricGroup,
             Runnable mailboxThreadChecker,
-            AgentPlan agentPlan) {
+            AgentPlan agentPlan,
+            PythonActionExecutor pythonActionExecutor) {
         super(store, agentMetricGroup, mailboxThreadChecker, agentPlan);
+        this.pythonActionExecutor = pythonActionExecutor;
     }
 
     @Override
@@ -50,5 +55,9 @@ public class PythonRunnerContextImpl extends RunnerContextImpl {
     public void sendEvent(String type, byte[] event) {
         // this method will be invoked by PythonActionExecutor's python interpreter.
         sendEvent(new PythonEvent(event, type));
+    }
+
+    public PythonActionExecutor getPythonActionExecutor() {
+        return pythonActionExecutor;
     }
 }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/operator/PythonGeneratorActionTask.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/operator/PythonGeneratorActionTask.java
@@ -20,30 +20,25 @@ package org.apache.flink.agents.runtime.python.operator;
 import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.plan.actions.Action;
 import org.apache.flink.agents.runtime.operator.ActionTask;
-import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
 
 /** An {@link ActionTask} wrapper a Python Generator to represent a code block in Python action. */
 public class PythonGeneratorActionTask extends PythonActionTask {
     private final String pythonGeneratorRef;
 
     public PythonGeneratorActionTask(
-            Object key,
-            Event event,
-            Action action,
-            PythonActionExecutor pythonActionExecutor,
-            String pythonGeneratorRef) {
-        super(key, event, action, pythonActionExecutor);
+            Object key, Event event, Action action, String pythonGeneratorRef) {
+        super(key, event, action);
         this.pythonGeneratorRef = pythonGeneratorRef;
     }
 
     @Override
-    public ActionTaskResult invoke() throws Exception {
+    public ActionTaskResult invoke() {
         LOG.debug(
                 "Try execute python generator action {} for event {} with key {}.",
                 action.getName(),
                 event,
                 key);
-        boolean finished = pythonActionExecutor.callPythonGenerator(pythonGeneratorRef);
+        boolean finished = getPythonActionExecutor().callPythonGenerator(pythonGeneratorRef);
         ActionTask generatedActionTask = finished ? null : this;
         return new ActionTaskResult(
                 finished,


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #297 

### Purpose of change

Move PythonActionExecutor to PythonRunnerContextImpl to make PythonActionExecutor serializable.

### Tests

Updated the e2e test to use RocksDB state backend to verify the change.

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Should this change be covered by the user documentation?-->
