### PR TITLE
[hotfix] Explicitly limit version for onnxruntime for python 3.10.

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -54,6 +54,8 @@ dependencies = [
     "openai>=1.66.3",
     "anthropic>=0.64.0",
     "chromadb==1.0.21",
+    "onnxruntime<1.24.1;python_version<'3.11'",
+    "onnxruntime>=1.24.1;python_version>='3.11'",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->


### Purpose of change

Onnxruntime is a transitive dependency introduced by chromadb, which is used for generating embedding. 

From onnxruntime 1.24.1, python 3.10 wheels are no longer published. We should explicitly limit the version in flink-agents for python 3.10.

### Tests

existing python ut tests

### API

No

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
