### PR TITLE
[hotfix] Remove unnecessary space to improve the pass rate of IntegrationTest

### DIFF
--- a/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/ChatModelIntegrationTest.java
+++ b/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/ChatModelIntegrationTest.java
@@ -102,7 +102,7 @@ public class ChatModelIntegrationTest extends OllamaPreparationUtils {
 
     public void checkResult(CloseableIterator<Object> results) {
         List<String> expectedWords =
-                List.of(" 77", "37", "89", "23", "68", "22", "26", "22", "23", "");
+                List.of("77", "37", "89", "23", "68", "22", "26", "22", "23", "");
         for (String expected : expectedWords) {
             Assertions.assertTrue(
                     results.hasNext(), "Output messages count %s is less than expected.");


### PR DESCRIPTION
### Purpose of change

Remove unnecessary space to improve the pass rate of ChatModelIntegrationTest.

### Tests

<!-- How is this change verified? -->

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
