### PR TITLE
[hotfix] Fix onnxruntime build failure on macOS x86_64

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -55,7 +55,6 @@ dependencies = [
     "anthropic>=0.64.0",
     "chromadb==1.0.21",
     "onnxruntime<1.24.1;python_version<'3.11'",
-    "onnxruntime>=1.24.1;python_version>='3.11'",
 ]
 
 [tool.setuptools]
@@ -110,7 +109,7 @@ members = ["."]
 [tool.uv]
 # Configure required environments for platform compatibility
 required-environments = [
-    "sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "sys_platform == 'darwin'",
     "sys_platform == 'linux'",
     "sys_platform == 'win32'",
 ]

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -78,6 +78,7 @@ if $build_python; then
   cd python
   rm -rf dist/  # Clean old build artifacts before building
   pip install uv
+  uv lock
   uv sync --extra dev
   uv run python -m build
   uv pip install dist/*.whl


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #xxx

### Purpose of change

Recently we added `onnxruntime>=1.24.1` requirement for Python 3.11+, but `onnxruntime` dropped macOS x86_64 wheel support since `1.24.1` ([release notes](https://github.com/Microsoft/onnxruntime/releases/tag/v1.24.1)). 

This cause build failure when Python 3.11+ is built for x86_64:
```
Using CPython 3.11.9 interpreter at: /export/apps/python/3.11/bin/python3
Creating virtual environment at: .venv
Resolved 124 packages in 591ms
warning: `google-auth==2.46.0` is yanked (reason: "incompatibility with Python 3.8")
warning: `numpy==2.4.0` is yanked (reason: "Backward compatibility bug")
error: Distribution `onnxruntime==1.24.1 @ registry+https://pypi.org/simple` can't be installed because it doesn't have a source distribution or wheel for the current platform

hint: You're on macOS (`macosx_26_0_x86_64`), but `onnxruntime` (v1.24.1) only has wheels for the following platforms: `manylinux_2_27_aarch64`, `manylinux_2_27_x86_64`, `manylinux_2_28_aarch64`, `manylinux_2_28_x86_64`, `macosx_14_0_arm64`, `win_amd64`; consider adding "sys_platform == 'darwin' and platform_machine == 'x86_64'" to `tool.uv.required-environments` to ensure uv resolves to a version with compatible wheels
error: Distribution `onnxruntime==1.24.1 @ registry+https://pypi.org/simple` can't be installed because it doesn't have a source distribution or wheel for the current platform

hint: You're on macOS (`macosx_26_0_x86_64`), but `onnxruntime` (v1.24.1) only has wheels for the following platforms: `manylinux_2_27_aarch64`, `manylinux_2_27_x86_64`, `manylinux_2_28_aarch64`, `manylinux_2_28_x86_64`, `macosx_14_0_arm64`, `win_amd64`; consider adding "sys_platform == 'darwin' and platform_machine == 'x86_64'" to `tool.uv.required-environments` to ensure uv resolves to a version with compatible wheels
error: The wheel filename "*.whl" is invalid: Must have a version
```

Since `onnxruntime` is transitive dependency from `chromadb`, I think no need to pin minimum version. We can just let `chromadb` pull the compatible version.

Changes:
  1. Remove `onnxruntime>=1.24.1` floor for Python 3.11
  2. Broaden `required-environments` from `darwin + arm64` to `darwin` so `uv lock` consider all macOS
   architecture
  3. Add `uv lock` step in build script before `uv sync` to make sure lockfile is regenerated

### Tests

<!-- How is this change verified? -->

Run `./tools/build.sh` on MacOS laptop

### API

<!-- Does this change touches any public APIs? -->

N / A

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->