### PR TITLE
Cross Language Unified Event

### DIFF
--- a/api/src/main/java/org/apache/flink/agents/api/Event.java
+++ b/api/src/main/java/org/apache/flink/agents/api/Event.java
@@ -19,34 +19,94 @@
 package org.apache.flink.agents.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
-/** Base class for all event types in the system. */
-public abstract class Event {
+/**
+ * Base class for all event types in the system.
+ *
+ * <p>This class serves dual purposes:
+ *
+ * <ul>
+ *   <li><b>Unified events</b>: Instantiated directly with a user-defined {@code type} string and
+ *       arbitrary key-value {@code attributes}. No subclassing required.
+ *   <li><b>Subclassed events</b>: Traditional usage where concrete subclasses (e.g., {@link
+ *       InputEvent}) extend this class. The {@code type} defaults to the fully qualified class
+ *       name.
+ * </ul>
+ */
+public class Event {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     private final UUID id;
+    private final String type;
     private final Map<String, Object> attributes;
     /** The timestamp of the source record. */
     private Long sourceTimestamp;
 
+    /** Unified event with user-defined type and properties. */
+    public Event(String type, Map<String, Object> attributes) {
+        this(UUID.randomUUID(), type, attributes);
+    }
+
+    /** Unified event with user-defined type and empty properties. */
+    public Event(String type) {
+        this(type, new HashMap<>());
+    }
+
+    /** Subclasses that don't set type (defaults to class name). */
     public Event() {
-        this(UUID.randomUUID(), new HashMap<>());
+        this(UUID.randomUUID(), null, new HashMap<>());
+    }
+
+    /** Subclasses with id and attributes but no explicit type. */
+    public Event(UUID id, Map<String, Object> attributes) {
+        this(id, null, attributes);
     }
 
     @JsonCreator
     public Event(
             @JsonProperty("id") UUID id,
+            @JsonProperty("type") String type,
             @JsonProperty("attributes") Map<String, Object> attributes) {
         this.id = id;
-        this.attributes = attributes;
+        this.type = type;
+        this.attributes = attributes != null ? attributes : new HashMap<>();
     }
 
     public UUID getId() {
         return id;
+    }
+
+    /**
+     * Returns the event type used for routing.
+     *
+     * <p>For unified events, returns the user-defined type string. For subclasses, defaults to the
+     * fully qualified class name.
+     *
+     * <p>Note: This method is {@link JsonIgnore}d so Jackson uses {@link #getRawType()} for the
+     * "type" JSON property, preserving null for subclassed events.
+     */
+    @JsonIgnore
+    public String getType() {
+        return type != null ? type : this.getClass().getName();
+    }
+
+    /**
+     * Returns the raw type field value, which may be null for subclassed events. This is used by
+     * Jackson for serialization of the "type" JSON property.
+     */
+    @JsonProperty("type")
+    public String getRawType() {
+        return type;
     }
 
     public Map<String, Object> getAttributes() {
@@ -73,17 +133,33 @@ public abstract class Event {
         this.sourceTimestamp = timestamp;
     }
 
+    /**
+     * Creates an Event from a JSON string.
+     *
+     * @param json the JSON string to deserialize
+     * @return the deserialized Event
+     * @throws IOException if parsing fails or the 'type' field is missing
+     */
+    public static Event fromJson(String json) throws IOException {
+        Event event = MAPPER.readValue(json, Event.class);
+        if (event.type == null || event.type.isEmpty()) {
+            throw new IllegalArgumentException("Event JSON must contain a 'type' field.");
+        }
+        return event;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Event other = (Event) o;
         return Objects.equals(this.id, other.id)
+                && Objects.equals(this.getType(), other.getType())
                 && Objects.equals(this.attributes, other.attributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, attributes);
+        return Objects.hash(id, getType(), attributes);
     }
 }

--- a/api/src/main/java/org/apache/flink/agents/api/EventContext.java
+++ b/api/src/main/java/org/apache/flink/agents/api/EventContext.java
@@ -25,25 +25,47 @@ import java.time.Instant;
 
 /** Contextual information about an event, such as its type and timestamp. */
 public class EventContext {
-    // Type of the event, the class name of the event
+    /**
+     * The routing key for the event. For subclassed events this is the FQN class name; for unified
+     * events this is the user-defined type string.
+     */
     private final String eventType;
+
+    /**
+     * The fully qualified Java class name used for deserialization. For unified events (no
+     * subclass), this is {@code "org.apache.flink.agents.api.Event"}.
+     */
+    private final String eventClass;
+
     // Timestamp of when the event occurred
     private final String timestamp;
 
     public EventContext(Event event) {
-        this(event.getClass().getName(), Instant.now().toString());
+        this(event.getType(), event.getClass().getName(), Instant.now().toString());
     }
 
+    /** Backward-compat constructor without eventClass (defaults to eventType). */
     @JsonCreator
     public EventContext(
             @JsonProperty("eventType") String eventType,
+            @JsonProperty("eventClass") String eventClass,
             @JsonProperty("timestamp") String timestamp) {
         this.eventType = eventType;
+        this.eventClass = eventClass != null ? eventClass : eventType;
         this.timestamp = timestamp;
+    }
+
+    /** Backward-compat: two-arg constructor (eventClass defaults to eventType). */
+    public EventContext(String eventType, String timestamp) {
+        this(eventType, eventType, timestamp);
     }
 
     public String getEventType() {
         return eventType;
+    }
+
+    public String getEventClass() {
+        return eventClass;
     }
 
     public String getTimestamp() {

--- a/api/src/main/java/org/apache/flink/agents/api/EventContext.java
+++ b/api/src/main/java/org/apache/flink/agents/api/EventContext.java
@@ -44,7 +44,6 @@ public class EventContext {
         this(event.getType(), event.getClass().getName(), Instant.now().toString());
     }
 
-    /** Backward-compat constructor without eventClass (defaults to eventType). */
     @JsonCreator
     public EventContext(
             @JsonProperty("eventType") String eventType,
@@ -55,7 +54,6 @@ public class EventContext {
         this.timestamp = timestamp;
     }
 
-    /** Backward-compat: two-arg constructor (eventClass defaults to eventType). */
     public EventContext(String eventType, String timestamp) {
         this(eventType, eventType, timestamp);
     }

--- a/api/src/main/java/org/apache/flink/agents/api/annotation/Action.java
+++ b/api/src/main/java/org/apache/flink/agents/api/annotation/Action.java
@@ -31,23 +31,40 @@ import java.lang.annotation.Target;
  * <p>This annotation specifies which event types the action should respond to. The annotated method
  * will be triggered when any of the specified event types occur.
  *
+ * <p>Events can be specified either as concrete Event subclasses via {@link #listenEvents()}, or as
+ * plain type strings via {@link #listenEventTypes()}. At least one of the two must be non-empty.
+ *
  * <p>Example usage:
  *
  * <pre>{@code
+ * // Class-based (existing pattern)
  * @Action(listenEvents = {InputEvent.class, CustomEvent.class})
- * public void handleEvents(Event event) {
- *     // Action logic here
- * }
+ * public void handleEvents(Event event) { ... }
+ *
+ * // String-based (unified events)
+ * @Action(listenEventTypes = {"MyCustomEvent", "AnotherEvent"})
+ * public void handleUnifiedEvents(Event event) { ... }
+ *
+ * // Mixed
+ * @Action(listenEvents = {InputEvent.class}, listenEventTypes = {"MyCustomEvent"})
+ * public void handleMixed(Event event) { ... }
  * }</pre>
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Action {
     /**
-     * List of event types that this action should respond to. At least one event type must be
-     * specified.
+     * List of event classes that this action should respond to.
      *
      * @return Array of Event classes that this action listens to
      */
-    Class<? extends Event>[] listenEvents();
+    Class<? extends Event>[] listenEvents() default {};
+
+    /**
+     * List of event type strings that this action should respond to. Used for unified events that
+     * don't have a corresponding Java class.
+     *
+     * @return Array of event type strings
+     */
+    String[] listenEventTypes() default {};
 }

--- a/api/src/test/java/org/apache/flink/agents/api/EventTest.java
+++ b/api/src/test/java/org/apache/flink/agents/api/EventTest.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.api;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Unit tests for the unified {@link Event} design. */
+class EventTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    // ── Unified event construction ─────────────────────────────────────────
+
+    @Test
+    void testUnifiedEventWithTypeAndAttributes() {
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put("field1", "hello");
+        attrs.put("field2", 42);
+
+        Event event = new Event("MyCustomEvent", attrs);
+
+        assertEquals("MyCustomEvent", event.getType());
+        assertEquals("MyCustomEvent", event.getRawType());
+        assertEquals("hello", event.getAttr("field1"));
+        assertEquals(42, event.getAttr("field2"));
+        assertNotNull(event.getId());
+    }
+
+    @Test
+    void testUnifiedEventWithTypeOnly() {
+        Event event = new Event("SimpleEvent");
+
+        assertEquals("SimpleEvent", event.getType());
+        assertEquals("SimpleEvent", event.getRawType());
+        assertTrue(event.getAttributes().isEmpty());
+    }
+
+    // ── Subclassed event fallback ──────────────────────────────────────────
+
+    @Test
+    void testSubclassedEventGetTypeFallsBackToClassName() {
+        InputEvent inputEvent = new InputEvent("data");
+
+        // getType() should return the FQN class name for subclassed events
+        assertEquals("org.apache.flink.agents.api.InputEvent", inputEvent.getType());
+
+        // getRawType() should return null (no explicit type set)
+        assertNull(inputEvent.getRawType());
+    }
+
+    @Test
+    void testBaseEventGetTypeFallsBackToClassName() {
+        Event event = new Event();
+
+        assertEquals("org.apache.flink.agents.api.Event", event.getType());
+        assertNull(event.getRawType());
+    }
+
+    // ── JSON serialization ─────────────────────────────────────────────────
+
+    @Test
+    void testUnifiedEventJsonSerialization() throws Exception {
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put("key", "value");
+
+        Event event = new Event("TestEvent", attrs);
+        String json = objectMapper.writeValueAsString(event);
+        JsonNode node = objectMapper.readTree(json);
+
+        // "type" should be present and match getRawType()
+        assertTrue(node.has("type"));
+        assertEquals("TestEvent", node.get("type").asText());
+
+        // "attributes" should be present
+        assertTrue(node.has("attributes"));
+        assertEquals("value", node.get("attributes").get("key").asText());
+
+        // "id" should be present
+        assertTrue(node.has("id"));
+    }
+
+    @Test
+    void testSubclassedEventJsonSerializationHasNullType() throws Exception {
+        InputEvent event = new InputEvent("test data");
+        String json = objectMapper.writeValueAsString(event);
+        JsonNode node = objectMapper.readTree(json);
+
+        // "type" should be null for subclassed events
+        assertTrue(node.has("type"));
+        assertTrue(node.get("type").isNull());
+
+        // Other fields should be present
+        assertTrue(node.has("input"));
+        assertEquals("test data", node.get("input").asText());
+        assertTrue(node.has("id"));
+    }
+
+    @Test
+    void testUnifiedEventJsonDeserialization() throws Exception {
+        UUID id = UUID.randomUUID();
+        String json =
+                String.format(
+                        "{\"id\":\"%s\",\"type\":\"MyEvent\",\"attributes\":{\"x\":1}}",
+                        id.toString());
+
+        Event event = objectMapper.readValue(json, Event.class);
+
+        assertEquals(id, event.getId());
+        assertEquals("MyEvent", event.getType());
+        assertEquals("MyEvent", event.getRawType());
+        assertEquals(1, event.getAttr("x"));
+    }
+
+    @Test
+    void testSubclassedEventJsonRoundTrip() throws Exception {
+        InputEvent original = new InputEvent("round trip");
+        String json = objectMapper.writeValueAsString(original);
+
+        InputEvent deserialized = objectMapper.readValue(json, InputEvent.class);
+
+        assertEquals(original.getId(), deserialized.getId());
+        assertEquals("round trip", deserialized.getInput());
+
+        // type should remain null after round trip
+        assertNull(deserialized.getRawType());
+        // getType() should still return the class name
+        assertEquals("org.apache.flink.agents.api.InputEvent", deserialized.getType());
+    }
+
+    // ── fromJson ───────────────────────────────────────────────────────────
+
+    @Test
+    void testFromJsonWithValidUnifiedEvent() throws IOException {
+        String json = "{\"type\":\"MyCustomEvent\",\"attributes\":{\"msg\":\"hello\"}}";
+        Event event = Event.fromJson(json);
+
+        assertEquals("MyCustomEvent", event.getType());
+        assertEquals("hello", event.getAttr("msg"));
+    }
+
+    @Test
+    void testFromJsonMissingType() {
+        String json = "{\"attributes\":{\"msg\":\"hello\"}}";
+        assertThrows(IllegalArgumentException.class, () -> Event.fromJson(json));
+    }
+
+    @Test
+    void testFromJsonEmptyType() {
+        String json = "{\"type\":\"\",\"attributes\":{}}";
+        assertThrows(IllegalArgumentException.class, () -> Event.fromJson(json));
+    }
+
+    @Test
+    void testFromJsonInvalidJson() {
+        assertThrows(IOException.class, () -> Event.fromJson("{invalid}"));
+    }
+
+    // ── Attributes ─────────────────────────────────────────────────────────
+
+    @Test
+    void testSetAndGetAttr() {
+        Event event = new Event("Test");
+        event.setAttr("key1", "value1");
+        event.setAttr("key2", 42);
+
+        assertEquals("value1", event.getAttr("key1"));
+        assertEquals(42, event.getAttr("key2"));
+        assertNull(event.getAttr("nonexistent"));
+    }
+
+    // ── Equality ───────────────────────────────────────────────────────────
+
+    @Test
+    void testUnifiedEventEquality() {
+        UUID id = UUID.randomUUID();
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put("k", "v");
+
+        Event a = new Event(id, "T", attrs);
+        Event b = new Event(id, "T", new HashMap<>(attrs));
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    void testUnifiedEventInequality() {
+        Event a = new Event("TypeA");
+        Event b = new Event("TypeB");
+
+        assertNotEquals(a, b);
+    }
+
+    // ── Source timestamp ───────────────────────────────────────────────────
+
+    @Test
+    void testSourceTimestamp() {
+        Event event = new Event("Test");
+        assertFalse(event.hasSourceTimestamp());
+
+        event.setSourceTimestamp(123456789L);
+        assertTrue(event.hasSourceTimestamp());
+        assertEquals(123456789L, event.getSourceTimestamp());
+    }
+}

--- a/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
@@ -296,12 +296,25 @@ public class AgentPlan implements Serializable {
     }
 
     private void extractActions(
-            Class<? extends Event>[] listenEventTypes, Method method, Map<String, Object> config)
+            Class<? extends Event>[] listenEventClasses,
+            String[] listenEventTypeStrings,
+            Method method,
+            Map<String, Object> config)
             throws Exception {
         // Convert event types to string names
         List<String> eventTypeNames = new ArrayList<>();
-        for (Class<? extends Event> eventType : listenEventTypes) {
+        for (Class<? extends Event> eventType : listenEventClasses) {
             eventTypeNames.add(eventType.getName());
+        }
+        for (String eventTypeString : listenEventTypeStrings) {
+            eventTypeNames.add(eventTypeString);
+        }
+
+        if (eventTypeNames.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Action method "
+                            + method.getName()
+                            + " must specify at least one event type via listenEvents or listenEventTypes.");
         }
 
         // Create a JavaFunction for this method
@@ -344,18 +357,19 @@ public class AgentPlan implements Serializable {
                 org.apache.flink.agents.api.annotation.Action actionAnnotation =
                         method.getAnnotation(org.apache.flink.agents.api.annotation.Action.class);
 
-                // Get the event types this action listens to
-                Class<? extends Event>[] listenEventTypes =
+                // Get the event types this action listens to (class-based + string-based)
+                Class<? extends Event>[] listenEventClasses =
                         Objects.requireNonNull(actionAnnotation).listenEvents();
+                String[] listenEventTypeStrings = actionAnnotation.listenEventTypes();
 
-                extractActions(listenEventTypes, method, null);
+                extractActions(listenEventClasses, listenEventTypeStrings, method, null);
             }
         }
 
         for (Map.Entry<String, Tuple3<Class<? extends Event>[], Method, Map<String, Object>>>
                 action : agent.getActions().entrySet()) {
             Tuple3<Class<? extends Event>[], Method, Map<String, Object>> tuple = action.getValue();
-            extractActions(tuple.f0, tuple.f1, tuple.f2);
+            extractActions(tuple.f0, new String[0], tuple.f1, tuple.f2);
         }
     }
 

--- a/python/flink_agents/api/agents/agent.py
+++ b/python/flink_agents/api/agents/agent.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 #################################################################################
 from abc import ABC
-from typing import Any, Callable, Dict, List, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Tuple, Type
 
 from flink_agents.api.events.event import Event
 from flink_agents.api.resource import (
@@ -86,7 +86,7 @@ class Agent(ABC):
     """
 
     _actions: Dict[
-        str, Tuple[List[Union[Type[Event], str]], Callable, Dict[str, Any]]
+        str, Tuple[List[Type[Event] | str], Callable, Dict[str, Any]]
     ]
     _resources: Dict[ResourceType, Dict[str, Any]]
 
@@ -100,7 +100,7 @@ class Agent(ABC):
     @property
     def actions(
         self,
-    ) -> Dict[str, Tuple[List[Union[Type[Event], str]], Callable, Dict[str, Any]]]:
+    ) -> Dict[str, Tuple[List[Type[Event] | str], Callable, Dict[str, Any]]]:
         """Get added actions."""
         return self._actions
 
@@ -112,7 +112,7 @@ class Agent(ABC):
     def add_action(
         self,
         name: str,
-        events: List[Union[Type[Event], str]],
+        events: List[Type[Event] | str],
         func: Callable,
         **config: Any,
     ) -> "Agent":
@@ -129,7 +129,7 @@ class Agent(ABC):
         **config : Any
             Key named arguments can be used by this action in runtime.
 
-        Returns
+        Returns:
         -------
         Agent
             The modified Agent instance.

--- a/python/flink_agents/api/agents/agent.py
+++ b/python/flink_agents/api/agents/agent.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 #################################################################################
 from abc import ABC
-from typing import Any, Callable, Dict, List, Tuple, Type
+from typing import Any, Callable, Dict, List, Tuple, Type, Union
 
 from flink_agents.api.events.event import Event
 from flink_agents.api.resource import (
@@ -85,7 +85,9 @@ class Agent(ABC):
                     )
     """
 
-    _actions: Dict[str, Tuple[List[Type[Event]], Callable, Dict[str, Any]]]
+    _actions: Dict[
+        str, Tuple[List[Union[Type[Event], str]], Callable, Dict[str, Any]]
+    ]
     _resources: Dict[ResourceType, Dict[str, Any]]
 
     def __init__(self) -> None:
@@ -96,7 +98,9 @@ class Agent(ABC):
             self._resources[type] = {}
 
     @property
-    def actions(self) -> Dict[str, Tuple[List[Type[Event]], Callable, Dict[str, Any]]]:
+    def actions(
+        self,
+    ) -> Dict[str, Tuple[List[Union[Type[Event], str]], Callable, Dict[str, Any]]]:
         """Get added actions."""
         return self._actions
 
@@ -106,7 +110,11 @@ class Agent(ABC):
         return self._resources
 
     def add_action(
-        self, name: str, events: List[Type[Event]], func: Callable, **config: Any
+        self,
+        name: str,
+        events: List[Union[Type[Event], str]],
+        func: Callable,
+        **config: Any,
     ) -> "Agent":
         """Add action to agent.
 
@@ -114,14 +122,14 @@ class Agent(ABC):
         ----------
         name : str
             The name of the action, should be unique in the same Agent.
-        events: List[Type[Event]]
-            The type of events listened by this action.
-        func: Callable
+        events : list[Type[Event] | str]
+            Event classes or string identifiers listened by this action.
+        func : Callable
             The function to be executed when receive listened events.
-        **config: Any
+        **config : Any
             Key named arguments can be used by this action in runtime.
 
-        Returns:
+        Returns
         -------
         Agent
             The modified Agent instance.

--- a/python/flink_agents/api/decorators.py
+++ b/python/flink_agents/api/decorators.py
@@ -15,12 +15,12 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 #################################################################################
-from typing import Callable, Type, Union
+from typing import Callable, Type
 
 from flink_agents.api.events.event import Event
 
 
-def action(*listen_events: Union[Type[Event], str]) -> Callable:
+def action(*listen_events: Type[Event] | str) -> Callable:
     """Decorator for marking a function as an agent action.
 
     Each argument can be either an :class:`Event` subclass (class-based routing)
@@ -31,12 +31,12 @@ def action(*listen_events: Union[Type[Event], str]) -> Callable:
     listen_events : Type[Event] | str
         Event classes or type-identifier strings that this action responds to.
 
-    Returns
+    Returns:
     -------
     Callable
         Decorator function that marks the target function with event listeners.
 
-    Raises
+    Raises:
     ------
     AssertionError
         If no events are provided, or if an argument is neither a string nor

--- a/python/flink_agents/api/decorators.py
+++ b/python/flink_agents/api/decorators.py
@@ -15,35 +15,41 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 #################################################################################
-from typing import Callable, Type
+from typing import Callable, Type, Union
 
 from flink_agents.api.events.event import Event
 
 
-def action(*listen_events: Type[Event]) -> Callable:
+def action(*listen_events: Union[Type[Event], str]) -> Callable:
     """Decorator for marking a function as an agent action.
+
+    Each argument can be either an :class:`Event` subclass (class-based routing)
+    or a plain ``str`` (unified-event routing by type identifier).
 
     Parameters
     ----------
-    listen_events : list[Type[Event]]
-        List of event types that this action should respond to.
+    listen_events : Type[Event] | str
+        Event classes or type-identifier strings that this action responds to.
 
-    Returns:
+    Returns
     -------
     Callable
         Decorator function that marks the target function with event listeners.
 
-    Raises:
+    Raises
     ------
     AssertionError
-        If no events are provided to listen to.
+        If no events are provided, or if an argument is neither a string nor
+        an ``Event`` subclass.
     """
     assert len(listen_events) > 0, (
         "action must have at least one event type to listen to"
     )
 
-    for event in listen_events:
-        assert issubclass(event, Event), "action must only listen to event types."
+    for evt in listen_events:
+        assert isinstance(evt, str) or (
+            isinstance(evt, type) and issubclass(evt, Event)
+        ), f"action must listen to Event subclasses or string identifiers, got {evt!r}"
 
     def decorator(func: Callable) -> Callable:
         func._listen_events = listen_events

--- a/python/flink_agents/api/events/event.py
+++ b/python/flink_agents/api/events/event.py
@@ -133,12 +133,12 @@ class Event(BaseModel, extra="allow"):
         json_str : str
             JSON string containing at least a ``type`` field.
 
-        Returns
+        Returns:
         -------
         Event
             The deserialized event.
 
-        Raises
+        Raises:
         ------
         ValueError
             If the ``type`` field is missing or empty.

--- a/python/flink_agents/api/events/event.py
+++ b/python/flink_agents/api/events/event.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 #################################################################################
 import hashlib
-from abc import ABC
+import json
 from typing import Any, Dict
 
 try:
@@ -30,8 +30,16 @@ from pydantic_core import PydanticSerializationError
 from pyflink.common import Row
 
 
-class Event(BaseModel, ABC, extra="allow"):
+class Event(BaseModel, extra="allow"):
     """Base class for all event types in the system.
+
+    This class serves dual purposes:
+
+    - **Unified events**: Instantiated directly with a user-defined ``type``
+      string and arbitrary key-value ``attributes``.  No subclassing required.
+    - **Subclassed events**: Traditional usage where concrete subclasses (e.g.,
+      :class:`InputEvent`) extend this class.  The ``type`` defaults to the
+      fully qualified class name.
 
     Event allows extra properties, but these must be BaseModel instances or JSON
     serializable.
@@ -40,11 +48,17 @@ class Event(BaseModel, ABC, extra="allow"):
     ----------
     id : UUID
         Unique identifier for the event, generated deterministically based on
-        event content. This ensures events with identical content have the same
-        ID, which is critical for ActionStateStore divergence detection.
+        event content.
+    type : str | None
+        User-defined event type for routing.  When *None*, :meth:`get_type`
+        falls back to the fully qualified class name.
+    attributes : Dict[str, Any]
+        Arbitrary key-value properties for unified events.
     """
 
     id: UUID = Field(default=None)
+    type: str | None = Field(default=None)
+    attributes: Dict[str, Any] = Field(default_factory=dict)
 
     @staticmethod
     def __serialize_unknown(field: Any) -> Dict[str, Any]:
@@ -90,6 +104,51 @@ class Event(BaseModel, ABC, extra="allow"):
         # Regenerate ID if content changed (but not if setting 'id' itself)
         if name != "id":
             object.__setattr__(self, "id", self._generate_content_based_id())
+
+    def get_type(self) -> str:
+        """Return the event type used for routing.
+
+        For unified events (where ``type`` is explicitly set), returns the
+        user-defined type string.  For subclasses, defaults to the fully
+        qualified class name (``module.ClassName``).
+        """
+        if self.type is not None:
+            return self.type
+        return f"{self.__class__.__module__}.{self.__class__.__qualname__}"
+
+    def get_attr(self, name: str) -> Any:
+        """Get an attribute value from the attributes map."""
+        return self.attributes.get(name)
+
+    def set_attr(self, name: str, value: Any) -> None:
+        """Set an attribute value in the attributes map."""
+        self.attributes[name] = value
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "Event":
+        """Deserialize a unified event from a JSON string.
+
+        Parameters
+        ----------
+        json_str : str
+            JSON string containing at least a ``type`` field.
+
+        Returns
+        -------
+        Event
+            The deserialized event.
+
+        Raises
+        ------
+        ValueError
+            If the ``type`` field is missing or empty.
+        """
+        data = json.loads(json_str)
+        event = cls.model_validate(data)
+        if event.type is None or event.type == "":
+            msg = "Event JSON must contain a 'type' field."
+            raise ValueError(msg)
+        return event
 
 
 class InputEvent(Event):

--- a/python/flink_agents/api/runner_context.py
+++ b/python/flink_agents/api/runner_context.py
@@ -24,6 +24,8 @@ from flink_agents.api.memory.long_term_memory import BaseLongTermMemory
 from flink_agents.api.metric_group import MetricGroup
 from flink_agents.api.resource import Resource, ResourceType
 
+__all__ = ["AsyncExecutionResult", "RunnerContext"]
+
 if TYPE_CHECKING:
     from flink_agents.api.memory_object import MemoryObject
 
@@ -79,15 +81,51 @@ class RunnerContext(ABC):
     This context provides access to event handling.
     """
 
-    @abstractmethod
-    def send_event(self, event: Event) -> None:
+    def send_event(
+        self,
+        event: Event | None = None,
+        *,
+        identifier: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Send an event to the agent for processing.
+
+        Can be called in two ways:
+
+        1. **Object form** — pass a pre-built :class:`Event` (or subclass)::
+
+               ctx.send_event(OutputEvent(output="hi"))
+
+        2. **Shorthand form** — provide ``identifier`` and key-value attrs::
+
+               ctx.send_event(identifier="MyEvent", field1="test", field2=1)
+
+           This creates a unified ``Event(type=identifier, attributes={...})``.
 
         Parameters
         ----------
-        event : Event
-            The event to be processed by the agent system.
+        event : Event | None
+            A pre-built event object.  Mutually exclusive with *identifier*.
+        identifier : str | None
+            A type-identifier string for unified events.
+        **kwargs : Any
+            Attributes to attach to the unified event (only when using
+            *identifier*).
         """
+        if event is not None and identifier is not None:
+            msg = "Provide either 'event' or 'identifier', not both."
+            raise ValueError(msg)
+        if event is not None:
+            self._send_event(event)
+        elif identifier is not None:
+            self._send_event(Event(type=identifier, attributes=kwargs))
+        else:
+            msg = "Must provide either 'event' or 'identifier'."
+            raise ValueError(msg)
+
+    @abstractmethod
+    def _send_event(self, event: Event) -> None:
+        """Low-level event dispatch — implemented by each runner context."""
 
     @abstractmethod
     def get_resource(self, name: str, type: ResourceType, metric_group: MetricGroup = None) -> Resource:

--- a/python/flink_agents/api/tests/test_decorators.py
+++ b/python/flink_agents/api/tests/test_decorators.py
@@ -62,3 +62,36 @@ def test_action_decorator_listen_non_event_type() -> None:  # noqa D103
         def forward_action(event: Event, ctx: RunnerContext) -> None:
             input = event.input
             ctx.send_event(OutputEvent(output=input))
+
+
+# ── String identifier tests ──────────────────────────────────────────────
+
+
+def test_action_decorator_with_string_identifier() -> None:
+    """Test that @action accepts a string identifier."""
+
+    @action("MyCustomEvent")
+    def my_handler(event: Event, ctx: RunnerContext) -> None:
+        pass
+
+    assert hasattr(my_handler, "_listen_events")
+    assert my_handler._listen_events == ("MyCustomEvent",)
+
+
+def test_action_decorator_mixed_class_and_string() -> None:
+    """Test that @action accepts a mix of event classes and strings."""
+
+    @action(InputEvent, "AnotherEvent")
+    def mixed_handler(event: Event, ctx: RunnerContext) -> None:
+        pass
+
+    assert mixed_handler._listen_events == (InputEvent, "AnotherEvent")
+
+
+def test_action_decorator_rejects_invalid_types() -> None:
+    """Test that @action rejects non-Event, non-string arguments."""
+    with pytest.raises(AssertionError):
+
+        @action(42)  # type: ignore[arg-type]
+        def bad_handler(event: Event, ctx: RunnerContext) -> None:
+            pass

--- a/python/flink_agents/api/tests/test_event.py
+++ b/python/flink_agents/api/tests/test_event.py
@@ -45,7 +45,7 @@ def test_event_setattr_non_serializable() -> None:  # noqa D103
         event.c = Type[InputEvent]
 
 
-def test_input_event_ignore_row_unserializable() -> None:  # noqa D103
+def test_input_event_ignore_row_unserializable_basic() -> None:  # noqa D103
     InputEvent(input=Row({"a": 1}))
 
 
@@ -123,5 +123,72 @@ def test_event_with_mixed_serializable_types() -> None:
     assert parsed["input"]["nested_row"]["inner"]["type"] == "Row"
 
 
-def test_input_event_ignore_row_unserializable() -> None:  # noqa D103
+def test_input_event_ignore_row_unserializable_duplicate() -> None:  # noqa D103
     InputEvent(input=Row({"a": 1}))
+
+
+# ── Unified Event tests ──────────────────────────────────────────────────
+
+
+def test_unified_event_creation() -> None:
+    """Test creating a unified event with type and attributes."""
+    event = Event(type="MyEvent", attributes={"field1": "test", "field2": 42})
+    assert event.type == "MyEvent"
+    assert event.attributes == {"field1": "test", "field2": 42}
+    assert event.get_type() == "MyEvent"
+
+
+def test_unified_event_get_type_falls_back_to_class_name() -> None:
+    """Test that get_type() falls back to FQN class name for subclasses."""
+    event = InputEvent(input="hello")
+    assert event.type is None
+    assert event.get_type() == (
+        f"{InputEvent.__module__}.{InputEvent.__qualname__}"
+    )
+
+
+def test_unified_event_base_get_type_no_type_set() -> None:
+    """Test that get_type() returns FQN class name for base Event without type."""
+    event = Event(a=1)
+    assert event.type is None
+    assert event.get_type() == f"{Event.__module__}.{Event.__qualname__}"
+
+
+def test_unified_event_get_attr_set_attr() -> None:
+    """Test get_attr and set_attr convenience methods."""
+    event = Event(type="TestEvent")
+    event.set_attr("key", "value")
+    assert event.get_attr("key") == "value"
+    assert event.get_attr("missing") is None
+
+
+def test_unified_event_from_json() -> None:
+    """Test deserializing a unified event from JSON."""
+    import json
+
+    data = {"type": "MyEvent", "attributes": {"x": 1}}
+    event = Event.from_json(json.dumps(data))
+    assert event.type == "MyEvent"
+    assert event.attributes == {"x": 1}
+
+
+def test_unified_event_from_json_missing_type() -> None:
+    """Test that from_json raises ValueError when type is missing."""
+    import json
+
+    with pytest.raises(ValueError, match="type"):
+        Event.from_json(json.dumps({"attributes": {}}))
+
+
+def test_unified_event_serialization_roundtrip() -> None:
+    """Test that unified events survive JSON serialization/deserialization."""
+    import json
+
+    original = Event(type="RoundTrip", attributes={"a": 1, "b": "two"})
+    json_str = original.model_dump_json()
+    parsed = json.loads(json_str)
+    assert parsed["type"] == "RoundTrip"
+    assert parsed["attributes"] == {"a": 1, "b": "two"}
+    restored = Event.model_validate(parsed)
+    assert restored.type == "RoundTrip"
+    assert restored.attributes == {"a": 1, "b": "two"}

--- a/python/flink_agents/plan/agent_plan.py
+++ b/python/flink_agents/plan/agent_plan.py
@@ -234,6 +234,17 @@ class AgentPlan(BaseModel):
 
 
 
+def _resolve_event_type(evt: Any) -> str:
+    """Convert a listen-event entry to a routing-key string.
+
+    If *evt* is a string, it is passed through as-is (unified-event identifier).
+    If *evt* is a class, its fully qualified name is returned.
+    """
+    if isinstance(evt, str):
+        return evt
+    return f"{evt.__module__}.{evt.__qualname__}"
+
+
 def _get_actions(agent: Agent) -> List[Action]:
     """Extract all registered agent actions from an agent.
 
@@ -255,8 +266,8 @@ def _get_actions(agent: Agent) -> List[Action]:
                     name=name,
                     exec=PythonFunction.from_callable(value.__func__),
                     listen_event_types=[
-                        f"{event_type.__module__}.{event_type.__name__}"
-                        for event_type in value._listen_events
+                        _resolve_event_type(et)
+                        for et in value._listen_events
                     ],
                 )
             )
@@ -266,21 +277,21 @@ def _get_actions(agent: Agent) -> List[Action]:
                     name=name,
                     exec=PythonFunction.from_callable(value),
                     listen_event_types=[
-                        f"{event_type.__module__}.{event_type.__name__}"
-                        for event_type in value._listen_events
+                        _resolve_event_type(et)
+                        for et in value._listen_events
                     ],
                 )
             )
-    for name, action in agent.actions.items():
+    for name, action_tuple in agent.actions.items():
         actions.append(
             Action(
                 name=name,
-                exec=PythonFunction.from_callable(action[1]),
+                exec=PythonFunction.from_callable(action_tuple[1]),
                 listen_event_types=[
-                    f"{event_type.__module__}.{event_type.__name__}"
-                    for event_type in action[0]
+                    _resolve_event_type(et)
+                    for et in action_tuple[0]
                 ],
-                config=action[2],
+                config=action_tuple[2],
             )
         )
     return actions

--- a/python/flink_agents/plan/tests/test_agent_plan.py
+++ b/python/flink_agents/plan/tests/test_agent_plan.py
@@ -317,3 +317,32 @@ def test_add_action_and_resource_to_agent() -> None:  # noqa: D103
     actual = json.loads(json_value)
     expected = json.loads(expected_json)
     assert actual == expected
+
+
+# ── String identifier tests ──────────────────────────────────────────────
+
+
+class StringIdAgent(Agent):
+    """Agent with actions listening to string identifiers."""
+
+    @action("CustomEvent")
+    @staticmethod
+    def handle_custom(event: Event, ctx: RunnerContext) -> None:  # noqa: D102
+        ctx.send_event(OutputEvent(output=event.get_attr("msg")))
+
+
+def test_from_agent_with_string_identifier() -> None:
+    """Test that AgentPlan correctly handles string identifiers."""
+    agent = StringIdAgent()
+    agent_plan = AgentPlan.from_agent(agent, AgentConfiguration())
+
+    # The string identifier should be preserved as-is
+    actions = agent_plan.get_actions("CustomEvent")
+    assert len(actions) == 1
+    assert actions[0].name == "handle_custom"
+    assert "CustomEvent" in actions[0].listen_event_types
+
+    # Verify serialization roundtrip preserves the string identifier
+    json_str = agent_plan.model_dump_json(serialize_as_any=True)
+    restored = AgentPlan.model_validate_json(json_str)
+    assert restored.get_actions("CustomEvent")[0].name == "handle_custom"

--- a/python/flink_agents/runtime/flink_runner_context.py
+++ b/python/flink_agents/runtime/flink_runner_context.py
@@ -218,22 +218,45 @@ class FlinkRunnerContext(RunnerContext):
         self.__ltm = ltm
 
     @override
-    def send_event(self, event: Event) -> None:
+    def _send_event(self, event: Event) -> None:
         """Send an event to the agent for processing.
+
+        Unified events (where ``event.type`` is set) are serialized as JSON and
+        sent via ``sendUnifiedEvent`` so that Java can reconstruct them without
+        cloudpickle.  Subclassed events use the legacy cloudpickle path.
 
         Parameters
         ----------
         event : Event
             The event to be processed by the agent system.
         """
-        class_path = f"{event.__class__.__module__}.{event.__class__.__qualname__}"
-        event_bytes = cloudpickle.dumps(event)
-        event_json_str = _build_event_log_string(event, class_path)
-        try:
-            self._j_runner_context.sendEvent(class_path, event_bytes, event_json_str)
-        except Exception as e:
-            err_msg = "Failed to send event " + class_path + " to runner context"
-            raise RuntimeError(err_msg) from e
+        if event.type is not None:
+            # Unified event — send as JSON to Java
+            event_json = event.model_dump_json()
+            try:
+                self._j_runner_context.sendUnifiedEvent(event_json)
+            except Exception as e:
+                err_msg = (
+                    "Failed to send unified event '"
+                    + event.type
+                    + "' to runner context"
+                )
+                raise RuntimeError(err_msg) from e
+        else:
+            class_path = (
+                f"{event.__class__.__module__}.{event.__class__.__qualname__}"
+            )
+            event_bytes = cloudpickle.dumps(event)
+            event_json_str = _build_event_log_string(event, class_path)
+            try:
+                self._j_runner_context.sendEvent(
+                    class_path, event_bytes, event_json_str
+                )
+            except Exception as e:
+                err_msg = (
+                    "Failed to send event " + class_path + " to runner context"
+                )
+                raise RuntimeError(err_msg) from e
 
     @override
     def get_resource(self, name: str, type: ResourceType, metric_group: MetricGroup = None) -> Resource:

--- a/python/flink_agents/runtime/local_runner.py
+++ b/python/flink_agents/runtime/local_runner.py
@@ -107,7 +107,7 @@ class LocalRunnerContext(RunnerContext):
         return self.__key
 
     @override
-    def send_event(self, event: Event) -> None:
+    def _send_event(self, event: Event) -> None:
         """Send an event to the context's event queue and log it.
 
         Parameters
@@ -326,7 +326,7 @@ class LocalRunner(AgentRunner):
             if isinstance(event, OutputEvent):
                 self.__outputs.append({key: event.output})
                 continue
-            event_type = f"{event.__class__.__module__}.{event.__class__.__name__}"
+            event_type = event.get_type()
             for action in self.__agent_plan.get_actions(event_type):
                 logger.info("key: %s, performing action: %s", key, action.name)
                 context.action_name = action.name

--- a/python/flink_agents/runtime/tests/test_local_execution_environment.py
+++ b/python/flink_agents/runtime/tests/test_local_execution_environment.py
@@ -124,3 +124,78 @@ def test_local_execution_environment_call_from_list_twice() -> None:  # noqa: D1
     env.from_list(input_list)
     with pytest.raises(RuntimeError):
         env.from_list(input_list)
+
+
+# ── Unified event E2E tests ──────────────────────────────────────────────
+
+
+class UnifiedEventAgent(Agent):  # noqa: D101
+    @action(InputEvent)
+    @staticmethod
+    def on_input(event: Event, ctx: RunnerContext) -> None:  # noqa: D102
+        ctx.send_event(
+            identifier="Intermediate", msg=event.input
+        )
+
+    @action("Intermediate")
+    @staticmethod
+    def on_intermediate(event: Event, ctx: RunnerContext) -> None:  # noqa: D102
+        ctx.send_event(
+            OutputEvent(output=f"processed:{event.get_attr('msg')}")
+        )
+
+
+def test_unified_event_workflow() -> None:
+    """End-to-end: InputEvent → unified 'Intermediate' → OutputEvent."""
+    env = AgentsExecutionEnvironment.get_execution_environment()
+
+    input_list = []
+    agent = UnifiedEventAgent()
+
+    output_list = env.from_list(input_list).apply(agent).to_list()
+
+    input_list.append({"key": "alice", "value": "hello"})
+    env.execute()
+
+    assert output_list == [{"alice": "processed:hello"}]
+
+
+class MixedEventAgent(Agent):  # noqa: D101
+    """Agent mixing class-based and string-based event routing."""
+
+    class Step1Event(Event):
+        """Custom class-based event."""
+
+        data: str
+
+    @action(InputEvent)
+    @staticmethod
+    def start(event: Event, ctx: RunnerContext) -> None:  # noqa: D102
+        ctx.send_event(MixedEventAgent.Step1Event(data=str(event.input)))
+
+    @action(Step1Event)
+    @staticmethod
+    def on_step1(event: Event, ctx: RunnerContext) -> None:  # noqa: D102
+        ctx.send_event(identifier="Step2", value=event.data)
+
+    @action("Step2")
+    @staticmethod
+    def on_step2(event: Event, ctx: RunnerContext) -> None:  # noqa: D102
+        ctx.send_event(
+            OutputEvent(output=f"done:{event.get_attr('value')}")
+        )
+
+
+def test_mixed_event_workflow() -> None:
+    """E2E: InputEvent → class Step1Event → unified 'Step2' → OutputEvent."""
+    env = AgentsExecutionEnvironment.get_execution_environment()
+
+    input_list = []
+    agent = MixedEventAgent()
+
+    output_list = env.from_list(input_list).apply(agent).to_list()
+
+    input_list.append({"key": "bob", "value": 42})
+    env.execute()
+
+    assert output_list == [{"bob": "done:42"}]

--- a/python/flink_agents/runtime/tests/test_local_execution_environment.py
+++ b/python/flink_agents/runtime/tests/test_local_execution_environment.py
@@ -160,7 +160,7 @@ def test_unified_event_workflow() -> None:
     assert output_list == [{"alice": "processed:hello"}]
 
 
-class MixedEventAgent(Agent):  # noqa: D101
+class MixedEventAgent(Agent):
     """Agent mixing class-based and string-based event routing."""
 
     class Step1Event(Event):

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/eventlog/EventLogRecordJsonDeserializer.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/eventlog/EventLogRecordJsonDeserializer.java
@@ -35,13 +35,11 @@ import java.io.IOException;
  * <p>This deserializer reconstructs EventLogRecord instances from JSON format by:
  *
  * <ul>
- *   <li>Deserializing the EventContext normally (contains eventType and timestamp)
- *   <li>Using the eventType from context to determine the concrete Event class
- *   <li>Deserializing the event JSON to the appropriate concrete Event type
+ *   <li>Deserializing the EventContext normally (contains eventType, eventClass, and timestamp)
+ *   <li>Using the {@code eventClass} from context to determine the concrete Event class for
+ *       deserialization
+ *   <li>Falling back to {@code eventType} if {@code eventClass} is not present (backward compat)
  * </ul>
- *
- * <p>This approach leverages the eventType information stored in EventContext to handle polymorphic
- * Event deserialization without requiring type annotations on the Event objects themselves.
  */
 public class EventLogRecordJsonDeserializer extends JsonDeserializer<EventLogRecord> {
 
@@ -58,47 +56,48 @@ public class EventLogRecordJsonDeserializer extends JsonDeserializer<EventLogRec
             throw new IOException("Missing 'timestamp' field in EventLogRecord JSON");
         }
 
-        // Deserialize event using eventType from event node
+        // Deserialize event using eventType/eventClass from event node
         JsonNode eventNode = rootNode.get("event");
         if (eventNode == null) {
             throw new IOException("Missing 'event' field in EventLogRecord JSON");
         }
         String eventType = getEventType(eventNode);
+        String eventClass = getEventClass(eventNode, eventType);
 
-        Event event = deserializeEvent(mapper, stripEventType(eventNode), eventType);
-        EventContext eventContext = new EventContext(eventType, timestampNode.asText());
+        Event event = deserializeEvent(mapper, stripMetaFields(eventNode), eventClass);
+        EventContext eventContext = new EventContext(eventType, eventClass, timestampNode.asText());
 
         return new EventLogRecord(eventContext, event);
     }
 
     /**
-     * Deserializes an Event from JSON using the provided event type.
+     * Deserializes an Event from JSON using the eventClass.
      *
      * @param mapper the ObjectMapper to use for deserialization
      * @param eventNode the JSON node containing the event data
-     * @param eventType the fully qualified class name of the event type
-     * @return the deserialized Event instance, or base Event if deserialization fails
+     * @param eventClass the fully qualified Java class name to deserialize into
+     * @return the deserialized Event instance
      */
-    private Event deserializeEvent(ObjectMapper mapper, JsonNode eventNode, String eventType)
+    private Event deserializeEvent(ObjectMapper mapper, JsonNode eventNode, String eventClass)
             throws IOException {
         try {
             // Load the concrete event class
-            Class<?> eventClass =
-                    Class.forName(eventType, true, Thread.currentThread().getContextClassLoader());
+            Class<?> clazz =
+                    Class.forName(eventClass, true, Thread.currentThread().getContextClassLoader());
 
-            // Verify it's actually an Event subclass
-            if (!Event.class.isAssignableFrom(eventClass)) {
+            // Verify it's actually an Event subclass (or Event itself)
+            if (!Event.class.isAssignableFrom(clazz)) {
                 throw new IOException(
-                        String.format("Class '%s' is not a subclass of Event", eventType));
+                        String.format("Class '%s' is not a subclass of Event", eventClass));
             }
 
             // Deserialize to the concrete event type
             @SuppressWarnings("unchecked")
-            Class<? extends Event> concreteEventClass = (Class<? extends Event>) eventClass;
+            Class<? extends Event> concreteEventClass = (Class<? extends Event>) clazz;
             return mapper.treeToValue(eventNode, concreteEventClass);
         } catch (Exception e) {
             throw new IOException(
-                    String.format("Failed to deserialize event of type '%s'", eventType), e);
+                    String.format("Failed to deserialize event of class '%s'", eventClass), e);
         }
     }
 
@@ -110,10 +109,24 @@ public class EventLogRecordJsonDeserializer extends JsonDeserializer<EventLogRec
         return eventTypeNode.asText();
     }
 
-    private static JsonNode stripEventType(JsonNode eventNode) {
+    /**
+     * Gets the eventClass from the event node, falling back to eventType for backward
+     * compatibility.
+     */
+    private static String getEventClass(JsonNode eventNode, String eventType) {
+        JsonNode eventClassNode = eventNode.get("eventClass");
+        if (eventClassNode != null && eventClassNode.isTextual()) {
+            return eventClassNode.asText();
+        }
+        // Backward compat: old logs don't have eventClass, fall back to eventType
+        return eventType;
+    }
+
+    private static JsonNode stripMetaFields(JsonNode eventNode) {
         if (eventNode.isObject()) {
             ObjectNode copy = ((ObjectNode) eventNode).deepCopy();
             copy.remove("eventType");
+            copy.remove("eventClass");
             return copy;
         }
         return eventNode;

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/eventlog/EventLogRecordJsonDeserializer.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/eventlog/EventLogRecordJsonDeserializer.java
@@ -38,7 +38,7 @@ import java.io.IOException;
  *   <li>Deserializing the EventContext normally (contains eventType, eventClass, and timestamp)
  *   <li>Using the {@code eventClass} from context to determine the concrete Event class for
  *       deserialization
- *   <li>Falling back to {@code eventType} if {@code eventClass} is not present (backward compat)
+ *   <li>Falling back to {@code eventType} if {@code eventClass} is not present
  * </ul>
  */
 public class EventLogRecordJsonDeserializer extends JsonDeserializer<EventLogRecord> {
@@ -109,16 +109,11 @@ public class EventLogRecordJsonDeserializer extends JsonDeserializer<EventLogRec
         return eventTypeNode.asText();
     }
 
-    /**
-     * Gets the eventClass from the event node, falling back to eventType for backward
-     * compatibility.
-     */
     private static String getEventClass(JsonNode eventNode, String eventType) {
         JsonNode eventClassNode = eventNode.get("eventClass");
         if (eventClassNode != null && eventClassNode.isTextual()) {
             return eventClassNode.asText();
         }
-        // Backward compat: old logs don't have eventClass, fall back to eventType
         return eventType;
     }
 

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/eventlog/EventLogRecordJsonSerializer.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/eventlog/EventLogRecordJsonSerializer.java
@@ -86,7 +86,8 @@ public class EventLogRecordJsonSerializer extends JsonSerializer<EventLogRecord>
         JsonNode eventNode = mapper.valueToTree(event);
         if (eventNode.isObject()) {
             ObjectNode objectNode = (ObjectNode) eventNode;
-            objectNode.put("eventType", event.getClass().getName());
+            objectNode.put("eventType", event.getType());
+            objectNode.put("eventClass", event.getClass().getName());
             objectNode.remove("sourceTimestamp");
         }
         return eventNode;
@@ -119,6 +120,7 @@ public class EventLogRecordJsonSerializer extends JsonSerializer<EventLogRecord>
     private ObjectNode reorderEventFields(ObjectNode original, Event event, ObjectMapper mapper) {
         ObjectNode ordered = mapper.createObjectNode();
 
+        // eventType — routing key (user-defined string or class name)
         JsonNode eventTypeNode = original.get("eventType");
         if (eventTypeNode != null) {
             ordered.set("eventType", eventTypeNode);
@@ -128,7 +130,15 @@ public class EventLogRecordJsonSerializer extends JsonSerializer<EventLogRecord>
                 ordered.put("eventType", eventType);
             }
         } else {
-            ordered.put("eventType", event.getClass().getName());
+            ordered.put("eventType", event.getType());
+        }
+
+        // eventClass — actual Java class for deserialization
+        JsonNode eventClassNode = original.get("eventClass");
+        if (eventClassNode != null) {
+            ordered.set("eventClass", eventClassNode);
+        } else {
+            ordered.put("eventClass", event.getClass().getName());
         }
 
         JsonNode idNode = original.get("id");

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -832,11 +832,11 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
     }
 
     private List<Action> getActionsTriggeredBy(Event event) {
-        if (event instanceof PythonEvent) {
-            return agentPlan.getActionsTriggeredBy(((PythonEvent) event).getEventType());
-        } else {
-            return agentPlan.getActionsTriggeredBy(event.getClass().getName());
-        }
+        // event.getType() is polymorphic:
+        //   - PythonEvent: returns the Python event type string
+        //   - Unified Event: returns the user-defined type string
+        //   - Subclassed Event: returns the FQN class name
+        return agentPlan.getActionsTriggeredBy(event.getType());
     }
 
     private MailboxProcessor getMailboxProcessor() throws Exception {

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/context/PythonRunnerContextImpl.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/context/PythonRunnerContextImpl.java
@@ -24,9 +24,10 @@ import org.apache.flink.agents.plan.AgentPlan;
 import org.apache.flink.agents.runtime.context.RunnerContextImpl;
 import org.apache.flink.agents.runtime.metrics.FlinkAgentsMetricGroupImpl;
 import org.apache.flink.agents.runtime.python.event.PythonEvent;
-import org.apache.flink.util.Preconditions;
 
 import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.IOException;
 
 /** A specialized {@link RunnerContext} that is specifically used when executing Python actions. */
 @NotThreadSafe
@@ -48,14 +49,28 @@ public class PythonRunnerContextImpl extends RunnerContextImpl {
 
     @Override
     public void sendEvent(Event event) {
-        Preconditions.checkState(
-                event instanceof PythonEvent, "PythonRunnerContext only accept Python event.");
+        // Accept both PythonEvent (legacy class-based) and plain Event (unified events).
         super.sendEvent(event);
     }
 
+    /** Legacy path: invoked by PythonActionExecutor for class-based Python events. */
     public void sendEvent(String type, byte[] event, String eventJsonStr) {
-        // this method will be invoked by PythonActionExecutor's python interpreter.
         sendEvent(new PythonEvent(event, type, eventJsonStr));
+    }
+
+    /**
+     * Sends a unified event from Python to Java.
+     *
+     * <p>Invoked by PythonActionExecutor's interpreter when a Python action sends a unified event
+     * (base Event with a {@code type} string and {@code attributes} map). The event is passed as a
+     * JSON string, deserialized into a Java {@link Event}, and dispatched normally.
+     *
+     * @param eventJson JSON string with at least a {@code "type"} field
+     * @throws IOException if JSON parsing fails
+     */
+    public void sendUnifiedEvent(String eventJson) throws IOException {
+        Event event = Event.fromJson(eventJson);
+        sendEvent(event);
     }
 
     public String getPythonAwaitableRef() {

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/event/PythonEvent.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/event/PythonEvent.java
@@ -69,6 +69,16 @@ public class PythonEvent extends Event {
     }
 
     /**
+     * Returns the Python event type for routing. Overrides the base {@link Event#getType()} so that
+     * both {@code getEventType()} and {@code getType()} return the same value. This makes routing
+     * consistent across all event types.
+     */
+    @Override
+    public String getType() {
+        return eventType;
+    }
+
+    /**
      * Returns the JSON string representation of this event.
      *
      * <p>This string is generated on the Python side when the event is created and is primarily

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/eventlog/EventLogRecordJsonSerdeTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/eventlog/EventLogRecordJsonSerdeTest.java
@@ -195,6 +195,79 @@ class EventLogRecordJsonSerdeTest {
         assertEquals(originalInputEvent.getInput(), deserializedEvent.getInput());
     }
 
+    @Test
+    void testSerializeUnifiedEvent() throws Exception {
+        // Given - a unified event with user-defined type
+        java.util.Map<String, Object> attrs = new java.util.HashMap<>();
+        attrs.put("msg", "hello");
+        Event unifiedEvent = new Event("MyCustomEvent", attrs);
+        EventContext context = new EventContext(unifiedEvent);
+        EventLogRecord record = new EventLogRecord(context, unifiedEvent);
+
+        // When
+        String json = objectMapper.writeValueAsString(record);
+
+        // Then
+        JsonNode jsonNode = objectMapper.readTree(json);
+        JsonNode eventNode = jsonNode.get("event");
+
+        // eventType should be the user-defined type string
+        assertEquals("MyCustomEvent", eventNode.get("eventType").asText());
+        // eventClass should be the base Event class
+        assertEquals("org.apache.flink.agents.api.Event", eventNode.get("eventClass").asText());
+        // attributes should be present
+        assertEquals("hello", eventNode.get("attributes").get("msg").asText());
+    }
+
+    @Test
+    void testDeserializeUnifiedEvent() throws Exception {
+        // Given - a unified event serialized via the EventLogRecord serializer
+        java.util.Map<String, Object> attrs = new java.util.HashMap<>();
+        attrs.put("key", "value");
+        attrs.put("count", 42);
+        Event originalEvent = new Event("CustomType", attrs);
+        EventContext originalContext = new EventContext(originalEvent);
+        EventLogRecord originalRecord = new EventLogRecord(originalContext, originalEvent);
+        String json = objectMapper.writeValueAsString(originalRecord);
+
+        // When
+        EventLogRecord deserializedRecord = objectMapper.readValue(json, EventLogRecord.class);
+
+        // Then
+        EventContext deserializedContext = deserializedRecord.getContext();
+        // eventType is the routing key (user-defined string)
+        assertEquals("CustomType", deserializedContext.getEventType());
+        // eventClass is the deserialization class
+        assertEquals("org.apache.flink.agents.api.Event", deserializedContext.getEventClass());
+
+        // The event should be deserialized as a base Event with the type field set
+        Event deserializedEvent = deserializedRecord.getEvent();
+        assertEquals("CustomType", deserializedEvent.getType());
+        assertEquals("CustomType", deserializedEvent.getRawType());
+    }
+
+    @Test
+    void testRoundTripUnifiedEvent() throws Exception {
+        // Given
+        java.util.Map<String, Object> attrs = new java.util.HashMap<>();
+        attrs.put("x", 1);
+        attrs.put("y", "two");
+        Event originalEvent = new Event("RoundTripEvent", attrs);
+        EventContext context = new EventContext(originalEvent);
+        EventLogRecord record = new EventLogRecord(context, originalEvent);
+
+        // When - serialize and deserialize
+        String json = objectMapper.writeValueAsString(record);
+        EventLogRecord deserialized = objectMapper.readValue(json, EventLogRecord.class);
+
+        // Then
+        assertEquals("RoundTripEvent", deserialized.getContext().getEventType());
+        assertEquals(
+                "org.apache.flink.agents.api.Event", deserialized.getContext().getEventClass());
+        Event event = deserialized.getEvent();
+        assertEquals("RoundTripEvent", event.getType());
+    }
+
     /** Custom test event class for testing polymorphic serialization. */
     public static class CustomTestEvent extends Event {
         private String customData;


### PR DESCRIPTION
Linked issue: #424

### Purpose of change

Add unified event support. Users can create events with a `type` string and `attributes` map instead of defining subclasses. Enables string-based event routing and JSON-based cross-language transport. Fully backward compatible with existing subclassed events.

### Tests

New unit tests in Java (`EventTest`, `EventLogRecordJsonSerdeTest`) and Python (`test_event`, `test_decorators`, `test_agent_plan`, `test_local_execution_environment`) covering unified event creation, serialization, routing, and backward compatibility.

### API

Yes. `Event` class (Java/Python) gains `type`, `attributes`, `getType()`/`get_type()`. `@Action` annotation gains `listenEventTypes()`. `@action` decorator accepts string identifiers. `RunnerContext.send_event()` accepts string identifier with kwargs.

More details about the design in the issue #424

### Documentation

- [x] `doc-needed`
- [ ] `doc-not-needed`
- [ ] `doc-included`