### PR TITLE
[hotfix] Add the Apache 2.0 License to the omitted files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,24 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
 # How to contribute to Flink Agents
 
 Thank you for your intention to contribute the Flink Agents project!

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # Add 'priority/major' label to any changes within the entire repository
 priority/major:
   - changed-files:

--- a/tools/.rat-excludes
+++ b/tools/.rat-excludes
@@ -1,4 +1,3 @@
-.github/*
 .rat-excludes
 build
 docs
@@ -13,6 +12,7 @@ docs
 .*\.txt$
 target/*
 README.md
+PULL_REQUEST_TEMPLATE.md
 .pytest_cache/*
 .ruff_cache/*
 .*\.egg-info/*


### PR DESCRIPTION

### Purpose of change
Add the Apache 2.0 License to the omitted files
<!-- What is the purpose of this change? -->

### Tests
Run the `check-license.sh` script on the computer.
<!-- How is this change verified? -->

### API
No
<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
