### PR TITLE
[hotfix][mcp] Fix MCPTool Jackson deserialization by ignoring unknown properties

### DIFF
--- a/integrations/mcp/src/main/java/org/apache/flink/agents/integrations/mcp/MCPTool.java
+++ b/integrations/mcp/src/main/java/org/apache/flink/agents/integrations/mcp/MCPTool.java
@@ -20,6 +20,7 @@ package org.apache.flink.agents.integrations.mcp;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.agents.api.tools.Tool;
 import org.apache.flink.agents.api.tools.ToolMetadata;
@@ -38,6 +39,7 @@ import java.util.Objects;
  * <p>This represents a single tool from an MCP server. It extends the base Tool class and delegates
  * actual execution to the MCP server.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class MCPTool extends Tool {
 
     private static final String FIELD_MCP_SERVER = "mcpServer";

--- a/integrations/mcp/src/test/java/org/apache/flink/agents/integrations/mcp/MCPToolTest.java
+++ b/integrations/mcp/src/test/java/org/apache/flink/agents/integrations/mcp/MCPToolTest.java
@@ -36,6 +36,27 @@ class MCPToolTest {
 
     @Test
     @DisabledOnJre(JRE.JAVA_11)
+    @DisplayName("JSON deserialization works with default ObjectMapper (no FAIL_ON_UNKNOWN_PROPERTIES override)")
+    void testJsonDeserializationWithDefaultMapper() throws Exception {
+        ToolMetadata metadata =
+                new ToolMetadata("add", "Add two numbers", "{\"type\":\"object\"}");
+        MCPServer server = new MCPServer(DEFAULT_ENDPOINT);
+        MCPTool original = new MCPTool(metadata, server);
+
+        // Use a default ObjectMapper — this would fail without @JsonIgnoreProperties
+        // because Tool.getName()/getDescription() are serialized but MCPTool's
+        // @JsonCreator only accepts metadata + mcpServer.
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(original);
+        MCPTool deserialized = mapper.readValue(json, MCPTool.class);
+
+        assertThat(deserialized.getName()).isEqualTo("add");
+        assertThat(deserialized.getMetadata()).isEqualTo(metadata);
+        assertThat(deserialized.getMcpServer()).isEqualTo(server);
+    }
+
+    @Test
+    @DisabledOnJre(JRE.JAVA_11)
     @DisplayName("Create MCPTool with metadata and server")
     void testCreation() {
         ToolMetadata metadata = new ToolMetadata("add", "Add two numbers", "{\"type\":\"object\"}");


### PR DESCRIPTION
## What is the purpose of the change

`MCPTool` deserialization fails with `UnrecognizedPropertyException` when a default `ObjectMapper` encounters the `name` and `description` fields serialized from the parent `Tool` class. These fields are not declared in `MCPTool`'s `@JsonCreator` constructor.

This breaks checkpoint/restore and any JSON round-trip of `MCPTool`.

## Brief change log

- Add `@JsonIgnoreProperties(ignoreUnknown = true)` to `MCPTool`
- Add regression test `testJsonDeserializationWithDefaultMapper` that uses a default `ObjectMapper` (the existing `testJsonSerialization` masked the bug by disabling `FAIL_ON_UNKNOWN_PROPERTIES` globally)

## Does this pull request potentially affect one of the following parts

- Runtime: yes (checkpoint/restore of MCP tool state)
- Integration: yes (MCP module)

## Documentation

N/A — bug fix only

## Documentation

- [ ] `doc-needed` 
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` 
