### PR TITLE
[docs] Add workaround to install flink-agents 0.2.0

### DIFF
--- a/docs/content/docs/get-started/installation.md
+++ b/docs/content/docs/get-started/installation.md
@@ -114,11 +114,11 @@ Choose one of the following installation methods:
 {{< hint warning >}}
 __Temporary (v0.2.0):__ Due to PyPI wheel size limitations, the `flink-agents` version 0.2.0 is currently not available directly from PyPI. Please download the wheel file manually and install from local:
 
-```shell
-# Download the wheel file
-wget https://downloads.apache.org/flink/flink-agents-0.2.0/python/flink_agents-0.2.0-py3-none-any.whl
+1. Download [flink-agents 0.2.0 wheel](https://www.apache.org/dyn/closer.lua/flink/flink-agents-0.2.0/python/flink_agents-0.2.0-py3-none-any.whl)
 
-# Install from local wheel
+2. Install from local wheel:
+
+```shell
 pip install flink_agents-0.2.0-py3-none-any.whl apache-flink==${FLINK_VERSION}
 ```
 {{< /hint >}}

--- a/docs/content/docs/get-started/installation.md
+++ b/docs/content/docs/get-started/installation.md
@@ -112,7 +112,15 @@ Choose one of the following installation methods:
 #### From Official Release
 
 {{< hint warning >}}
-__Note:__ This will be available after Flink Agents is released.
+__Temporary (v0.2.0):__ Due to PyPI wheel size limitations, the `flink-agents` version 0.2.0 is currently not available directly from PyPI. Please download the wheel file manually and install from local:
+
+```shell
+# Download the wheel file
+wget [URL]
+
+# Install from local wheel
+pip install flink_agents-0.2.0-py3-none-any.whl apache-flink==${FLINK_VERSION}
+```
 {{< /hint >}}
 
 Install Flink Agents using pip:

--- a/docs/content/docs/get-started/installation.md
+++ b/docs/content/docs/get-started/installation.md
@@ -116,7 +116,7 @@ __Temporary (v0.2.0):__ Due to PyPI wheel size limitations, the `flink-agents` v
 
 ```shell
 # Download the wheel file
-wget [URL]
+wget https://downloads.apache.org/flink/flink-agents-0.2.0/python/flink_agents-0.2.0-py3-none-any.whl
 
 # Install from local wheel
 pip install flink_agents-0.2.0-py3-none-any.whl apache-flink==${FLINK_VERSION}


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #xxx

### Purpose of change

Due to PyPI wheel size limitations, the `flink-agents` version 0.2.0 is currently not available directly from PyPI. We provide a workaround in the docs.

__Update the URL before Merging!__

### Tests

<!-- How is this change verified? -->

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
