### PR TITLE
[Feature][runtime] Support the use of Java EembeddingModel in Python

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -64,6 +64,11 @@ under the License.
             <artifactId>flink-agents-integrations-chat-models-ollama</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-agents-integrations-embedding-models-ollama</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/e2e-test/flink-agents-end-to-end-tests-resource-cross-language/pom.xml
+++ b/e2e-test/flink-agents-end-to-end-tests-resource-cross-language/pom.xml
@@ -27,6 +27,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
+            <artifactId>flink-agents-integrations-chat-models-ollama</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
             <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
         </dependency>

--- a/plan/src/test/java/org/apache/flink/agents/plan/AgentPlanTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/AgentPlanTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.agents.api.agents.Agent;
 import org.apache.flink.agents.api.annotation.ChatModelSetup;
 import org.apache.flink.agents.api.annotation.Tool;
 import org.apache.flink.agents.api.chat.messages.ChatMessage;
+import org.apache.flink.agents.api.chat.model.python.PythonChatModelSetup;
 import org.apache.flink.agents.api.context.RunnerContext;
 import org.apache.flink.agents.api.resource.Resource;
 import org.apache.flink.agents.api.resource.ResourceDescriptor;
@@ -440,7 +441,7 @@ public class AgentPlanTest {
         Resource pythonChatModel =
                 agentPlan.getResource("pythonChatModel", ResourceType.CHAT_MODEL);
         assertThat(pythonChatModel).isNotNull();
-        assertThat(pythonChatModel).isInstanceOf(TestPythonResource.class);
+        assertThat(pythonChatModel).isInstanceOf(PythonChatModelSetup.class);
         assertThat(pythonChatModel.getResourceType()).isEqualTo(ResourceType.CHAT_MODEL);
 
         // Test that resources are cached (should be the same instance)

--- a/python/flink_agents/api/embedding_models/embedding_model.py
+++ b/python/flink_agents/api/embedding_models/embedding_model.py
@@ -85,7 +85,7 @@ class BaseEmbeddingModelSetup(Resource, ABC):
     def model_kwargs(self) -> Dict[str, Any]:
         """Return embedding model settings."""
 
-    def embed(self, text: str, **kwargs: Any) -> list[float]:
+    def embed(self, text: str | Sequence[str], **kwargs: Any) -> list[float] | list[list[float]]:
         """Generate embedding vector for a single text query.
 
         Converts the input text into a high-dimensional vector representation

--- a/python/flink_agents/api/embedding_models/java_embedding_model.py
+++ b/python/flink_agents/api/embedding_models/java_embedding_model.py
@@ -1,0 +1,47 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+from flink_agents.api.decorators import java_resource
+from flink_agents.api.embedding_models.embedding_model import (
+    BaseEmbeddingModelConnection,
+    BaseEmbeddingModelSetup,
+)
+
+
+@java_resource
+class JavaEmbeddingModelConnection(BaseEmbeddingModelConnection):
+    """Java-based implementation of EmbeddingModelConnection that wraps a Java embedding
+    model object.
+
+    This class serves as a bridge between Python and Java embedding model environments,
+    but unlike JavaEmbeddingModelSetup, it does not provide direct embedding
+    functionality in Python.
+    """
+
+    java_class_name: str=""
+
+@java_resource
+class JavaEmbeddingModelSetup(BaseEmbeddingModelSetup):
+    """Java-based implementation of EmbeddingModelSetup that bridges Python and Java
+    embedding model functionality.
+
+    This class wraps a Java embedding model setup object and provides Python interface
+    compatibility while delegating actual embedding operations to the underlying Java
+    implementation.
+    """
+
+    java_class_name: str=""

--- a/python/flink_agents/api/events/chat_event.py
+++ b/python/flink_agents/api/events/chat_event.py
@@ -18,7 +18,7 @@
 from typing import List
 from uuid import UUID
 
-from flink_agents.api.agents.react_agent import OutputSchema
+from flink_agents.api.agents.types import OutputSchema
 from flink_agents.api.chat_message import ChatMessage
 from flink_agents.api.events.event import Event
 

--- a/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/chat_model_cross_language_agent.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/chat_model_cross_language_agent.py
@@ -35,6 +35,9 @@ from flink_agents.api.events.event import InputEvent, OutputEvent
 from flink_agents.api.prompts.prompt import Prompt
 from flink_agents.api.resource import ResourceDescriptor
 from flink_agents.api.runner_context import RunnerContext
+from flink_agents.integrations.chat_models.ollama_chat_model import (
+    OllamaChatModelConnection,
+)
 
 
 class ChatModelCrossLanguageAgent(Agent):
@@ -67,7 +70,15 @@ class ChatModelCrossLanguageAgent(Agent):
 
     @chat_model_connection
     @staticmethod
-    def ollama_connection() -> ResourceDescriptor:
+    def ollama_connection_python() -> ResourceDescriptor:
+        """ChatModelConnection responsible for ollama model service connection."""
+        return ResourceDescriptor(
+            clazz=OllamaChatModelConnection, request_timeout=240.0
+        )
+
+    @chat_model_connection
+    @staticmethod
+    def ollama_connection_java() -> ResourceDescriptor:
         """ChatModelConnection responsible for ollama model service connection."""
         return ResourceDescriptor(
             clazz=JavaChatModelConnection,
@@ -82,7 +93,7 @@ class ChatModelCrossLanguageAgent(Agent):
         """ChatModel which focus on math, and reuse ChatModelConnection."""
         return ResourceDescriptor(
             clazz=JavaChatModelSetup,
-            connection="ollama_connection",
+            connection="ollama_connection_python",
             java_clazz="org.apache.flink.agents.integrations.chatmodels.ollama.OllamaChatModelSetup",
             model=os.environ.get("OLLAMA_CHAT_MODEL", "qwen3:1.7b"),
             prompt="from_messages_prompt",
@@ -96,7 +107,7 @@ class ChatModelCrossLanguageAgent(Agent):
         """ChatModel which focus on text generate, and reuse ChatModelConnection."""
         return ResourceDescriptor(
             clazz=JavaChatModelSetup,
-            connection="ollama_connection",
+            connection="ollama_connection_java",
             java_clazz="org.apache.flink.agents.integrations.chatmodels.ollama.OllamaChatModelSetup",
             model=os.environ.get("OLLAMA_CHAT_MODEL", "qwen3:1.7b"),
             prompt="from_text_prompt",

--- a/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/embedding_model_cross_language_agent.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/embedding_model_cross_language_agent.py
@@ -1,0 +1,123 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+import os
+
+from flink_agents.api.agents.agent import Agent
+from flink_agents.api.decorators import (
+    action,
+    embedding_model_connection,
+    embedding_model_setup,
+)
+from flink_agents.api.embedding_models.java_embedding_model import (
+    JavaEmbeddingModelConnection,
+    JavaEmbeddingModelSetup,
+)
+from flink_agents.api.events.event import InputEvent, OutputEvent
+from flink_agents.api.resource import ResourceDescriptor, ResourceType
+from flink_agents.api.runner_context import RunnerContext
+
+
+class EmbeddingModelCrossLanguageAgent(Agent):
+    """Example agent demonstrating cross-language embedding model testing."""
+
+    @embedding_model_connection
+    @staticmethod
+    def embedding_model_connection() -> ResourceDescriptor:
+        """EmbeddingModelConnection responsible for ollama model service connection."""
+        return ResourceDescriptor(
+            clazz=JavaEmbeddingModelConnection,
+            java_clazz="org.apache.flink.agents.integrations.embeddingmodels.ollama.OllamaEmbeddingModelConnection",
+            host="http://localhost:11434",
+        )
+
+    @embedding_model_setup
+    @staticmethod
+    def embedding_model() -> ResourceDescriptor:
+        """EmbeddingModel which focus on math, and reuse ChatModelConnection."""
+        return ResourceDescriptor(
+            clazz=JavaEmbeddingModelSetup,
+            java_clazz="org.apache.flink.agents.integrations.embeddingmodels.ollama.OllamaEmbeddingModelSetup",
+            connection="embedding_model_connection",
+            model=os.environ.get("OLLAMA_EMBEDDING_MODEL", "nomic-embed-text:latest"),
+        )
+
+    @action(InputEvent)
+    @staticmethod
+    def process_input(event: InputEvent, ctx: RunnerContext) -> None:
+        """User defined action for processing input.
+
+        In this action, we will test embedding model functionality.
+        """
+        input_text = event.input
+
+        short_doc = f"{input_text[:5]}..."
+
+        print(f"[TEST] Starting embedding generation test for: '{input_text[:10]}...'")
+
+        try:
+            # Get embedding model
+            embeddingModel = ctx.get_resource("embedding_model", ResourceType.EMBEDDING_MODEL)
+
+            # Test single text embedding
+            embedding = embeddingModel.embed(input_text)
+            print(f"[TEST] Generated embedding with dimension: {len(embedding)}")
+
+            # Validate single embedding result
+            if embedding is None or not isinstance(embedding, list) or len(embedding) == 0:
+                err_msg = "Embedding cannot be null or empty"
+                raise AssertionError(err_msg) # noqa: TRY301
+
+            if not all(isinstance(x, float) for x in embedding):
+                err_msg = "All embedding values must be floats"
+                raise AssertionError(err_msg) # noqa: TRY301
+
+            print(f"[TEST] Validated single embedding: Text={short_doc}, Dimension={len(embedding)}, Text='{input_text[:30]}...'")
+
+            # Test batch embedding
+            embeddings = embeddingModel.embed([input_text])
+            print(f"[TEST] Generated batch embeddings: count={len(embeddings)}")
+
+            # Validate batch embedding results
+            if embeddings is None or not isinstance(embeddings, list) or len(embeddings) == 0:
+                err_msg = "Batch embeddings cannot be null or empty"
+                raise AssertionError(err_msg) # noqa: TRY301
+
+            if len(embeddings) != 1:
+                err_msg = f"Expected 1 embedding but got {len(embeddings)}"
+                raise AssertionError(err_msg) # noqa: TRY301
+
+            for i, emb in enumerate(embeddings):
+                if not isinstance(emb, list) or len(emb) == 0:
+                    err_msg = f"Embedding at index {i} is invalid"
+                    raise AssertionError(err_msg) # noqa: TRY301
+                print(f"[TEST] Validated batch embedding {i}: Dimension={len(emb)}")
+
+            # Create test result as a single string
+            test_result = f"[PASS] Text={short_doc}, Dimension={len(embedding)}, BatchCount={len(embeddings)}"
+
+            ctx.send_event(OutputEvent(output=test_result))
+
+            print(f"[TEST] Embedding generation test PASSED for: '{input_text[:50]}...'")
+
+        except Exception as e:
+            # Create error result as a single string
+            test_result = f"[FAIL] Text={short_doc}, Error={e!s}"
+
+            ctx.send_event(OutputEvent(output=test_result))
+
+            print(f"[TEST] Embedding generation test FAILED: {e!s}")

--- a/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/embedding_model_cross_language_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/embedding_model_cross_language_test.py
@@ -1,0 +1,103 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+import os
+import sysconfig
+from pathlib import Path
+
+import pytest
+from pyflink.common import Encoder, WatermarkStrategy
+from pyflink.common.typeinfo import Types
+from pyflink.datastream import (
+    RuntimeExecutionMode,
+    StreamExecutionEnvironment,
+)
+from pyflink.datastream.connectors.file_system import (
+    FileSource,
+    StreamFormat,
+    StreamingFileSink,
+)
+
+from flink_agents.api.execution_environment import AgentsExecutionEnvironment
+from flink_agents.e2e_tests.e2e_tests_resource_cross_language.embedding_model_cross_language_agent import (
+    EmbeddingModelCrossLanguageAgent,
+)
+from flink_agents.e2e_tests.test_utils import pull_model
+
+current_dir = Path(__file__).parent
+
+OLLAMA_MODEL = os.environ.get("OLLAMA_EMBEDDING_MODEL", "nomic-embed-text:latest")
+os.environ["OLLAMA_EMBEDDING_MODEL"] = OLLAMA_MODEL
+
+client = pull_model(OLLAMA_MODEL)
+
+os.environ["PYTHONPATH"] = sysconfig.get_paths()["purelib"]
+
+@pytest.mark.skipif(client is None, reason="Ollama client is not available or test model is missing.")
+def test_java_embedding_model_integration(tmp_path: Path) -> None:  # noqa: D103
+    env = StreamExecutionEnvironment.get_execution_environment()
+    env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
+    env.set_parallelism(1)
+
+    # currently, bounded source is not supported due to runtime implementation, so
+    # we use continuous file source here.
+    input_datastream = env.from_source(
+        source=FileSource.for_record_stream_format(
+            StreamFormat.text_line_format(), f"file:///{current_dir}/../resources/java_chat_module_input"
+        ).build(),
+        watermark_strategy=WatermarkStrategy.no_watermarks(),
+        source_name="streaming_agent_example",
+    )
+
+    deserialize_datastream = input_datastream.map(
+        lambda x: str(x)
+    )
+
+    agents_env = AgentsExecutionEnvironment.get_execution_environment(env=env)
+    output_datastream = (
+        agents_env.from_datastream(
+            input=deserialize_datastream, key_selector= lambda x: "orderKey"
+        )
+        .apply(EmbeddingModelCrossLanguageAgent())
+        .to_datastream()
+    )
+
+    result_dir = tmp_path / "results"
+    result_dir.mkdir(parents=True, exist_ok=True)
+
+    (output_datastream.map(lambda x: str(x).replace('\n', '')
+                          .replace('\r', ''), Types.STRING()).add_sink(
+        StreamingFileSink.for_row_format(
+            base_path=str(result_dir.absolute()),
+            encoder=Encoder.simple_string_encoder(),
+        ).build()
+    ))
+
+    agents_env.execute()
+
+    actual_result = []
+    for file in result_dir.iterdir():
+        if file.is_dir():
+            for child in file.iterdir():
+                with child.open() as f:
+                    actual_result.extend(f.readlines())
+        if file.is_file():
+            with file.open() as f:
+                actual_result.extend(f.readlines())
+
+    assert "PASS" in actual_result[0]
+    assert "PASS" in actual_result[1]

--- a/python/flink_agents/plan/resource_provider.py
+++ b/python/flink_agents/plan/resource_provider.py
@@ -157,6 +157,8 @@ class PythonSerializableResourceProvider(SerializableResourceProvider):
 JAVA_RESOURCE_MAPPING: dict[ResourceType, str] = {
     ResourceType.CHAT_MODEL: "flink_agents.runtime.java.java_chat_model.JavaChatModelSetupImpl",
     ResourceType.CHAT_MODEL_CONNECTION: "flink_agents.runtime.java.java_chat_model.JavaChatModelConnectionImpl",
+    ResourceType.EMBEDDING_MODEL: "flink_agents.runtime.java.java_embedding_model.JavaEmbeddingModelSetupImpl",
+    ResourceType.EMBEDDING_MODEL_CONNECTION: "flink_agents.runtime.java.java_embedding_model.JavaEmbeddingModelConnectionImpl",
 }
 
 class JavaResourceProvider(ResourceProvider):

--- a/python/flink_agents/runtime/java/java_embedding_model.py
+++ b/python/flink_agents/runtime/java/java_embedding_model.py
@@ -1,0 +1,107 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+from typing import Any, Dict, Sequence
+
+from flink_agents.api.embedding_models.java_embedding_model import (
+    JavaEmbeddingModelConnection,
+    JavaEmbeddingModelSetup,
+)
+
+
+class JavaEmbeddingModelConnectionImpl(JavaEmbeddingModelConnection):
+    """Java-based implementation of EmbeddingModelConnection that wraps a Java embedding
+    model object.
+    This class serves as a bridge between Python and Java embedding model environments,
+    but unlike JavaEmbeddingModelSetup, it does not provide direct embedding
+    functionality in Python.
+    """
+
+    _j_resource: Any
+    _j_resource_adapter: Any
+
+    def __init__(self, j_resource: Any, j_resource_adapter: Any, **kwargs: Any) -> None:
+        """Creates a new JavaEmbeddingModelConnection.
+
+        Args:
+            j_resource: The Java resource object
+            j_resource_adapter: The Java resource adapter for method invocation
+            **kwargs: Additional keyword arguments
+        """
+        super().__init__(**kwargs)
+        self._j_resource=j_resource
+        self._j_resource_adapter=j_resource_adapter
+
+    def embed(self, text: str | Sequence[str], **kwargs: Any) -> list[float] | list[list[float]]:
+        """Generate embedding vector for a single text input.
+        Converts the input text into a high-dimensional vector representation
+        suitable for semantic similarity search and retrieval operations.
+
+        Args:
+            text: The text string to convert into an embedding vector.
+            **kwargs: Additional parameters passed to the embedding model.
+        """
+        result = self._j_resource.embed(
+            text if isinstance(text, str) else list(text), kwargs
+        )
+        return list(result) if isinstance(text, str) else [list(emb) for emb in result]
+
+
+class JavaEmbeddingModelSetupImpl(JavaEmbeddingModelSetup):
+    """Java-based implementation of EmbeddingModelSetup that wraps a Java embedding
+    model object.
+    This class serves as a bridge between Python and Java embedding model environments,
+    but unlike JavaEmbeddingModelConnection, it does not provide direct embedding
+    functionality in Python.
+    """
+    _j_resource: Any
+    _j_resource_adapter: Any
+
+    def __init__(self, j_resource: Any, j_resource_adapter: Any, **kwargs: Any) -> None:
+        """Creates a new JavaEmbeddingModelSetup.
+
+        Args:
+            j_resource: The Java resource object
+            j_resource_adapter: The Java resource adapter for method invocation
+            **kwargs: Additional keyword arguments
+        """
+        super().__init__(**kwargs)
+        self._j_resource=j_resource
+        self._j_resource_adapter=j_resource_adapter
+
+    @property
+    def model_kwargs(self) -> Dict[str, Any]:
+        """Return embedding model settings.
+
+        Returns:
+            Empty dictionary as parameters are managed by Java side
+        """
+        return {}
+
+    def embed(self, text: str | Sequence[str], **kwargs: Any) -> list[float] | list[list[float]]:
+        """Generate embedding vector for a single text query.
+        Converts the input text into a high-dimensional vector representation
+        suitable for semantic similarity search and retrieval operations.
+
+        Args:
+            text: The text string to convert into an embedding vector.
+            **kwargs: Additional parameters passed to the embedding model.
+        """
+        result = self._j_resource.embed(
+            text if isinstance(text, str) else list(text), kwargs
+        )
+        return list(result) if isinstance(text, str) else [list(emb) for emb in result]

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -620,7 +620,8 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
                                 throw new RuntimeException(e);
                             }
                         },
-                        pythonInterpreter);
+                        pythonInterpreter,
+                        javaResourceAdapter);
         pythonResourceAdapter.open();
         agentPlan.setPythonResourceAdapter(pythonResourceAdapter);
     }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/python/utils/PythonResourceAdapterImplTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/python/utils/PythonResourceAdapterImplTest.java
@@ -49,7 +49,7 @@ public class PythonResourceAdapterImplTest {
     @BeforeEach
     void setUp() throws Exception {
         mocks = MockitoAnnotations.openMocks(this);
-        pythonResourceAdapter = new PythonResourceAdapterImpl(getResource, mockInterpreter);
+        pythonResourceAdapter = new PythonResourceAdapterImpl(getResource, mockInterpreter, null);
     }
 
     @AfterEach
@@ -152,10 +152,13 @@ public class PythonResourceAdapterImplTest {
 
         when(getResource.apply(resourceName, ResourceType.CHAT_MODEL)).thenReturn(mockResource);
 
-        Object result = pythonResourceAdapter.getResource(resourceName, resourceType);
+        pythonResourceAdapter.getResource(resourceName, resourceType);
 
-        assertThat(result).isEqualTo(mockResource);
-        verify(getResource).apply(resourceName, ResourceType.CHAT_MODEL);
+        verify(mockInterpreter)
+                .invoke(
+                        eq(PythonResourceAdapterImpl.FROM_JAVA_RESOURCE),
+                        eq(resourceType),
+                        any(Map.class));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #362 

### Purpose of change
- Support using JavaChatModelConnection directly in Python
- Support Python resource retrieval through the Java resource using the `getResource` function
    The previous implementation had the following issues:
    
    - **PythonResourceProvider couldn't directly create PythonResource**: In the old design, `PythonResourceProvider` relied on `PythonResourceAdapter` to instantiate `PythonResource`. However, `PythonResourceAdapter` was only created when a Java component invoked a Python resource.
    
    **Changes made:**
    
    - Rewrote the creation logic for `PythonResourceAdapter` so that it is automatically instantiated whenever a Python resource exists.
    - Aligned the `getResource` logic in `JavaResourceAdapter` with that of `AgentPlan`, eliminating redundant code by removing the duplicated implementation.

- Support Java resource retrieval through the Python resource using the `get_resource` function
- Support the use of the Java EembeddingModel in Python

<!-- What is the purpose of this change? -->

### Tests
E2E test
<!-- How is this change verified? -->

### API
No
<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [x] `doc-needed` <!-- Your PR changes impact docs -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
