### PR TITLE
[Feature] Improve Python Async Execution API

### DIFF
--- a/python/flink_agents/e2e_tests/e2e_tests_integration/flink_integration_agent.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/flink_integration_agent.py
@@ -89,7 +89,7 @@ class DataStreamAgent(Agent):
 
     @action(InputEvent)
     @staticmethod
-    def first_action(event: Event, ctx: RunnerContext):  # noqa D102
+    async def first_action(event: Event, ctx: RunnerContext):  # noqa D102
         def log_to_stdout(input: Any, total: int) -> bool:
             # Simulating asynchronous time consumption
             time.sleep(random.random())
@@ -103,7 +103,7 @@ class DataStreamAgent(Agent):
         total = current_total + 1
         stm.set("status.total_reviews", total)
 
-        log_success = yield from ctx.execute_async(log_to_stdout, input_data, total)
+        log_success = await ctx.execute_async(log_to_stdout, input_data, total)
 
         content = copy.deepcopy(input_data)
         content.review += " first action, log success=" + str(log_success) + ","

--- a/python/flink_agents/e2e_tests/long_term_memory_test.py
+++ b/python/flink_agents/e2e_tests/long_term_memory_test.py
@@ -170,7 +170,7 @@ class LongTermMemoryAgent(Agent):
 
     @action(InputEvent)
     @staticmethod
-    def add_items(event: Event, ctx: RunnerContext):  # noqa D102
+    async def add_items(event: Event, ctx: RunnerContext):  # noqa D102
         input_data = event.input
         ltm = ctx.long_term_memory
 
@@ -181,7 +181,7 @@ class LongTermMemoryAgent(Agent):
             capacity=5,
             compaction_strategy=SummarizationStrategy(model="ollama_qwen3"),
         )
-        yield from ctx.execute_async(memory_set.add, items=input_data.review)
+        await ctx.execute_async(memory_set.add, items=input_data.review)
         timestamp_after_add = datetime.now(timezone.utc).isoformat()
 
         stm = ctx.short_term_memory
@@ -201,11 +201,11 @@ class LongTermMemoryAgent(Agent):
 
     @action(MyEvent)
     @staticmethod
-    def retrieve_items(event: Event, ctx: RunnerContext):  # noqa D102
+    async def retrieve_items(event: Event, ctx: RunnerContext):  # noqa D102
         record: Record = event.value
         record.timestamp_second_action = datetime.now(timezone.utc).isoformat()
         memory_set = ctx.long_term_memory.get_memory_set(name="test_ltm")
-        items = yield from ctx.execute_async(memory_set.get)
+        items = await ctx.execute_async(memory_set.get)
         if (
             (record.id == 1 and record.count == 3)
             or (record.id == 2 and record.count == 5)

--- a/python/flink_agents/plan/tests/test_function.py
+++ b/python/flink_agents/plan/tests/test_function.py
@@ -26,7 +26,6 @@ import pytest
 from flink_agents.api.events.event import Event, InputEvent, OutputEvent
 from flink_agents.plan.function import (
     PythonFunction,
-    PythonGeneratorWrapper,
     _is_function_cacheable,
     call_python_function,
     clear_python_function_cache,
@@ -315,9 +314,10 @@ def test_selective_caching_generator_functions() -> None:
     result = call_python_function(
         "flink_agents.plan.tests.test_function", "generator_function", (3,)
     )
-    assert isinstance(result, PythonGeneratorWrapper)
+    # Result is now a generator directly (no wrapper)
+    assert isinstance(result, Generator)
     # Convert generator to list for testing
-    result_list = list(result.generator)
+    result_list = list(result)
     assert result_list == [0, 1, 2]
 
     # Should not be cached

--- a/python/flink_agents/runtime/flink_runner_context.py
+++ b/python/flink_agents/runtime/flink_runner_context.py
@@ -31,7 +31,7 @@ from flink_agents.api.memory.long_term_memory import (
 )
 from flink_agents.api.memory_object import MemoryType
 from flink_agents.api.resource import Resource, ResourceType
-from flink_agents.api.runner_context import RunnerContext
+from flink_agents.api.runner_context import AsyncExecutionResult, RunnerContext
 from flink_agents.plan.agent_plan import AgentPlan
 from flink_agents.runtime.flink_memory_object import FlinkMemoryObject
 from flink_agents.runtime.flink_metric_group import FlinkMetricGroup
@@ -191,18 +191,11 @@ class FlinkRunnerContext(RunnerContext):
         func: Callable[[Any], Any],
         *args: Any,
         **kwargs: Any,
-    ) -> Any:
+    ) -> AsyncExecutionResult:
         """Asynchronously execute the provided function. Access to memory
         is prohibited within the function.
         """
-        future = self.executor.submit(func, *args, **kwargs)
-        while not future.done():
-            # TODO: Currently, we are using a polling mechanism to check whether
-            #  the future has completed. This approach should be optimized in the
-            #  future by switching to a notification-based model, where the Flink
-            #  operator is notified directly once the future is completed.
-            yield
-        return future.result()
+        return AsyncExecutionResult(self.executor, func, args, kwargs)
 
     @property
     @override

--- a/python/flink_agents/runtime/tests/test_local_execution_environment.py
+++ b/python/flink_agents/runtime/tests/test_local_execution_environment.py
@@ -38,13 +38,13 @@ class Agent1(Agent):  # noqa: D101
 class Agent1WithAsync(Agent):  # noqa: D101
     @action(InputEvent)
     @staticmethod
-    def increment(event: Event, ctx: RunnerContext):  # noqa D102
+    async def increment(event: Event, ctx: RunnerContext):  # noqa D102
         def my_func(value: int) -> int:
             time.sleep(1)
             return value + 1
 
         input = event.input
-        value = yield from ctx.execute_async(my_func, input)
+        value = await ctx.execute_async(my_func, input)
         ctx.send_event(OutputEvent(output=value))
 
 

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/operator/PythonActionTask.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/operator/PythonActionTask.java
@@ -51,17 +51,17 @@ public class PythonActionTask extends ActionTask {
                 key);
         runnerContext.checkNoPendingEvents();
 
-        String pythonGeneratorRef =
+        String pythonAwaitableRef =
                 executor.executePythonFunction(
                         (PythonFunction) action.getExec(), (PythonEvent) event, key.hashCode());
         // If a user-defined action uses an interface to submit asynchronous tasks, it will return a
-        // Python generator object instance upon its first execution. Otherwise, it means that no
-        // asynchronous tasks were submitted and the action has already completed.
-        if (pythonGeneratorRef != null) {
-            // The Python action generates a generator. We need to execute it once, which will
+        // Python coroutine (awaitable) object instance upon its first execution. Otherwise, it
+        // means that no asynchronous tasks were submitted and the action has already completed.
+        if (pythonAwaitableRef != null) {
+            // The Python action generates an awaitable. We need to execute it once, which will
             // submit an asynchronous task and return whether the action has been completed.
             ActionTask tempGeneratedActionTask =
-                    new PythonGeneratorActionTask(key, event, action, pythonGeneratorRef);
+                    new PythonGeneratorActionTask(key, event, action, pythonAwaitableRef);
             tempGeneratedActionTask.setRunnerContext(runnerContext);
             return tempGeneratedActionTask.invoke(userCodeClassLoader, executor);
         }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/operator/PythonGeneratorActionTask.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/operator/PythonGeneratorActionTask.java
@@ -22,24 +22,24 @@ import org.apache.flink.agents.plan.actions.Action;
 import org.apache.flink.agents.runtime.operator.ActionTask;
 import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
 
-/** An {@link ActionTask} wrapper a Python Generator to represent a code block in Python action. */
+/** An {@link ActionTask} wrapper a Python awaitable to represent a code block in Python action. */
 public class PythonGeneratorActionTask extends PythonActionTask {
-    private final String pythonGeneratorRef;
+    private final String pythonAwaitableRef;
 
     public PythonGeneratorActionTask(
-            Object key, Event event, Action action, String pythonGeneratorRef) {
+            Object key, Event event, Action action, String pythonAwaitableRef) {
         super(key, event, action);
-        this.pythonGeneratorRef = pythonGeneratorRef;
+        this.pythonAwaitableRef = pythonAwaitableRef;
     }
 
     @Override
     public ActionTaskResult invoke(ClassLoader userCodeClassLoader, PythonActionExecutor executor) {
         LOG.debug(
-                "Try execute python generator action {} for event {} with key {}.",
+                "Try execute python awaitable action {} for event {} with key {}.",
                 action.getName(),
                 event,
                 key);
-        boolean finished = executor.callPythonGenerator(pythonGeneratorRef);
+        boolean finished = executor.callPythonAwaitable(pythonAwaitableRef);
         ActionTask generatedActionTask = finished ? null : this;
         return new ActionTaskResult(
                 finished,


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #408

### Purpose of change

This PR improves the Python Async Execution API by replacing the `yield from` pattern with the standard Python `async`/`await` syntax.

### Tests

- Updated existing unit tests in `test_function.py` and `test_local_execution_environment.py`
- Updated e2e tests (`flink_integration_agent.py`, `long_term_memory_test.py`) to use the new async/await syntax

### API

Yes, this PR changes the public API:

**Before:**
```python
@action(InputEvent)
@staticmethod
def my_action(event: Event, ctx: RunnerContext):
    result = yield from ctx.execute_async(slow_function, arg1, arg2)
    ctx.send_event(OutputEvent(output=result))
```

**After:**
```python
@action(InputEvent)
@staticmethod
async def my_action(event: Event, ctx: RunnerContext):
    result = await ctx.execute_async(slow_function, arg1, arg2)
    ctx.send_event(OutputEvent(output=result))
```

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [x] `doc-needed` <!-- Your PR changes impact docs -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->