### PR TITLE
[hotfix] Fix the type mismatch issue in the format_messages method

### DIFF
--- a/python/flink_agents/api/agents/react_agent.py
+++ b/python/flink_agents/api/agents/react_agent.py
@@ -242,7 +242,9 @@ class ReActAgent(Agent):
                 usr_input = usr_input.as_dict(recursive=True)
             else:  # regard as pojo
                 usr_input = usr_input.__dict__
-            usr_msgs = prompt.format_messages(role=MessageRole.USER, **usr_input)
+            # Convert Any values to str to match format_messages signature
+            str_usr_input = {k: str(v) for k, v in usr_input.items()}
+            usr_msgs = prompt.format_messages(role=MessageRole.USER, **str_usr_input)
 
         try:
             schema_prompt = cast(

--- a/python/flink_agents/api/chat_models/chat_model.py
+++ b/python/flink_agents/api/chat_models/chat_model.py
@@ -185,7 +185,9 @@ class BaseChatModelSetup(Resource):
 
             # fill the prompt template
             for msg in messages:
-                input_variable.update(msg.extra_args)
+                # Convert Any values to str to match format_messages signature
+                str_extra_args = {k: str(v) for k, v in msg.extra_args.items()}
+                input_variable.update(str_extra_args)
             prompt_messages = prompt.format_messages(**input_variable)
 
             # append meaningful messages

--- a/python/flink_agents/runtime/tests/test_built_in_actions.py
+++ b/python/flink_agents/runtime/tests/test_built_in_actions.py
@@ -94,7 +94,9 @@ class MockChatModel(BaseChatModelSetup):
             if "sum" in messages[-1].content:
                 input_variable = {}
                 for msg in messages:
-                    input_variable.update(msg.extra_args)
+                    # Convert Any values to str to match format_messages signature
+                    str_extra_args = {k: str(v) for k, v in msg.extra_args.items()}
+                    input_variable.update(str_extra_args)
                 messages = prompt.format_messages(**input_variable)
 
         # Bind tools


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->

### Purpose of change
Fix the type mismatch issue in the format_messages method.
<!-- What is the purpose of this change? -->

### Tests
ut
<!-- How is this change verified? -->

### API
no
<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
