### PR TITLE
[hotfix] Use qwen3:1.7b in ChatModelCrossLanguageTest to improve stability

### DIFF
--- a/e2e-test/flink-agents-end-to-end-tests-resource-cross-language/src/test/java/org/apache/flink/agents/resource/test/ChatModelCrossLanguageAgent.java
+++ b/e2e-test/flink-agents-end-to-end-tests-resource-cross-language/src/test/java/org/apache/flink/agents/resource/test/ChatModelCrossLanguageAgent.java
@@ -62,7 +62,7 @@ import java.util.List;
  * the model is allowed to call.
  */
 public class ChatModelCrossLanguageAgent extends Agent {
-    public static final String OLLAMA_MODEL = "qwen3:0.6b";
+    public static final String OLLAMA_MODEL = "qwen3:1.7b";
 
     @ChatModelConnection
     public static ResourceDescriptor javaChatModelConnection() {


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #435 

### Purpose of change
Use qwen3:1.7b in ChatModelCrossLanguageTest to improve stability
<!-- What is the purpose of this change? -->

### Tests
E2E test
<!-- How is this change verified? -->

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
