### PR TITLE
[doc] Clarify Azure OpenAI vs Azure AI in documentation 

### DIFF
--- a/docs/content/docs/development/chat_models.md
+++ b/docs/content/docs/development/chat_models.md
@@ -144,10 +144,14 @@ public class MyAgent extends Agent {
 
 ### Azure AI
 
-Azure AI provides cloud-based chat models through Azure AI Inference API, supporting various models including GPT-4, GPT-4o, and other Azure-hosted models.
+Azure AI provides cloud-based chat models through Azure AI Inference API, supporting various models including Llama, Mistral, Phi, and other models deployed via Azure AI Studio.
 
 {{< hint info >}}
 Azure AI is only supported in Java currently. To use Azure AI from Python agents, see [Using Cross-Language Providers](#using-cross-language-providers).
+{{< /hint >}}
+
+{{< hint warning >}}
+**Azure AI vs OpenAI (Azure):** Azure AI uses the Azure AI Inference API to access models deployed via Azure AI Studio (Llama, Mistral, Phi, etc.). If you want to use OpenAI models (GPT-4, etc.) hosted on Azure, see [OpenAI (Azure)](#openai-azure) instead.
 {{< /hint >}}
 
 #### Prerequisites
@@ -686,10 +690,14 @@ Model availability and specifications may change. Always check the official Open
 
 ### OpenAI (Azure)
 
-OpenAI (Azure) provides access to OpenAI models through Azure's cloud infrastructure, using the same OpenAI SDK with Azure-specific authentication and endpoints. This offers enterprise security, compliance, and regional availability while using familiar OpenAI APIs.
+OpenAI (Azure) provides access to OpenAI models (GPT-4, GPT-4o, etc.) through Azure's cloud infrastructure, using the same OpenAI SDK with Azure-specific authentication and endpoints. This offers enterprise security, compliance, and regional availability while using familiar OpenAI APIs.
 
 {{< hint info >}}
 OpenAI (Azure) is only supported in Python currently. To use OpenAI (Azure) from Java agents, see [Using Cross-Language Providers](#using-cross-language-providers).
+{{< /hint >}}
+
+{{< hint warning >}}
+**OpenAI (Azure) vs Azure AI:** OpenAI (Azure) uses the OpenAI SDK to access OpenAI models (GPT-4, etc.) hosted on Azure. If you want to use other models like Llama, Mistral, or Phi deployed via Azure AI Studio, see [Azure AI](#azure-ai) instead.
 {{< /hint >}}
 
 #### Prerequisites

--- a/docs/content/docs/faq/faq.md
+++ b/docs/content/docs/faq/faq.md
@@ -97,6 +97,7 @@ Flink Agents provides built-in integrations for many ecosystem providers. Some i
 | [Anthropic]({{< ref "docs/development/chat_models#anthropic" >}}) | ✅ | ❌ |
 | [Ollama]({{< ref "docs/development/chat_models#ollama" >}}) | ✅ | ✅ |
 | [Tongyi (DashScope)]({{< ref "docs/development/chat_models#tongyi-dashscope" >}}) | ✅ | ❌ |
+| [OpenAI (Azure)]({{< ref "docs/development/chat_models#openai-azure" >}}) | ✅ | ❌ |
 | [Azure AI]({{< ref "docs/development/chat_models#azure-ai" >}}) | ❌ | ✅ |
 
 **Embedding Models**


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: N/A  (documentation improvement) 

### Purpose of change

  Clarify the difference between Azure OpenAI and Azure AI:                                              
  - Add missing "OpenAI (Azure)" entry to FAQ Chat Models support matrix                                 
  - Add warning hints in both Azure sections of chat_models.md explaining:                               
    - **OpenAI (Azure)**: Uses OpenAI SDK to access OpenAI models (GPT-4, etc.) on Azure                 
    - **Azure AI**: Uses Azure AI Inference API to access other models (Llama, Mistral, Phi) via Azure AI
   Studio                                                                                                
  - Update section descriptions to accurately reflect supported models  

### Tests

<!-- How is this change verified? -->
No tests needed - documentation only change.      
### API

<!-- Does this change touches any public APIs? -->
 No API changes.  
### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
