### PR TITLE
[runtime] Fix Python awaitable lost during checkpoint restore

### DIFF
--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -203,6 +203,8 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
 
     private final transient Map<ActionTask, ContinuationContext> continuationContexts;
 
+    private final transient Map<ActionTask, String> pythonAwaitableRefs;
+
     // Each job can only have one identifier and this identifier must be consistent across restarts.
     // We cannot use job id as the identifier here because user may change job id by
     // creating a savepoint, stop the job and then resume from savepoint.
@@ -229,6 +231,7 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         this.actionTaskMemoryContexts = new HashMap<>();
         this.actionTaskDurableContexts = new HashMap<>();
         this.continuationContexts = new HashMap<>();
+        this.pythonAwaitableRefs = new HashMap<>();
         OperatorUtils.setChainStrategy(this, ChainingStrategy.ALWAYS);
     }
 
@@ -508,6 +511,7 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
             actionTaskMemoryContexts.remove(actionTask);
             actionTaskDurableContexts.remove(actionTask);
             continuationContexts.remove(actionTask);
+            pythonAwaitableRefs.remove(actionTask);
             maybePersistTaskResult(
                     key,
                     sequenceNumber,
@@ -554,6 +558,14 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
                         generatedActionTask,
                         ((JavaRunnerContextImpl) actionTask.getRunnerContext())
                                 .getContinuationContext());
+            }
+            if (actionTask.getRunnerContext() instanceof PythonRunnerContextImpl) {
+                String awaitableRef =
+                        ((PythonRunnerContextImpl) actionTask.getRunnerContext())
+                                .getPythonAwaitableRef();
+                if (awaitableRef != null) {
+                    pythonAwaitableRefs.put(generatedActionTask, awaitableRef);
+                }
             }
 
             actionTasksKState.add(generatedActionTask);
@@ -883,6 +895,12 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
                 continuationContext = new ContinuationContext();
             }
             ((JavaRunnerContextImpl) runnerContext).setContinuationContext(continuationContext);
+        }
+        if (runnerContext instanceof PythonRunnerContextImpl) {
+            // Get the awaitable ref from the transient map. After checkpoint restore, this will be
+            // null, signaling that the awaitable was lost and needs re-execution.
+            String awaitableRef = pythonAwaitableRefs.get(actionTask);
+            ((PythonRunnerContextImpl) runnerContext).setPythonAwaitableRef(awaitableRef);
         }
         actionTask.setRunnerContext(runnerContext);
     }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/context/PythonRunnerContextImpl.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/context/PythonRunnerContextImpl.java
@@ -31,6 +31,13 @@ import javax.annotation.concurrent.NotThreadSafe;
 /** A specialized {@link RunnerContext} that is specifically used when executing Python actions. */
 @NotThreadSafe
 public class PythonRunnerContextImpl extends RunnerContextImpl {
+
+    /**
+     * Reference to the Python awaitable object in the interpreter. This is set when a Python action
+     * yields an awaitable and is used by PythonGeneratorActionTask to resume execution.
+     */
+    private String pythonAwaitableRef;
+
     public PythonRunnerContextImpl(
             FlinkAgentsMetricGroupImpl agentMetricGroup,
             Runnable mailboxThreadChecker,
@@ -49,5 +56,13 @@ public class PythonRunnerContextImpl extends RunnerContextImpl {
     public void sendEvent(String type, byte[] event, String eventJsonStr) {
         // this method will be invoked by PythonActionExecutor's python interpreter.
         sendEvent(new PythonEvent(event, type, eventJsonStr));
+    }
+
+    public String getPythonAwaitableRef() {
+        return pythonAwaitableRef;
+    }
+
+    public void setPythonAwaitableRef(String pythonAwaitableRef) {
+        this.pythonAwaitableRef = pythonAwaitableRef;
     }
 }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/operator/PythonActionTask.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/operator/PythonActionTask.java
@@ -21,6 +21,7 @@ import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.plan.PythonFunction;
 import org.apache.flink.agents.plan.actions.Action;
 import org.apache.flink.agents.runtime.operator.ActionTask;
+import org.apache.flink.agents.runtime.python.context.PythonRunnerContextImpl;
 import org.apache.flink.agents.runtime.python.event.PythonEvent;
 import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
 
@@ -60,8 +61,8 @@ public class PythonActionTask extends ActionTask {
         if (pythonAwaitableRef != null) {
             // The Python action generates an awaitable. We need to execute it once, which will
             // submit an asynchronous task and return whether the action has been completed.
-            ActionTask tempGeneratedActionTask =
-                    new PythonGeneratorActionTask(key, event, action, pythonAwaitableRef);
+            ((PythonRunnerContextImpl) runnerContext).setPythonAwaitableRef(pythonAwaitableRef);
+            ActionTask tempGeneratedActionTask = new PythonGeneratorActionTask(key, event, action);
             tempGeneratedActionTask.setRunnerContext(runnerContext);
             return tempGeneratedActionTask.invoke(userCodeClassLoader, executor);
         }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutor.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutor.java
@@ -163,14 +163,14 @@ public class PythonActionExecutor {
      * @param pythonAwaitableRef the reference name of the Python awaitable object stored in the
      *     interpreter's context
      * @return true if the awaitable has completed; false otherwise
-     * @throws AwaitableLostException if the awaitable is not found (e.g., lost during restore)
      */
     public boolean callPythonAwaitable(String pythonAwaitableRef) {
         // Calling awaitable.send(None) in Python returns a tuple of (finished, output).
         Object pythonAwaitable = interpreter.get(pythonAwaitableRef);
-        if (pythonAwaitable == null) {
-            throw new AwaitableLostException(pythonAwaitableRef);
-        }
+        checkState(
+                pythonAwaitable != null,
+                "Python awaitable '%s' not found in interpreter. ",
+                pythonAwaitableRef);
         Object invokeResult = interpreter.invoke(CALL_PYTHON_AWAITABLE, pythonAwaitable);
         checkState(invokeResult.getClass().isArray() && ((Object[]) invokeResult).length == 2);
         return (boolean) ((Object[]) invokeResult)[0];
@@ -196,27 +196,6 @@ public class PythonActionExecutor {
     public static class PythonActionExecutionException extends Exception {
         public PythonActionExecutionException(String message, Throwable cause) {
             super(message, cause);
-        }
-    }
-
-    /**
-     * Thrown when a Python awaitable is not found during restore. This typically happens when the
-     * coroutine state was lost because Python coroutines cannot be serialized. The action should be
-     * re-executed from the beginning, and durable execution will skip already-completed calls.
-     */
-    public static class AwaitableLostException extends RuntimeException {
-        private final String awaitableRef;
-
-        public AwaitableLostException(String awaitableRef) {
-            super(
-                    "Python awaitable '"
-                            + awaitableRef
-                            + "' not found. The action will be re-executed from the beginning.");
-            this.awaitableRef = awaitableRef;
-        }
-
-        public String getAwaitableRef() {
-            return awaitableRef;
         }
     }
 }


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #508 

### Purpose of change

<!-- What is the purpose of this change? -->
  Fix a crash that occurs when restoring a Python async action from checkpoint.                        
                                                                                                       
  **Root cause:** Python coroutines cannot be serialized. When a checkpoint captures state while an async action is in progress (e.g., waiting for LLM response), the coroutine object is lost. On restore, the awaitable reference is `None`, causing:                                                 
  AttributeError: 'NoneType' object has no attribute 'send'                                            
                                                                                                       
  **Fix:**                                                                                             
  - Detect `None` awaitable in `PythonActionExecutor.callPythonAwaitable()`                            
  - Throw `AwaitableLostException` to signal the awaitable was lost                                    
  - `PythonGeneratorActionTask` catches this and re-executes the action from the beginning             
  - Durable execution cache ensures already-completed calls are skipped   

### Tests

<!-- How is this change verified? -->
  - Manual testing: Run `react_agent_example.py`, trigger LLM timeout, verify job recovers instead of crashing                                                                                             
  - No unit test added - these classes depend on Pemja (Python interpreter) which is difficult to mock; the fix is better validated via e2e testing    
### API

<!-- Does this change touches any public APIs? -->
No public API changes. 
### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
