### PR TITLE
[hotfix][mcp] Fix MCPTool Jackson deserialization by ignoring unknown properties

### DIFF
--- a/api/src/main/java/org/apache/flink/agents/api/tools/Tool.java
+++ b/api/src/main/java/org/apache/flink/agents/api/tools/Tool.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.agents.api.tools;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.agents.api.resource.ResourceType;
 import org.apache.flink.agents.api.resource.SerializableResource;
 
@@ -41,6 +42,7 @@ public abstract class Tool extends SerializableResource {
     }
 
     /** Return resource type of class. */
+    @JsonIgnore
     @Override
     public final ResourceType getResourceType() {
         return ResourceType.TOOL;
@@ -53,11 +55,13 @@ public abstract class Tool extends SerializableResource {
     public abstract ToolResponse call(ToolParameters parameters);
 
     /** Get the tool name from metadata. */
+    @JsonIgnore
     public final String getName() {
         return metadata.getName();
     }
 
     /** Get the tool description from metadata. */
+    @JsonIgnore
     public final String getDescription() {
         return metadata.getDescription();
     }

--- a/integrations/mcp/src/test/java/org/apache/flink/agents/integrations/mcp/MCPToolTest.java
+++ b/integrations/mcp/src/test/java/org/apache/flink/agents/integrations/mcp/MCPToolTest.java
@@ -36,6 +36,35 @@ class MCPToolTest {
 
     @Test
     @DisabledOnJre(JRE.JAVA_11)
+    @DisplayName(
+            "JSON round-trip works because @JsonIgnore on Tool getters prevents redundant fields")
+    void testJsonDeserializationWithDefaultMapper() throws Exception {
+        ToolMetadata metadata = new ToolMetadata("add", "Add two numbers", "{\"type\":\"object\"}");
+        MCPServer server = MCPServer.builder(DEFAULT_ENDPOINT).build();
+        MCPTool original = new MCPTool(metadata, server);
+
+        // Use a default ObjectMapper — @JsonIgnore on Tool.getName()/getDescription()/
+        // getResourceType() prevents these from being serialized, so deserialization
+        // succeeds without needing @JsonIgnoreProperties on MCPTool.
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(original);
+
+        // Verify redundant top-level fields are not serialized
+        // (name/description inside metadata are expected)
+        com.fasterxml.jackson.databind.JsonNode tree = mapper.readTree(json);
+        assertThat(tree.has("name")).isFalse();
+        assertThat(tree.has("description")).isFalse();
+        assertThat(tree.has("resourceType")).isFalse();
+
+        MCPTool deserialized = mapper.readValue(json, MCPTool.class);
+
+        assertThat(deserialized.getName()).isEqualTo("add");
+        assertThat(deserialized.getMetadata()).isEqualTo(metadata);
+        assertThat(deserialized.getMcpServer()).isEqualTo(server);
+    }
+
+    @Test
+    @DisabledOnJre(JRE.JAVA_11)
     @DisplayName("Create MCPTool with metadata and server")
     void testCreation() {
         ToolMetadata metadata = new ToolMetadata("add", "Add two numbers", "{\"type\":\"object\"}");


### PR DESCRIPTION
## What is the purpose of the change

`MCPTool` deserialization fails with `UnrecognizedPropertyException` when a default `ObjectMapper` encounters the `name` and `description` fields serialized from the parent `Tool` class. These fields are not declared in `MCPTool`'s `@JsonCreator` constructor.

This breaks checkpoint/restore and any JSON round-trip of `MCPTool`.

## Brief change log

- Add `@JsonIgnoreProperties(ignoreUnknown = true)` to `MCPTool`
- Add regression test `testJsonDeserializationWithDefaultMapper` that uses a default `ObjectMapper` (the existing `testJsonSerialization` masked the bug by disabling `FAIL_ON_UNKNOWN_PROPERTIES` globally)

## Does this pull request potentially affect one of the following parts

- Runtime: yes (checkpoint/restore of MCP tool state)
- Integration: yes (MCP module)

## Documentation

N/A — bug fix only

## Documentation

- [ ] `doc-needed` 
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` 
