### PR TITLE
[api][plan] Use resource descriptor to declare a MCP server in Agent.

### DIFF
--- a/api/src/main/java/org/apache/flink/agents/api/resource/Constant.java
+++ b/api/src/main/java/org/apache/flink/agents/api/resource/Constant.java
@@ -79,4 +79,7 @@ public class Constant {
     // elasticsearch
     public static String ELASTICSEARCH_VECTOR_STORE =
             "org.apache.flink.agents.integrations.vectorstores.elasticsearch.ElasticsearchVectorStore";
+
+    // MCP
+    public static String MCP_SERVER = "org.apache.flink.agents.integrations.mcp.MCPServer";
 }

--- a/integrations/mcp/src/main/java/org/apache/flink/agents/integrations/mcp/MCPServer.java
+++ b/integrations/mcp/src/main/java/org/apache/flink/agents/integrations/mcp/MCPServer.java
@@ -28,8 +28,9 @@ import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTranspor
 import io.modelcontextprotocol.spec.McpSchema;
 import org.apache.flink.agents.api.chat.messages.ChatMessage;
 import org.apache.flink.agents.api.chat.messages.MessageRole;
+import org.apache.flink.agents.api.resource.Resource;
+import org.apache.flink.agents.api.resource.ResourceDescriptor;
 import org.apache.flink.agents.api.resource.ResourceType;
-import org.apache.flink.agents.api.resource.SerializableResource;
 import org.apache.flink.agents.api.tools.ToolMetadata;
 import org.apache.flink.agents.integrations.mcp.auth.ApiKeyAuth;
 import org.apache.flink.agents.integrations.mcp.auth.Auth;
@@ -44,6 +45,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiFunction;
 
 /**
  * Resource representing an MCP server and exposing its tools/prompts.
@@ -73,7 +75,7 @@ import java.util.Objects;
  *
  * <p>Reference: <a href="https://modelcontextprotocol.io/sdk/java/mcp-client">MCP Java Client</a>
  */
-public class MCPServer extends SerializableResource {
+public class MCPServer extends Resource {
 
     private static final String FIELD_ENDPOINT = "endpoint";
     private static final String FIELD_HEADERS = "headers";
@@ -129,6 +131,18 @@ public class MCPServer extends SerializableResource {
         public MCPServer build() {
             return new MCPServer(endpoint, headers, timeoutSeconds, auth);
         }
+    }
+
+    public MCPServer(
+            ResourceDescriptor descriptor, BiFunction<String, ResourceType, Resource> getResource) {
+        super(descriptor, getResource);
+        this.endpoint =
+                Objects.requireNonNull(
+                        descriptor.getArgument("endpoint"), "endpoint cannot be null");
+        Map<String, String> headers = descriptor.getArgument("headers");
+        this.headers = headers != null ? new HashMap<>(headers) : new HashMap<>();
+        this.timeoutSeconds = (int) descriptor.getArgument("timeout");
+        this.auth = descriptor.getArgument("auth");
     }
 
     /**

--- a/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
@@ -332,11 +332,12 @@ public class AgentPlan implements Serializable {
     private void extractMCPServer(Method method) throws Exception {
         // Use reflection to handle MCP classes to support Java 11 without MCP
         String name = method.getName();
-        Object mcpServer = method.invoke(null);
 
-        addResourceProvider(
-                JavaSerializableResourceProvider.createResourceProvider(
-                        name, MCP_SERVER, (SerializableResource) mcpServer));
+        ResourceDescriptor descriptor = (ResourceDescriptor) method.invoke(null);
+        JavaResourceProvider provider = new JavaResourceProvider(name, MCP_SERVER, descriptor);
+
+        addResourceProvider(provider);
+        Object mcpServer = provider.provide(null);
 
         // Call listTools() via reflection
         Method listToolsMethod = mcpServer.getClass().getMethod("listTools");

--- a/python/flink_agents/api/resource.py
+++ b/python/flink_agents/api/resource.py
@@ -260,3 +260,6 @@ class Constant:
     JAVA_COLLECTION_MANAGEABLE_VECTOR_STORE = "flink_agents.api.vector_stores.java_vector_store.JavaCollectionManageableVectorStore"
     # chroma
     CHROMA_VECTOR_STORE = "flink_agents.integrations.vector_stores.chroma.chroma_vector_store.ChromaVectorStore"
+
+    # MCP
+    MCP_SERVER = "flink_agents.integrations.mcp.mcp.MCPServer"

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/e2e_tests_mcp/mcp_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/e2e_tests_mcp/mcp_test.py
@@ -52,7 +52,6 @@ from flink_agents.api.resource import (
 )
 from flink_agents.api.runner_context import RunnerContext
 from flink_agents.e2e_tests.test_utils import pull_model
-from flink_agents.integrations.mcp.mcp import MCPServer
 
 OLLAMA_MODEL = os.environ.get("MCP_OLLAMA_CHAT_MODEL", "qwen3:1.7b")
 MCP_SERVER_ENDPOINT = "http://127.0.0.1:8000/mcp"
@@ -70,9 +69,9 @@ class MyMCPAgent(Agent):
 
     @mcp_server
     @staticmethod
-    def my_mcp_server() -> MCPServer:
+    def my_mcp_server() -> ResourceDescriptor:
         """Define MCP server connection."""
-        return MCPServer(endpoint=MCP_SERVER_ENDPOINT)
+        return ResourceDescriptor(clazz=Constant.MCP_SERVER, endpoint=MCP_SERVER_ENDPOINT)
 
     @chat_model_connection
     @staticmethod

--- a/python/flink_agents/integrations/mcp/mcp.py
+++ b/python/flink_agents/integrations/mcp/mcp.py
@@ -38,7 +38,7 @@ from typing_extensions import override
 
 from flink_agents.api.chat_message import ChatMessage, MessageRole
 from flink_agents.api.prompts.prompt import Prompt
-from flink_agents.api.resource import ResourceType, SerializableResource
+from flink_agents.api.resource import Resource, ResourceType
 from flink_agents.api.tools.tool import Tool, ToolMetadata, ToolType
 from flink_agents.integrations.mcp.utils import extract_mcp_content_item
 
@@ -49,7 +49,7 @@ class MCPTool(Tool):
     This represents a single tool from an MCP server.
     """
 
-    mcp_server: "MCPServer" = Field(default=None, exclude=True)
+    mcp_server: "MCPServer" = Field(default=None)
 
     @classmethod
     @override
@@ -86,7 +86,7 @@ class MCPPrompt(Prompt):
     title: str | None
     description: str | None = None
     prompt_arguments: list[PromptArgument] = Field(default_factory=list)
-    mcp_server: "MCPServer" = Field(default=None, exclude=True)
+    mcp_server: "MCPServer" = Field(default=None)
 
     def _check_arguments(self, **kwargs: str) -> Dict[str, str]:
         if self.mcp_server is None:
@@ -133,7 +133,7 @@ class MCPPrompt(Prompt):
             finally:
                 self.mcp_server = None
 
-class MCPServer(SerializableResource, ABC):
+class MCPServer(Resource, ABC):
     """Resource representing an MCP server and exposing its tools/prompts.
 
     This is a logical container for MCP tools and prompts; it is not directly invokable.


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #454 

### Purpose of change

Use resource descriptor to declare a MCP server in Agent.

### Tests

exist mcp tests.

### API

Yes, use resource descriptor to declare a MCP server in Agent, rather than directly construct MCPServer object.

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [x] `doc-needed` <!-- Your PR changes impact docs -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
