### PR TITLE
[Bug] Tool call doesn't work in OpenAI chat model integration

### DIFF
--- a/python/flink_agents/e2e_tests/chat_model_example.py
+++ b/python/flink_agents/e2e_tests/chat_model_example.py
@@ -38,8 +38,10 @@ from flink_agents.integrations.chat_models.ollama_chat_model import (
     OllamaChatModelConnection,
     OllamaChatModelSetup,
 )
-from flink_agents.integrations.chat_models.openai.openai_chat_model import OpenAIChatModelConnection, \
-    OpenAIChatModelSetup
+from flink_agents.integrations.chat_models.openai.openai_chat_model import (
+    OpenAIChatModelConnection,
+    OpenAIChatModelSetup,
+)
 from flink_agents.integrations.chat_models.tongyi_chat_model import (
     TongyiChatModelConnection,
     TongyiChatModelSetup,


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #336

### Purpose of change

<!-- What is the purpose of this change? -->

I'm trying to use OpenAI chat model to make some function calls for my test Agent app, however it seems the tool call function doesn't work in current implementation. The tool call failed with below error message:

```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for ToolResponseEvent
responses.call_O9kSJDZYTBerHtWVrHWgpJrZ.[key]
  Input should be a valid UUID, invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `l` at 3 [type=uuid_parsing, input_value='call_O9kSJDZYTBerHtWVrHWgpJrZ', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/uuid_parsing
external_ids.call_O9kSJDZYTBerHtWVrHWgpJrZ.[key]
  Input should be a valid UUID, invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `l` at 3 [type=uuid_parsing, input_value='call_O9kSJDZYTBerHtWVrHWgpJrZ', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/uuid_parsing
```
This PR is for fixing this issue.

### Tests

<!-- How is this change verified? -->
Add OpenAI chat model in the end-to-end test `chat_model_example.py` and verified locally.

```
2025-11-21 15:47:10,929 - INFO - key: 0002, performing action: chat_model_action
2025-11-21 15:47:12,232 - INFO - HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
2025-11-21 15:47:12,235 - INFO - key: 0002, send_event: id=UUID('bed4c2c9-9bfb-471c-a414-b93285d7d4eb') model='creative_chat_model' tool_calls=[{'id': UUID('19c35960-6128-4cb3-9001-de8ad4d7152e'), 'type': 'function', 'function': {'name': 'add', 'arguments': {'a': 1, 'b': 2}}, 'original_id': 'call_hoskOBq7PxS2qqoxOkoZQpEZ'}]
2025-11-21 15:47:12,235 - INFO - key: 0002, performing action: tool_call_action
2025-11-21 15:47:12,235 - INFO - key: 0002, send_event: id=UUID('4aeab19f-5442-4f5c-8e33-4bd754b0359f') request_id=UUID('bed4c2c9-9bfb-471c-a414-b93285d7d4eb') responses={UUID('19c35960-6128-4cb3-9001-de8ad4d7152e'): 3} external_ids={UUID('19c35960-6128-4cb3-9001-de8ad4d7152e'): 'call_hoskOBq7PxS2qqoxOkoZQpEZ'}
2025-11-21 15:47:12,235 - INFO - key: 0002, performing action: chat_model_action
2025-11-21 15:47:13,256 - INFO - HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
2025-11-21 15:47:13,263 - INFO - key: 0002, send_event: id=UUID('a3b6d511-821e-494f-8c4e-4db0037e5c7c') request_id=UUID('f6ce4201-2bc6-4775-a0ba-732db123a71e') response=ChatMessage(role=<MessageRole.ASSISTANT: 'assistant'>, content='Why was the cat sitting on the computer?\n\nBecause it wanted to keep an eye on the mouse!', tool_calls=[], extra_args={})
2025-11-21 15:47:13,264 - INFO - key: 0002, performing action: process_chat_response
2025-11-21 15:47:13,264 - INFO - key: 0002, send_event: id=UUID('46a5d1dd-7728-4b98-9dd6-8b812d3b004d') output='Why was the cat sitting on the computer?\n\nBecause it wanted to keep an eye on the mouse!'
0001: The sum of 1 and 2 is 3.
0002: Why was the cat sitting on the computer?

Because it wanted to keep an eye on the mouse!

```

### API

<!-- Does this change touches any public APIs? -->
n/a

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
