### PR TITLE
[hotfix] Add missing `mcp_server` in Java ResourceType API

### DIFF
--- a/api/src/main/java/org/apache/flink/agents/api/resource/ResourceType.java
+++ b/api/src/main/java/org/apache/flink/agents/api/resource/ResourceType.java
@@ -30,7 +30,8 @@ public enum ResourceType {
     EMBEDDING_MODEL_CONNECTION("embedding_model_connection"),
     VECTOR_STORE("vector_store"),
     PROMPT("prompt"),
-    TOOL("tool");
+    TOOL("tool"),
+    MCP_SERVER("mcp_server");
 
     private final String value;
 


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #xxx

### Purpose of change

<!-- What is the purpose of this change? -->

We need to define `mcp_server` in Java `ResourceType` API, otherwise below error could occur if the app integrates with MCP server:

```
py4j.protocol.Py4JJavaError: An error occurred while calling o125.invoke.
: java.lang.IllegalArgumentException: Unknown ResourceType value: mcp_server
	at org.apache.flink.agents.api.resource.ResourceType.fromValue(ResourceType.java:58)
	at org.apache.flink.agents.plan.serializer.ResourceProviderJsonDeserializer.deserializePythonSerializableResourceProvider(ResourceProviderJsonDeserializer.java:104)
	at org.apache.flink.agents.plan.serializer.ResourceProviderJsonDeserializer.deserialize(ResourceProviderJsonDeserializer.java:66)
	at org.apache.flink.agents.plan.serializer.ResourceProviderJsonDeserializer.deserialize(ResourceProviderJsonDeserializer.java:45)
```


### Tests

<!-- How is this change verified? -->
Deploy a test app in local Flink cluster

### API

<!-- Does this change touches any public APIs? -->
- Add new `mcp_server` in `ResourceType.java`

### Documentation

<!-- Should this change be covered by the user documentation?-->
n/a
