### PR TITLE
[infra] Add doc-including label to indicate docs are included in the PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,3 +24,4 @@ Linked issue: #xxx
 
 - [ ] `doc-needed` <!-- Your PR changes impact docs -->
 - [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
+- [ ] `doc-including` <!-- Your PR already contains the necessary documentation updates -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,4 +24,4 @@ Linked issue: #xxx
 
 - [ ] `doc-needed` <!-- Your PR changes impact docs -->
 - [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
-- [ ] `doc-including` <!-- Your PR already contains the necessary documentation updates -->
+- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->

--- a/.github/workflows/document_bot.yml
+++ b/.github/workflows/document_bot.yml
@@ -40,5 +40,5 @@ jobs:
         uses: apache/pulsar-test-infra/docbot@8ff059e49446fff5bb9baf2de4a12bc05c2d57ab
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LABEL_WATCH_LIST: 'doc-needed,doc-not-needed'
+          LABEL_WATCH_LIST: 'doc-needed,doc-not-needed,doc-including'
           LABEL_MISSING: 'doc-label-missing'

--- a/.github/workflows/document_bot.yml
+++ b/.github/workflows/document_bot.yml
@@ -40,5 +40,5 @@ jobs:
         uses: apache/pulsar-test-infra/docbot@8ff059e49446fff5bb9baf2de4a12bc05c2d57ab
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LABEL_WATCH_LIST: 'doc-needed,doc-not-needed,doc-including'
+          LABEL_WATCH_LIST: 'doc-needed,doc-not-needed,doc-included'
           LABEL_MISSING: 'doc-label-missing'


### PR DESCRIPTION
### Purpose of change
Add doc-including label to indicate docs are included in the PR.

> **Before merging the commits, the committer should add `doc-including` label for the repository.**

<!-- What is the purpose of this change? -->

### Tests
I tested these changes in my repository: https://github.com/GreatEugenius/flink-agents/pull/25
<!-- How is this change verified? -->

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
