### PR TITLE
[fix] Fixed the DurableExecutionException error that could not be serialized

### DIFF
--- a/runtime/src/main/java/org/apache/flink/agents/runtime/context/RunnerContextImpl.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/context/RunnerContextImpl.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.agents.runtime.context;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.agents.api.Event;
@@ -359,7 +360,13 @@ public class RunnerContextImpl implements RunnerContext {
 
     /** Serializable exception info for durable execution persistence. */
     public static class DurableExecutionException {
+        private static final String FIELD_MESSAGE = "message";
+        private static final String FIELD_EXCEPTION_CLASS = "exceptionClass";
+
+        @JsonProperty(FIELD_MESSAGE)
         private final String exceptionClass;
+
+        @JsonProperty(FIELD_EXCEPTION_CLASS)
         private final String message;
 
         public DurableExecutionException() {


### PR DESCRIPTION


<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: [#473](https://github.com/apache/flink-agents/issues/473)

### Purpose of change

Fixed the DurableExecutionException error that could not be serialized. 

### Tests

<!-- How is this change verified? -->

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
