### PR TITLE
[hotfix] Remove unnecessary import statements from the mcp document

### DIFF
--- a/docs/content/docs/development/mcp.md
+++ b/docs/content/docs/development/mcp.md
@@ -1,4 +1,4 @@
-from python.flink_agents.api.resource import ResourceName---
+---
 title: MCP
 weight: 9
 type: docs


### PR DESCRIPTION
### Purpose of change
Remove unnecessary import statements from the mcp document.
<!-- What is the purpose of this change? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
