### PR TITLE
[runtime] Avoid create new runner context each time execute action.

### DIFF
--- a/python/flink_agents/runtime/flink_runner_context.py
+++ b/python/flink_agents/runtime/flink_runner_context.py
@@ -219,13 +219,23 @@ def create_flink_runner_context(
     agent_plan_json: str,
     executor: ThreadPoolExecutor,
     j_resource_adapter: Any,
-    job_identifier: str,
-    key: int,
 ) -> FlinkRunnerContext:
     """Used to create a FlinkRunnerContext Python object in Pemja environment."""
-    ctx = FlinkRunnerContext(
+    return FlinkRunnerContext(
         j_runner_context, agent_plan_json, executor, j_resource_adapter
     )
+
+
+def flink_runner_context_switch_action_context(
+    ctx: FlinkRunnerContext,
+    job_identifier: str,
+    key: int,
+) -> None:
+    """Switch the context of the flink runner context.
+
+    The ctx is reused across keyed partitions, the context related to
+    specific key should be switched when process new action.
+    """
     backend = ctx.config.get(LongTermMemoryOptions.BACKEND)
     # use external vector store based long term memory
     if backend == LongTermMemoryBackend.EXTERNAL_VECTOR_STORE:
@@ -240,19 +250,6 @@ def create_flink_runner_context(
                 key=str(key),
             )
         )
-    return ctx
-
-
-def create_long_term_memory(
-    j_runner_context: Any,
-    agent_plan_json: str,
-    executor: ThreadPoolExecutor,
-    j_resource_adapter: Any,
-) -> FlinkRunnerContext:
-    """Used to create a FlinkRunnerContext Python object in Pemja environment."""
-    return FlinkRunnerContext(
-        j_runner_context, agent_plan_json, executor, j_resource_adapter
-    )
 
 
 def create_async_thread_pool() -> ThreadPoolExecutor:

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -133,6 +133,9 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
     // PythonActionExecutor for Python actions
     private transient PythonActionExecutor pythonActionExecutor;
 
+    // RunnerContext for Python actions
+    private transient PythonRunnerContextImpl pythonRunnerContext;
+
     // PythonResourceAdapter for Python resources in Java actions
     private transient PythonResourceAdapterImpl pythonResourceAdapter;
 
@@ -143,6 +146,9 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
     private transient SegmentedQueue keySegmentQueue;
 
     private final transient MailboxExecutor mailboxExecutor;
+
+    // RunnerContext for Java Actions
+    private transient RunnerContextImpl runnerContext;
 
     // We need to check whether the current thread is the mailbox thread using the mailbox
     // processor.
@@ -174,7 +180,8 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
 
     // This in memory map keep track of the runner context for the async action task that having
     // been finished
-    private final transient Map<ActionTask, RunnerContextImpl> actionTaskRunnerContexts;
+    private final transient Map<ActionTask, RunnerContextImpl.MemoryContext>
+            actionTaskMemoryContexts;
 
     // Each job can only have one identifier and this identifier must be consistent across restarts.
     // We cannot use job id as the identifier here because user may change job id by
@@ -198,7 +205,7 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         this.eventListeners = new ArrayList<>();
         this.actionStateStore = actionStateStore;
         this.checkpointIdToSeqNums = new HashMap<>();
-        this.actionTaskRunnerContexts = new HashMap<>();
+        this.actionTaskMemoryContexts = new HashMap<>();
     }
 
     @Override
@@ -443,12 +450,14 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         } else {
             maybeInitActionState(key, sequenceNumber, actionTask.action, actionTask.event);
             ActionTask.ActionTaskResult actionTaskResult =
-                    actionTask.invoke(getRuntimeContext().getUserCodeClassLoader());
+                    actionTask.invoke(
+                            getRuntimeContext().getUserCodeClassLoader(),
+                            this.pythonActionExecutor);
 
             // We remove the RunnerContext of the action task from the map after it is finished. The
             // RunnerContext will be added later if the action task has a generated action task,
             // meaning it is not finished.
-            actionTaskRunnerContexts.remove(actionTask);
+            actionTaskMemoryContexts.remove(actionTask);
             maybePersistTaskResult(
                     key,
                     sequenceNumber,
@@ -483,7 +492,8 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
 
             // If the action task is not finished, we keep the runner context in the memory for the
             // next generated ActionTask to be invoked.
-            actionTaskRunnerContexts.put(generatedActionTask, actionTask.getRunnerContext());
+            actionTaskMemoryContexts.put(
+                    generatedActionTask, actionTask.getRunnerContext().getMemoryContext());
 
             actionTasksKState.add(generatedActionTask);
         }
@@ -552,6 +562,9 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
             pythonEnvironmentManager.open();
             EmbeddedPythonEnvironment env = pythonEnvironmentManager.createEnvironment();
             pythonInterpreter = env.getInterpreter();
+            pythonRunnerContext =
+                    new PythonRunnerContextImpl(
+                            this.metricGroup, this::checkMailboxThread, this.agentPlan);
             if (containPythonAction) {
                 initPythonActionExecutor();
             } else {
@@ -568,6 +581,7 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
                         pythonInterpreter,
                         new ObjectMapper().writeValueAsString(agentPlan),
                         javaResourceAdapter,
+                        pythonRunnerContext,
                         jobIdentifier);
         pythonActionExecutor.open();
     }
@@ -752,31 +766,28 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         }
 
         RunnerContextImpl runnerContext;
-        if (actionTaskRunnerContexts.containsKey(actionTask)) {
-            runnerContext = actionTaskRunnerContexts.get(actionTask);
-        } else if (actionTask.action.getExec() instanceof JavaFunction) {
-            runnerContext =
-                    new RunnerContextImpl(
-                            new CachedMemoryStore(sensoryMemState),
-                            new CachedMemoryStore(shortTermMemState),
-                            metricGroup,
-                            this::checkMailboxThread,
-                            agentPlan);
+        if (actionTask.action.getExec() instanceof JavaFunction) {
+            runnerContext = createOrGetRunnerContext(true);
         } else if (actionTask.action.getExec() instanceof PythonFunction) {
-            runnerContext =
-                    new PythonRunnerContextImpl(
-                            new CachedMemoryStore(sensoryMemState),
-                            new CachedMemoryStore(shortTermMemState),
-                            metricGroup,
-                            this::checkMailboxThread,
-                            agentPlan,
-                            pythonActionExecutor);
+            runnerContext = createOrGetRunnerContext(false);
         } else {
             throw new IllegalStateException(
                     "Unsupported action type: " + actionTask.action.getExec().getClass());
         }
 
-        runnerContext.setActionName(actionTask.action.getName());
+        RunnerContextImpl.MemoryContext memoryContext;
+        if (actionTaskMemoryContexts.containsKey(actionTask)) {
+            // action task for async execution action, should retrieve intermediate results from
+            // map.
+            memoryContext = actionTaskMemoryContexts.get(actionTask);
+        } else {
+            memoryContext =
+                    new RunnerContextImpl.MemoryContext(
+                            new CachedMemoryStore(sensoryMemState),
+                            new CachedMemoryStore(shortTermMemState));
+        }
+
+        runnerContext.switchActionContext(actionTask.action.getName(), memoryContext);
         actionTask.setRunnerContext(runnerContext);
     }
 
@@ -880,6 +891,24 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         while (mark != null) {
             super.processWatermark(mark);
             mark = keySegmentQueue.popOldestWatermark();
+        }
+    }
+
+    private RunnerContextImpl createOrGetRunnerContext(Boolean isJava) {
+        if (isJava) {
+            if (runnerContext == null) {
+                runnerContext =
+                        new RunnerContextImpl(
+                                this.metricGroup, this::checkMailboxThread, this.agentPlan);
+            }
+            return runnerContext;
+        } else {
+            if (pythonRunnerContext == null) {
+                pythonRunnerContext =
+                        new PythonRunnerContextImpl(
+                                this.metricGroup, this::checkMailboxThread, this.agentPlan);
+            }
+            return pythonRunnerContext;
         }
     }
 

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionTask.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionTask.java
@@ -20,6 +20,7 @@ package org.apache.flink.agents.runtime.operator;
 import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.plan.actions.Action;
 import org.apache.flink.agents.runtime.context.RunnerContextImpl;
+import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,7 +88,8 @@ public abstract class ActionTask {
     }
 
     /** Invokes the action task. */
-    public abstract ActionTaskResult invoke(ClassLoader userCodeClassLoader) throws Exception;
+    public abstract ActionTaskResult invoke(
+            ClassLoader userCodeClassLoader, PythonActionExecutor executor) throws Exception;
 
     public class ActionTaskResult {
         private final boolean finished;

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/JavaActionTask.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/JavaActionTask.java
@@ -20,6 +20,7 @@ package org.apache.flink.agents.runtime.operator;
 import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.plan.JavaFunction;
 import org.apache.flink.agents.plan.actions.Action;
+import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -36,7 +37,8 @@ public class JavaActionTask extends ActionTask {
     }
 
     @Override
-    public ActionTaskResult invoke(ClassLoader userCodeClassLoader) throws Exception {
+    public ActionTaskResult invoke(ClassLoader userCodeClassLoader, PythonActionExecutor executor)
+            throws Exception {
         LOG.debug(
                 "Try execute java action {} for event {} with key {}.",
                 action.getName(),

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/context/PythonRunnerContextImpl.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/context/PythonRunnerContextImpl.java
@@ -21,10 +21,8 @@ import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.api.context.RunnerContext;
 import org.apache.flink.agents.plan.AgentPlan;
 import org.apache.flink.agents.runtime.context.RunnerContextImpl;
-import org.apache.flink.agents.runtime.memory.CachedMemoryStore;
 import org.apache.flink.agents.runtime.metrics.FlinkAgentsMetricGroupImpl;
 import org.apache.flink.agents.runtime.python.event.PythonEvent;
-import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -32,23 +30,11 @@ import javax.annotation.concurrent.NotThreadSafe;
 /** A specialized {@link RunnerContext} that is specifically used when executing Python actions. */
 @NotThreadSafe
 public class PythonRunnerContextImpl extends RunnerContextImpl {
-
-    private final PythonActionExecutor pythonActionExecutor;
-
     public PythonRunnerContextImpl(
-            CachedMemoryStore sensoryMemStore,
-            CachedMemoryStore shortTermMemStore,
             FlinkAgentsMetricGroupImpl agentMetricGroup,
             Runnable mailboxThreadChecker,
-            AgentPlan agentPlan,
-            PythonActionExecutor pythonActionExecutor) {
-        super(
-                sensoryMemStore,
-                shortTermMemStore,
-                agentMetricGroup,
-                mailboxThreadChecker,
-                agentPlan);
-        this.pythonActionExecutor = pythonActionExecutor;
+            AgentPlan agentPlan) {
+        super(agentMetricGroup, mailboxThreadChecker, agentPlan);
     }
 
     @Override
@@ -61,9 +47,5 @@ public class PythonRunnerContextImpl extends RunnerContextImpl {
     public void sendEvent(String type, byte[] event, String eventString) {
         // this method will be invoked by PythonActionExecutor's python interpreter.
         sendEvent(new PythonEvent(event, type, eventString));
-    }
-
-    public PythonActionExecutor getPythonActionExecutor() {
-        return pythonActionExecutor;
     }
 }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/operator/PythonGeneratorActionTask.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/operator/PythonGeneratorActionTask.java
@@ -20,6 +20,7 @@ package org.apache.flink.agents.runtime.python.operator;
 import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.plan.actions.Action;
 import org.apache.flink.agents.runtime.operator.ActionTask;
+import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
 
 /** An {@link ActionTask} wrapper a Python Generator to represent a code block in Python action. */
 public class PythonGeneratorActionTask extends PythonActionTask {
@@ -32,13 +33,13 @@ public class PythonGeneratorActionTask extends PythonActionTask {
     }
 
     @Override
-    public ActionTaskResult invoke(ClassLoader userCodeClassLoader) {
+    public ActionTaskResult invoke(ClassLoader userCodeClassLoader, PythonActionExecutor executor) {
         LOG.debug(
                 "Try execute python generator action {} for event {} with key {}.",
                 action.getName(),
                 event,
                 key);
-        boolean finished = getPythonActionExecutor().callPythonGenerator(pythonGeneratorRef);
+        boolean finished = executor.callPythonGenerator(pythonGeneratorRef);
         ActionTask generatedActionTask = finished ? null : this;
         return new ActionTaskResult(
                 finished,


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #344

### Purpose of change

Currently, we create a new `RunnerContext` each time execute a new action, which cause the repeated creation for `AgentPlan`.
In this pr, we support create a `RunnerContext` once, and reuse it across actions, only switch the action related context in `RunnerContext` before execute a new action.

### Tests

Existed tests can verify this change.

### API

No

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
