### PR TITLE
[FLINK-AGENTS] Fix Java agents failing to connect to MCP servers without prompt support (#538)

### DIFF
--- a/integrations/mcp/src/main/java/org/apache/flink/agents/integrations/mcp/MCPServer.java
+++ b/integrations/mcp/src/main/java/org/apache/flink/agents/integrations/mcp/MCPServer.java
@@ -42,6 +42,7 @@ import java.net.URI;
 import java.net.http.HttpRequest;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -361,6 +362,21 @@ public class MCPServer extends Resource {
     }
 
     /**
+     * Check if the MCP server supports prompts based on its declared capabilities.
+     *
+     * @return true if the server declared prompt capabilities during initialization
+     */
+    public boolean supportsPrompts() {
+        try {
+            McpSyncClient mcpClient = getClient();
+            McpSchema.ServerCapabilities caps = mcpClient.getServerCapabilities();
+            return caps != null && caps.prompts() != null;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
      * List available tools from the MCP server.
      *
      * @return List of MCPTool instances
@@ -456,6 +472,9 @@ public class MCPServer extends Resource {
      * @return List of MCPPrompt instances
      */
     public List<MCPPrompt> listPrompts() {
+        if (!supportsPrompts()) {
+            return Collections.emptyList();
+        }
         return getRetryExecutor()
                 .execute(
                         () -> {

--- a/integrations/mcp/src/test/java/org/apache/flink/agents/integrations/mcp/MCPServerTest.java
+++ b/integrations/mcp/src/test/java/org/apache/flink/agents/integrations/mcp/MCPServerTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.condition.JRE;
 
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
@@ -269,5 +270,15 @@ class MCPServerTest {
         assertThat(server.getMaxRetries()).isEqualTo(5);
         assertThat(server.getInitialBackoffMs()).isEqualTo(200);
         assertThat(server.getMaxBackoffMs()).isEqualTo(5000);
+    }
+
+    @Test
+    @DisabledOnJre(JRE.JAVA_11)
+    @DisplayName("listPrompts returns empty list when server does not support prompts")
+    void testListPromptsReturnsEmptyWhenNotSupported() {
+        MCPServer server = MCPServer.builder(DEFAULT_ENDPOINT).build();
+
+        List<MCPPrompt> prompts = server.listPrompts();
+        assertThat(prompts).isEmpty();
     }
 }


### PR DESCRIPTION
Linked issue: #538

## What is the purpose of the change

Fix Java agents failing with `McpError: Method not found` when connecting to MCP servers that don't support prompts (e.g., AgentCore Gateway). PR #447 fixed the Python path (#412) but the Java path in `AgentPlan.extractJavaMCPServer` was not addressed.

## Brief change log

- Add `MCPServer.supportsPrompts()` — checks `McpSyncClient.getServerCapabilities().prompts() != null`
- Guard `listPrompts` call in `AgentPlan.extractJavaMCPServer` with `supportsPrompts()` via reflection
- Add unit test verifying `supportsPrompts` method exists and is reflection-callable

## Does this pull request potentially affect one of the following parts

- Runtime / Operators: no
- Plan: yes (AgentPlan.extractJavaMCPServer)
- Integrations / MCP: yes (MCPServer.supportsPrompts)

## How was this patch tested?

- Unit test: `MCPServerTest.testSupportsPromptsMethodExists`
- End-to-end: Tested with Amazon Bedrock AgentCore Gateway (tools-only MCP server, `capabilities.prompts=null`). Agent plan creation succeeds, tools are discovered, Flink job completes successfully.

### Documentation

- [x] `doc-not-needed`
