### PR TITLE
[hotfix] Fix the problems using Kafka as action state store

### DIFF
--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateUtil.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateUtil.java
@@ -59,22 +59,15 @@ public class ActionStateUtil {
     }
 
     private static String generateUUIDForEvent(Event event) throws IOException {
-        if (event instanceof InputEvent) {
+        if (event instanceof PythonEvent) {
+            PythonEvent pythonEvent = (PythonEvent) event;
+            return String.valueOf(UUID.nameUUIDFromBytes(pythonEvent.getEvent()));
+        } else if (event instanceof InputEvent) {
             InputEvent inputEvent = (InputEvent) event;
             byte[] inputEventBytes =
                     MAPPER.writeValueAsBytes(
                             new Object[] {inputEvent.getInput(), inputEvent.getAttributes()});
             return String.valueOf(UUID.nameUUIDFromBytes(inputEventBytes));
-        } else if (event instanceof PythonEvent) {
-            PythonEvent pythonEvent = (PythonEvent) event;
-            byte[] pythonEventBytes =
-                    MAPPER.writeValueAsBytes(
-                            new Object[] {
-                                pythonEvent.getEvent(),
-                                pythonEvent.getEventType(),
-                                pythonEvent.getAttributes()
-                            });
-            return String.valueOf(UUID.nameUUIDFromBytes(pythonEventBytes));
         } else {
             return String.valueOf(
                     UUID.nameUUIDFromBytes(

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/event/PythonEvent.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/event/PythonEvent.java
@@ -20,7 +20,6 @@
 package org.apache.flink.agents.runtime.python.event;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.agents.api.Event;
 
@@ -61,7 +60,6 @@ public class PythonEvent extends Event {
         this.eventJsonStr = eventJsonStr;
     }
 
-    @JsonIgnore // Don't serialize byte array in logs - used for processing only
     public byte[] getEvent() {
         return event;
     }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/python/event/PythonEventTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/python/event/PythonEventTest.java
@@ -83,8 +83,8 @@ class PythonEventTest {
         assertThat(jsonNode.has("eventType")).isTrue();
         assertThat(jsonNode.has("eventJsonStr")).isTrue();
         assertThat(jsonNode.has("attributes")).isTrue();
-        // event bytes should not be serialized
-        assertThat(jsonNode.has("event")).isFalse();
+        // event bytes should be serialized for ActionState persistence
+        assertThat(jsonNode.has("event")).isTrue();
         assertThat(jsonNode.get("eventType").asText()).isEqualTo(eventType);
         assertThat(jsonNode.get("eventJsonStr").asText()).isEqualTo(eventJsonStr);
         assertThat(jsonNode.get("attributes").get("testKey").asText()).isEqualTo("testValue");
@@ -117,7 +117,7 @@ class PythonEventTest {
         JsonNode eventNode = jsonNode.get("event");
         assertThat(eventNode.get("eventType").asText()).isEqualTo(eventType);
         assertThat(eventNode.get("id").asText()).isEqualTo(eventId.toString());
-        // Byte array should not be in the log
-        assertThat(eventNode.has("event")).isFalse();
+        // Byte array should be serialized for ActionState persistence
+        assertThat(eventNode.has("event")).isTrue();
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/python/event/PythonEventTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/python/event/PythonEventTest.java
@@ -117,7 +117,7 @@ class PythonEventTest {
         JsonNode eventNode = jsonNode.get("event");
         assertThat(eventNode.get("eventType").asText()).isEqualTo(eventType);
         assertThat(eventNode.get("id").asText()).isEqualTo(eventId.toString());
-        // Byte array should be serialized for ActionState persistence
-        assertThat(eventNode.has("event")).isTrue();
+        // Byte array should not be in the log
+        assertThat(eventNode.has("event")).isFalse();
     }
 }


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #xxx

This PR fixes issues with the Kafka ActionStateStore that prevented actions from being correctly skipped after checkpoint recovery:

1. **Fix ActionState deserialization failure**: Removed `@JsonIgnore` from `PythonEvent.getEvent()` so that Python event bytes are persisted in ActionState. Without this, recovered ActionState had `null` event bytes, causing `TypeError: a bytes-like object is required, not 'NoneType'` after recovery.

2. **Fix ActionStateStore not initialized during state recovery**: Moved ActionStateStore initialization to also run in `initializeState()`, ensuring it's available when rebuilding state from recovery markers.

3. **Fix state key mismatch after recovery**: Changed Python `Event.id` from random UUID to deterministic content-based UUID (MD5 hash). This ensures the same event produces the same ActionState key across restarts, enabling proper state lookup and divergence detection.

4. **Fix Kafka consumer partition assignment**: Use `consumer.assign()` instead of `subscribe()` for explicit partition control during state rebuild.

### Tests

Manually verified with local Kafka instance. E2E tests will be added in a follow-up PR.

### API

No public API changes.

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
