### PR TITLE
[test] Use qwen3:8b in integration test to improve stability.

### DIFF
--- a/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/ChatModelIntegrationAgent.java
+++ b/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/ChatModelIntegrationAgent.java
@@ -67,7 +67,7 @@ import java.util.List;
  * the model is allowed to call.
  */
 public class ChatModelIntegrationAgent extends Agent {
-    public static final String OLLAMA_MODEL = "qwen3:0.6b";
+    public static final String OLLAMA_MODEL = "qwen3:8b";
 
     @ChatModelConnection
     public static ResourceDescriptor chatModelConnection() {

--- a/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/ReActAgentTest.java
+++ b/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/ReActAgentTest.java
@@ -53,7 +53,7 @@ import java.util.List;
 import static org.apache.flink.agents.integration.test.OllamaPreparationUtils.pullModel;
 
 public class ReActAgentTest {
-    public static final String OLLAMA_MODEL = "qwen3:1.7b";
+    public static final String OLLAMA_MODEL = "qwen3:8b";
 
     @org.apache.flink.agents.api.annotation.Tool(
             description = "Useful function to add two numbers.")

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/chat_model_integration_agent.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/chat_model_integration_agent.py
@@ -84,7 +84,7 @@ class ChatModelTestAgent(Agent):
             return ResourceDescriptor(
                 clazz=OllamaChatModelSetup,
                 connection="ollama_connection",
-                model=os.environ.get("OLLAMA_CHAT_MODEL", "qwen3:1.7b"),
+                model=os.environ.get("OLLAMA_CHAT_MODEL", "qwen3:8b"),
                 tools=["add"],
                 extract_reasoning=True,
             )
@@ -114,7 +114,7 @@ class ChatModelTestAgent(Agent):
             return ResourceDescriptor(
                 clazz=TongyiChatModelSetup,
                 connection="ollama_connection",
-                model=os.environ.get("OLLAMA_CHAT_MODEL", "qwen3:1.7b"),
+                model=os.environ.get("OLLAMA_CHAT_MODEL", "qwen3:8b"),
                 extract_reasoning=True,
             )
         elif model_provider == "OpenAI":

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/chat_model_integration_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/chat_model_integration_test.py
@@ -30,7 +30,7 @@ current_dir = Path(__file__).parent
 
 TONGYI_MODEL = os.environ.get("TONGYI_CHAT_MODEL", "qwen-plus")
 os.environ["TONGYI_CHAT_MODEL"] = TONGYI_MODEL
-OLLAMA_MODEL = os.environ.get("OLLAMA_CHAT_MODEL", "qwen3:1.7b")
+OLLAMA_MODEL = os.environ.get("OLLAMA_CHAT_MODEL", "qwen3:8b")
 os.environ["OLLAMA_CHAT_MODEL"] = OLLAMA_MODEL
 OPENAI_MODEL = os.environ.get("OPENAI_CHAT_MODEL", "gpt-3.5-turbo")
 os.environ["OPENAI_CHAT_MODEL"] = OPENAI_MODEL

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/e2e_tests_mcp/mcp_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/e2e_tests_mcp/mcp_test.py
@@ -55,7 +55,7 @@ from flink_agents.integrations.chat_models.ollama_chat_model import (
     OllamaChatModelSetup,
 )
 
-OLLAMA_MODEL = os.environ.get("MCP_OLLAMA_CHAT_MODEL", "qwen3:1.7b")
+OLLAMA_MODEL = os.environ.get("MCP_OLLAMA_CHAT_MODEL", "qwen3:8b")
 MCP_SERVER_ENDPOINT = "http://127.0.0.1:8000/mcp"
 
 

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/react_agent_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/react_agent_test.py
@@ -48,7 +48,7 @@ current_dir = Path(__file__).parent
 
 os.environ["PYTHONPATH"] = sysconfig.get_paths()["purelib"]
 
-OLLAMA_MODEL = os.environ.get("REACT_OLLAMA_MODEL", "qwen3:1.7b")
+OLLAMA_MODEL = os.environ.get("REACT_OLLAMA_MODEL", "qwen3:8b")
 os.environ["OLLAMA_CHAT_MODEL"] = OLLAMA_MODEL
 
 


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->

### Purpose of change

Currently, we use qwen3:0.6b and qwen3:1.7b in chat model integration tests and react agent tests, which may lead some test failure caused by llm can't recognize the user's intent accurately. 
The power of qwen3:8b is better than 0.6b and 1.7b, so we use it to improve test stability. The side effect is the ci duration will increase from 8min to ~14min.

### Tests

<!-- How is this change verified? -->

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
