### PR TITLE
[runtime] Remove userCodeClassLoader field for ActionTask to fix can't be serialized to state.

### DIFF
--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -421,7 +421,8 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
             }
         } else {
             maybeInitActionState(key, sequenceNumber, actionTask.action, actionTask.event);
-            ActionTask.ActionTaskResult actionTaskResult = actionTask.invoke();
+            ActionTask.ActionTaskResult actionTaskResult =
+                    actionTask.invoke(getRuntimeContext().getUserCodeClassLoader());
 
             // We remove the RunnerContext of the action task from the map after it is finished. The
             // RunnerContext will be added later if the action task has a generated action task,
@@ -657,8 +658,7 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
 
     private ActionTask createActionTask(Object key, Action action, Event event) {
         if (action.getExec() instanceof JavaFunction) {
-            return new JavaActionTask(
-                    key, event, action, getRuntimeContext().getUserCodeClassLoader());
+            return new JavaActionTask(key, event, action);
         } else if (action.getExec() instanceof PythonFunction) {
             return new PythonActionTask(key, event, action);
         } else {

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionTask.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionTask.java
@@ -87,7 +87,7 @@ public abstract class ActionTask {
     }
 
     /** Invokes the action task. */
-    public abstract ActionTaskResult invoke() throws Exception;
+    public abstract ActionTaskResult invoke(ClassLoader userCodeClassLoader) throws Exception;
 
     public class ActionTaskResult {
         private final boolean finished;

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/JavaActionTask.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/JavaActionTask.java
@@ -30,17 +30,13 @@ import static org.apache.flink.util.Preconditions.checkState;
  * action task will be invoked only once.
  */
 public class JavaActionTask extends ActionTask {
-
-    private final ClassLoader userCodeClassLoader;
-
-    public JavaActionTask(Object key, Event event, Action action, ClassLoader userCodeClassLoader) {
+    public JavaActionTask(Object key, Event event, Action action) {
         super(key, event, action);
         checkState(action.getExec() instanceof JavaFunction);
-        this.userCodeClassLoader = userCodeClassLoader;
     }
 
     @Override
-    public ActionTaskResult invoke() throws Exception {
+    public ActionTaskResult invoke(ClassLoader userCodeClassLoader) throws Exception {
         LOG.debug(
                 "Try execute java action {} for event {} with key {}.",
                 action.getName(),

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/operator/PythonActionTask.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/operator/PythonActionTask.java
@@ -43,7 +43,7 @@ public class PythonActionTask extends ActionTask {
                 "Python action only accept python event, but got " + event);
     }
 
-    public ActionTaskResult invoke() throws Exception {
+    public ActionTaskResult invoke(ClassLoader userCodeClassLoader) throws Exception {
         LOG.debug(
                 "Try execute python action {} for event {} with key {}.",
                 action.getName(),
@@ -64,7 +64,7 @@ public class PythonActionTask extends ActionTask {
             ActionTask tempGeneratedActionTask =
                     new PythonGeneratorActionTask(key, event, action, pythonGeneratorRef);
             tempGeneratedActionTask.setRunnerContext(runnerContext);
-            return tempGeneratedActionTask.invoke();
+            return tempGeneratedActionTask.invoke(userCodeClassLoader);
         }
         return new ActionTaskResult(
                 true, runnerContext.drainEvents(event.getSourceTimestamp()), null);

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/operator/PythonGeneratorActionTask.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/operator/PythonGeneratorActionTask.java
@@ -32,7 +32,7 @@ public class PythonGeneratorActionTask extends PythonActionTask {
     }
 
     @Override
-    public ActionTaskResult invoke() {
+    public ActionTaskResult invoke(ClassLoader userCodeClassLoader) {
         LOG.debug(
                 "Try execute python generator action {} for event {} with key {}.",
                 action.getName(),

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/RescalingTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/RescalingTest.java
@@ -89,7 +89,7 @@ import static org.junit.Assert.assertTrue;
 
 /** This test case is derived from an existing test in Flink. */
 @RunWith(Parameterized.class)
-public class RescalingITCase extends TestLogger {
+public class RescalingTest extends TestLogger {
 
     @ClassRule
     public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
@@ -104,7 +104,7 @@ public class RescalingITCase extends TestLogger {
         return Arrays.asList(new Object[][] {{"hashmap"}, {"rocksdb"}});
     }
 
-    public RescalingITCase(String backend) {
+    public RescalingTest(String backend) {
         this.backend = backend;
     }
 


### PR DESCRIPTION


<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #377 

### Purpose of change

1. Rename `RescalingITCase` to `RescalingTest` to enable run in CI.
2. Remove `userCodeClassLoader` field in `JavaActionTask` to fix can't be serialized to state.

### Tests

RescalingTest

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
