### PR TITLE
[hotfix][doc] Use version 0.2.0 rather than 0.2-SNAPSHOT in maven dependency doc.

### DIFF
--- a/docs/content/docs/get-started/installation.md
+++ b/docs/content/docs/get-started/installation.md
@@ -191,7 +191,7 @@ For execution in IDE, enable the feature `add dependencies with provided scope t
 ```xml
 <properties>
     <flink.version>2.2</flink.version>
-    <flink-agents.version>0.2-SNAPSHOT</flink-agents.version>
+    <flink-agents.version>0.2.0</flink-agents.version>
 </properties>
 
 <dependencies>


### PR DESCRIPTION


<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #xxx

### Purpose of change

<!-- What is the purpose of this change? -->

### Tests

<!-- How is this change verified? -->

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
