### PR TITLE
[bugfix][test]parsing log path error on windows

### DIFF
--- a/runtime/src/main/java/org/apache/flink/agents/runtime/eventlog/FileEventLogger.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/eventlog/FileEventLogger.java
@@ -110,7 +110,11 @@ public class FileEventLogger implements EventLogger {
                         config.getProperties()
                                 .getOrDefault(BASE_LOG_DIR_PROPERTY_KEY, DEFAULT_BASE_LOG_DIR);
         String jobId = params.getRuntimeContext().getJobInfo().getJobId().toString();
-        String taskName = params.getRuntimeContext().getTaskInfo().getTaskName().replaceAll("[\\\\/:*?\"<>|]", "_");
+        String taskName =
+                params.getRuntimeContext()
+                        .getTaskInfo()
+                        .getTaskName()
+                        .replaceAll("[\\\\/:*?\"<>|]", "_");
         int subTaskId = params.getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
         String fileName = String.format("events-%s-%s-%d.log", jobId, taskName, subTaskId);
         return Paths.get(baseLogDir, fileName).toString();


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: https://github.com/apache/flink-agents/issues/293
<mark>**Full disclosure: This fix was generated by an LLM, as this is not my area of expertise. Please review carefully.**</mark>

### Purpose of change

<!-- What is the purpose of this change? -->
Fix the reported Issue https://github.com/apache/flink-agents/issues/293

### Tests

<!-- How is this change verified? -->
Not verified on the github action, but verified on my local machine, do we currently have a Windows Server available for testing?

### API

<!-- Does this change touches any public APIs? -->
No

### Documentation

<!-- Should this change be covered by the user documentation?-->
No
