### PR TITLE
[hotfix] Use qwen3:1.7b in Python Integration Test to improve stability

### DIFF
--- a/python/flink_agents/integrations/chat_models/tests/start_ollama_server.sh
+++ b/python/flink_agents/integrations/chat_models/tests/start_ollama_server.sh
@@ -35,6 +35,6 @@ if [[ $os == "Linux" ]]; then
       sleep 10 # wait for ollama to start
   fi
 
-  ollama pull qwen3:0.6b
-  ollama run qwen3:0.6b
+  echo "ollama pull $1"
+  ollama pull $1
 fi

--- a/python/flink_agents/integrations/chat_models/tests/test_ollama_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/tests/test_ollama_chat_model.py
@@ -32,14 +32,16 @@ from flink_agents.integrations.chat_models.ollama_chat_model import (
 )
 from flink_agents.plan.tools.function_tool import FunctionTool, from_callable
 
-test_model = os.environ.get("OLLAMA_CHAT_MODEL", "qwen3:0.6b")
+test_model = os.environ.get("OLLAMA_CHAT_MODEL", "qwen3:1.7b")
 current_dir = Path(__file__).parent
 
 try:
     # only auto setup ollama in ci with python 3.10 to reduce ci cost.
     if "3.10" in sys.version:
         subprocess.run(
-            ["bash", f"{current_dir}/start_ollama_server.sh"], timeout=300, check=True
+            ["bash", f"{current_dir}/start_ollama_server.sh", test_model],
+            timeout=300,
+            check=True,
         )
     client = Client()
     models = client.list()


### PR DESCRIPTION
### Purpose of change
Use qwen3:1.7b in Python Integration Test to improve stability.
<!-- What is the purpose of this change? -->


### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
