### PR TITLE
[hotfix] Remove onnxruntime version specification on osx.

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -105,12 +105,6 @@ members = ["."]
 
 # Configure platform-specific dependency resolution
 [tool.uv]
-# Ensure uv resolves to compatible versions for macOS ARM64
-constraint-dependencies = [
-    # Use a compatible onnxruntime version for macOS ARM64
-    "onnxruntime>=1.16.0,<1.23.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
-]
-
 # Configure required environments for platform compatibility
 required-environments = [
     "sys_platform == 'darwin' and platform_machine == 'arm64'",


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->


### Purpose of change

ONNX Runtime has recently completed its support for macOS, so it is no longer necessary to specify a separate version for osx

### Tests

No

### API

No

### Documentation

No
