### PR TITLE
[api][runtime] Clean up resource when close.

### DIFF
--- a/api/src/main/java/org/apache/flink/agents/api/chat/model/python/PythonChatModelConnection.java
+++ b/api/src/main/java/org/apache/flink/agents/api/chat/model/python/PythonChatModelConnection.java
@@ -87,4 +87,9 @@ public class PythonChatModelConnection extends BaseChatModelConnection
         Object pythonMessageResponse = adapter.callMethod(chatModel, "chat", kwargs);
         return adapter.fromPythonChatMessage(pythonMessageResponse);
     }
+
+    @Override
+    public void close() throws Exception {
+        this.chatModel.close();
+    }
 }

--- a/api/src/main/java/org/apache/flink/agents/api/embedding/model/python/PythonEmbeddingModelConnection.java
+++ b/api/src/main/java/org/apache/flink/agents/api/embedding/model/python/PythonEmbeddingModelConnection.java
@@ -124,4 +124,9 @@ public class PythonEmbeddingModelConnection extends BaseEmbeddingModelConnection
     public Object getPythonResource() {
         return embeddingModel;
     }
+
+    @Override
+    public void close() throws Exception {
+        this.embeddingModel.close();
+    }
 }

--- a/api/src/main/java/org/apache/flink/agents/api/resource/Resource.java
+++ b/api/src/main/java/org/apache/flink/agents/api/resource/Resource.java
@@ -64,4 +64,7 @@ public abstract class Resource {
     protected FlinkAgentsMetricGroup getMetricGroup() {
         return metricGroup;
     }
+
+    /** Close the resource. */
+    public void close() throws Exception {}
 }

--- a/integrations/chat-models/anthropic/src/main/java/org/apache/flink/agents/integrations/chatmodels/anthropic/AnthropicChatModelConnection.java
+++ b/integrations/chat-models/anthropic/src/main/java/org/apache/flink/agents/integrations/chatmodels/anthropic/AnthropicChatModelConnection.java
@@ -112,6 +112,11 @@ public class AnthropicChatModelConnection extends BaseChatModelConnection {
     }
 
     @Override
+    public void close() {
+        this.client.close();
+    }
+
+    @Override
     public ChatMessage chat(
             List<ChatMessage> messages,
             List<org.apache.flink.agents.api.tools.Tool> tools,

--- a/integrations/chat-models/openai/src/main/java/org/apache/flink/agents/integrations/chatmodels/openai/OpenAIChatModelConnection.java
+++ b/integrations/chat-models/openai/src/main/java/org/apache/flink/agents/integrations/chatmodels/openai/OpenAIChatModelConnection.java
@@ -451,4 +451,9 @@ public class OpenAIChatModelConnection extends BaseChatModelConnection {
         }
         return mapper.convertValue(value, MAP_TYPE);
     }
+
+    @Override
+    public void close() throws Exception {
+        this.client.close();
+    }
 }

--- a/integrations/mcp/src/main/java/org/apache/flink/agents/integrations/mcp/MCPPrompt.java
+++ b/integrations/mcp/src/main/java/org/apache/flink/agents/integrations/mcp/MCPPrompt.java
@@ -227,4 +227,9 @@ public class MCPPrompt extends Prompt {
     public String toString() {
         return String.format("MCPPrompt{name='%s', server='%s'}", name, mcpServer.getEndpoint());
     }
+
+    @Override
+    public void close() throws Exception {
+        this.mcpServer.close();
+    }
 }

--- a/integrations/mcp/src/main/java/org/apache/flink/agents/integrations/mcp/MCPTool.java
+++ b/integrations/mcp/src/main/java/org/apache/flink/agents/integrations/mcp/MCPTool.java
@@ -125,4 +125,9 @@ public class MCPTool extends Tool {
         return String.format(
                 "MCPTool{name='%s', server='%s'}", metadata.getName(), mcpServer.getEndpoint());
     }
+
+    @Override
+    public void close() throws Exception {
+        this.mcpServer.close();
+    }
 }

--- a/integrations/vector-stores/elasticsearch/src/main/java/org/apache/flink/agents/integrations/vectorstores/elasticsearch/ElasticsearchVectorStore.java
+++ b/integrations/vector-stores/elasticsearch/src/main/java/org/apache/flink/agents/integrations/vectorstores/elasticsearch/ElasticsearchVectorStore.java
@@ -250,6 +250,11 @@ public class ElasticsearchVectorStore extends BaseVectorStore
     }
 
     @Override
+    public void close() throws Exception {
+        this.client.close();
+    }
+
+    @Override
     public Collection getOrCreateCollection(String name, Map<String, Object> metadata)
             throws Exception {
         // Check if index exists

--- a/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
@@ -212,6 +212,15 @@ public class AgentPlan implements Serializable {
         return config.getConfData();
     }
 
+    public void close() throws Exception {
+        for (Map<String, Resource> resources : resourceCache.values()) {
+            for (Resource resource : resources.values()) {
+                resource.close();
+            }
+        }
+        resourceCache.clear();
+    }
+
     private void writeObject(ObjectOutputStream out) throws IOException {
         String serializedStr = new ObjectMapper().writeValueAsString(this);
         out.writeUTF(serializedStr);

--- a/python/flink_agents/api/resource.py
+++ b/python/flink_agents/api/resource.py
@@ -90,6 +90,9 @@ class Resource(BaseModel, ABC):
         """
         return self._metric_group
 
+    def close(self) -> None:
+        """Close the resource."""
+
 
 class SerializableResource(Resource, ABC):
     """Resource which is serializable."""

--- a/python/flink_agents/api/runner_context.py
+++ b/python/flink_agents/api/runner_context.py
@@ -231,3 +231,7 @@ class RunnerContext(ABC):
         ReadableConfiguration
             The configuration for flink agents.
         """
+
+    @abstractmethod
+    def close(self) -> None:
+        """Clean up the resources."""

--- a/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
@@ -22,6 +22,7 @@ from anthropic import Anthropic
 from anthropic._types import NOT_GIVEN
 from anthropic.types import MessageParam, TextBlockParam, ToolParam
 from pydantic import Field, PrivateAttr
+from typing_extensions import override
 
 from flink_agents.api.chat_message import ChatMessage, MessageRole
 from flink_agents.api.chat_models.chat_model import (
@@ -207,6 +208,14 @@ class AnthropicChatModelConnection(BaseChatModelConnection):
                 role=MessageRole(message.role),
                 content=message.content[0].text,
             )
+
+    @override
+    def close(self) -> None:
+        if self._client is not None:
+            try:
+                self._client.close()
+            finally:
+                self._client = None
 
 
 DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-20250514"

--- a/python/flink_agents/integrations/chat_models/openai/openai_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/openai/openai_chat_model.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Literal, Sequence
 import httpx
 from openai import NOT_GIVEN, OpenAI
 from pydantic import Field, PrivateAttr
+from typing_extensions import override
 
 from flink_agents.api.chat_message import ChatMessage
 from flink_agents.api.chat_models.chat_model import (
@@ -183,6 +184,14 @@ class OpenAIChatModelConnection(BaseChatModelConnection):
         message = response.choices[0].message
 
         return convert_from_openai_message(message)
+
+    @override
+    def close(self) -> None:
+        if self._client is not None:
+            try:
+                self._client.close()
+            finally:
+                self._client = None
 
 
 DEFAULT_TEMPERATURE = 0.1

--- a/python/flink_agents/integrations/embedding_models/openai_embedding_model.py
+++ b/python/flink_agents/integrations/embedding_models/openai_embedding_model.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, Sequence
 
 from openai import NOT_GIVEN, OpenAI
 from pydantic import Field
+from typing_extensions import override
 
 from flink_agents.api.embedding_models.embedding_model import (
     BaseEmbeddingModelConnection,
@@ -94,7 +95,7 @@ class OpenAIEmbeddingModelConnection(BaseEmbeddingModelConnection):
             **kwargs,
         )
 
-    __client: OpenAI = None
+    __client: OpenAI | None = None
 
     @property
     def client(self) -> OpenAI:
@@ -129,6 +130,15 @@ class OpenAIEmbeddingModelConnection(BaseEmbeddingModelConnection):
 
         embeddings = [list(embedding.embedding) for embedding in response.data]
         return embeddings[0] if isinstance(text, str) else embeddings
+
+    @override
+    def close(self) -> None:
+        """Do nothing."""
+        if self.__client is not None:
+            try:
+                self.__client.close()
+            finally:
+                self.__client = None
 
 
 class OpenAIEmbeddingModelSetup(BaseEmbeddingModelSetup):

--- a/python/flink_agents/integrations/mcp/mcp.py
+++ b/python/flink_agents/integrations/mcp/mcp.py
@@ -67,6 +67,14 @@ class MCPTool(Tool):
             self.mcp_server.call_tool_async(self.metadata.name, *args, **kwargs)
         )
 
+    @override
+    def close(self) -> None:
+        if self.mcp_server is not None:
+            try:
+                self.mcp_server.close()
+            finally:
+                self.mcp_server = None
+
 
 class MCPPrompt(Prompt):
     """MCP prompt definition that extends the base Prompt class.
@@ -117,6 +125,13 @@ class MCPPrompt(Prompt):
         arguments = self._check_arguments(**arguments)
         return self.mcp_server.get_prompt(self.name, arguments)
 
+    @override
+    def close(self) -> None:
+        if self.mcp_server is not None:
+            try:
+                self.mcp_server.close()
+            finally:
+                self.mcp_server = None
 
 class MCPServer(SerializableResource, ABC):
     """Resource representing an MCP server and exposing its tools/prompts.
@@ -308,6 +323,7 @@ class MCPServer(SerializableResource, ABC):
 
         return chat_messages
 
+    @override
     def close(self) -> None:
         """Close the MCP server connection and clean up resources."""
         asyncio.run(self._cleanup_connection())

--- a/python/flink_agents/plan/agent_plan.py
+++ b/python/flink_agents/plan/agent_plan.py
@@ -223,6 +223,14 @@ class AgentPlan(BaseModel):
         """Set java resource adapter for java resource provider."""
         self.__j_resource_adapter = j_resource_adapter
 
+    def close(self) -> None:
+        """Clean up the resources."""
+        for type in self.__resources:
+            for name in self.__resources[type]:
+                self.__resources[type][name].close()
+        self.__resources.clear()
+
+
 
 def _get_actions(agent: Agent) -> List[Action]:
     """Extract all registered agent actions from an agent.

--- a/python/flink_agents/runtime/flink_runner_context.py
+++ b/python/flink_agents/runtime/flink_runner_context.py
@@ -46,7 +46,7 @@ class FlinkRunnerContext(RunnerContext):
     This context allows access to event handling.
     """
 
-    __agent_plan: AgentPlan
+    __agent_plan: AgentPlan | None
     __ltm: BaseLongTermMemory = None
 
     def __init__(
@@ -209,6 +209,14 @@ class FlinkRunnerContext(RunnerContext):
         """
         return self.__agent_plan.config
 
+    @override
+    def close(self) -> None:
+        if self.__agent_plan is not None:
+            try:
+                self.__agent_plan.close()
+            finally:
+                self.__agent_plan = None
+
 
 def create_flink_runner_context(
     j_runner_context: Any,
@@ -246,6 +254,12 @@ def flink_runner_context_switch_action_context(
                 key=str(key),
             )
         )
+
+def close_flink_runner_context(
+    ctx: FlinkRunnerContext,
+) -> None:
+    """Clean up the resources kept by the flink runner context."""
+    ctx.close()
 
 
 def create_async_thread_pool() -> ThreadPoolExecutor:

--- a/python/flink_agents/runtime/java/java_chat_model.py
+++ b/python/flink_agents/runtime/java/java_chat_model.py
@@ -81,6 +81,10 @@ class JavaChatModelConnectionImpl(JavaChatModelConnection):
 
         return from_java_chat_message(j_response_message)
 
+    @override
+    def close(self) -> None:
+        self.j_resource.close()
+
 
 class JavaChatModelSetupImpl(JavaChatModelSetup):
     """Java-based implementation of ChatModelSetup that bridges Python and Java chat

--- a/python/flink_agents/runtime/java/java_resource_wrapper.py
+++ b/python/flink_agents/runtime/java/java_resource_wrapper.py
@@ -62,6 +62,10 @@ class JavaPrompt(Prompt):
                                             extra_args=j_chat_message.getExtraArgs()) for j_chat_message in j_chat_messages]
         return chatMessages
 
+    @override
+    def close(self) -> None:
+        self.j_prompt.close()
+
 class JavaGetResourceWrapper:
     """Python wrapper for Java ResourceAdapter."""
 

--- a/python/flink_agents/runtime/local_runner.py
+++ b/python/flink_agents/runtime/local_runner.py
@@ -57,7 +57,7 @@ class LocalRunnerContext(RunnerContext):
         Name of the action being executed.
     """
 
-    __agent_plan: AgentPlan
+    __agent_plan: AgentPlan | None
     __key: Any
     events: deque[Event]
     action_name: str
@@ -220,6 +220,14 @@ class LocalRunnerContext(RunnerContext):
     def clear_sensory_memory(self) -> None:
         """Clean up sensory memory."""
         self._sensory_mem_store.clear()
+
+    def close(self) -> None:
+        """Cleanup the resource."""
+        if self.__agent_plan is not None:
+            try:
+                self.__agent_plan.close()
+            finally:
+                self.__agent_plan = None
 
 
 class LocalRunner(AgentRunner):

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/context/RunnerContextImpl.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/context/RunnerContextImpl.java
@@ -231,6 +231,8 @@ public class RunnerContextImpl implements RunnerContext {
             this.ltm.close();
             this.ltm = null;
         }
+
+        this.agentPlan.close();
     }
 
     public String getActionName() {

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -643,6 +643,13 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
 
     @Override
     public void close() throws Exception {
+        if (runnerContext != null) {
+            try {
+                runnerContext.close();
+            } finally {
+                runnerContext = null;
+            }
+        }
         if (pythonActionExecutor != null) {
             pythonActionExecutor.close();
         }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutor.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutor.java
@@ -43,6 +43,9 @@ public class PythonActionExecutor {
     private static final String FLINK_RUNNER_CONTEXT_SWITCH_ACTION_CONTEXT =
             "flink_runner_context.flink_runner_context_switch_action_context";
 
+    private static final String CLOSE_FLINK_RUNNER_CONTEXT =
+            "flink_runner_context.close_flink_runner_context";
+
     // ========== ASYNC THREAD POOL ===========
     private static final String CREATE_ASYNC_THREAD_POOL =
             "flink_runner_context.create_async_thread_pool";
@@ -175,6 +178,14 @@ public class PythonActionExecutor {
         if (interpreter != null) {
             if (pythonAsyncThreadPool != null) {
                 interpreter.invoke(CLOSE_ASYNC_THREAD_POOL, pythonAsyncThreadPool);
+            }
+
+            if (pythonRunnerContext != null) {
+                try {
+                    interpreter.invoke(CLOSE_FLINK_RUNNER_CONTEXT, pythonRunnerContext);
+                } finally {
+                    pythonRunnerContext = null;
+                }
             }
         }
     }


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #345 

### Purpose of change

Some resource may keep socket connection or other resources, we should clean up these resources when job failed/finished/cancelled.

### Tests

e2e test

### API

No

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
