### PR TITLE
[infra] Update the script for sdist release

### DIFF
--- a/tools/releasing/create_binary_release.sh
+++ b/tools/releasing/create_binary_release.sh
@@ -22,6 +22,8 @@
 ##
 SKIP_GPG=${SKIP_GPG:-false}
 MVN=${MVN:-mvn}
+PYTHON_BIN=${PYTHON_BIN:-python3}
+UV=${UV:-uv}
 
 if [ -z "${RELEASE_VERSION:-}" ]; then
     echo "RELEASE_VERSION was not set."
@@ -31,6 +33,7 @@ fi
 # fail immediately
 set -o errexit
 set -o nounset
+set -o pipefail
 # print command before executing
 set -o xtrace
 
@@ -60,8 +63,9 @@ make_binary_release() {
 
   echo "Creating binary release"
 
-  # Dynamically discover dist sub-modules (directories containing pom.xml)
-  # Exclude 'common' module - it's for Python wheel optimization only, not for Maven release
+  # Dynamically discover dist sub-modules (directories containing pom.xml).
+  # Exclude 'common' because it is published to Maven Central for Python installs,
+  # not distributed as a convenience binary.
   DIST_MODULES=()
   for module_dir in dist/*/; do
     if [ -f "${module_dir}pom.xml" ]; then
@@ -99,29 +103,66 @@ make_binary_release() {
 
 make_python_release() {
   FLINK_AGENTS_VERSION=${RELEASE_VERSION/-SNAPSHOT/.dev0}
-  cd python/dist
+  PYTHON_SDIST="flink_agents-${FLINK_AGENTS_VERSION}.tar.gz"
 
-  # Need to move the downloaded wheel packages from Azure CI to the directory flink-python/dist manually.
-  for wheel_file in *.whl; do
-    if [[ ! ${wheel_file} =~ ^flink_agents-$FLINK_AGENTS_VERSION- ]]; then
-        echo -e "\033[31;1mThe file name of the python package: ${wheel_file} is not consistent with given release version: ${FLINK_AGENTS_VERSION}!\033[0m"
-        exit 1
-    fi
-    cp ${wheel_file} "${PYTHON_RELEASE_DIR}/${wheel_file}"
-  done
+  ${PYTHON_BIN} - <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+manifest_path = Path("python/jar_manifest.json")
+manifest = json.loads(manifest_path.read_text())
+release_version = os.environ["RELEASE_VERSION"]
+
+if manifest["version"] != release_version:
+    print(
+        f"jar_manifest.json version mismatch: expected {release_version}, found {manifest['version']}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+missing_sha256 = [
+    jar["artifact_id"]
+    for jar in manifest["jars"]
+    if not jar.get("sha256") or jar["sha256"] == "PLACEHOLDER"
+]
+if missing_sha256:
+    print(
+        "jar_manifest.json still contains placeholder SHA-256 values for: "
+        + ", ".join(missing_sha256),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+PY
+
+  cd python
+
+  if command -v "${UV}" >/dev/null 2>&1; then
+    "${UV}" run --with build "${PYTHON_BIN}" -m build --sdist
+  else
+    "${PYTHON_BIN}" -m build --version >/dev/null 2>&1 || {
+      echo "Neither '${UV}' nor '${PYTHON_BIN} -m build' is available to build the Python sdist."
+      exit 1
+    }
+    "${PYTHON_BIN}" -m build --sdist
+  fi
+
+  if [ ! -f "dist/${PYTHON_SDIST}" ] ; then
+    echo -e "\033[31;1mExpected Python sdist dist/${PYTHON_SDIST} was not produced.\033[0m"
+    exit 1
+  fi
+
+  cp "dist/${PYTHON_SDIST}" "${PYTHON_RELEASE_DIR}/${PYTHON_SDIST}"
 
   cd ${PYTHON_RELEASE_DIR}
 
-  # Sign sha the tgz and wheel packages
+  # Sign and hash the Python sdist.
   if [ "$SKIP_GPG" == "false" ] ; then
-    for wheel_file in *.whl; do
-      gpg --armor --detach-sig "${wheel_file}"
-    done
+    gpg --armor --detach-sig "${PYTHON_SDIST}"
   fi
 
-  for wheel_file in *.whl; do
-    $SHASUM "${wheel_file}" > "${wheel_file}.sha512"
-  done
+  $SHASUM "${PYTHON_SDIST}" > "${PYTHON_SDIST}.sha512"
 
   cd ${FLINK_AGENTS_DIR}
 }

--- a/tools/releasing/update_jar_manifest.sh
+++ b/tools/releasing/update_jar_manifest.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Variables with defaults (if not overwritten by environment)
+##
+PYTHON_BIN=${PYTHON_BIN:-python3}
+REPOSITORY_APACHE_BASE_URL=${REPOSITORY_APACHE_BASE_URL:-https://repository.apache.org/content/repositories}
+
+if [ -z "${RELEASE_VERSION:-}" ]; then
+    echo "RELEASE_VERSION was not set."
+    exit 1
+fi
+
+if [ -z "${STAGING_REPOSITORY_ID:-}" ] && [ -z "${MAVEN_REPOSITORY_URL:-}" ]; then
+    echo "Either STAGING_REPOSITORY_ID or MAVEN_REPOSITORY_URL must be set."
+    exit 1
+fi
+
+# fail immediately
+set -o errexit
+set -o nounset
+set -o pipefail
+# print command before executing
+set -o xtrace
+
+CURR_DIR=`pwd`
+if [[ `basename $CURR_DIR` != "tools" ]] ; then
+  echo "You have to call the script from the tools/ dir"
+  exit 1
+fi
+
+###########################
+
+cd ..
+
+if [ -n "${MAVEN_REPOSITORY_URL:-}" ]; then
+  RESOLVED_MAVEN_REPOSITORY_URL="${MAVEN_REPOSITORY_URL}"
+else
+  RESOLVED_MAVEN_REPOSITORY_URL="${REPOSITORY_APACHE_BASE_URL}/${STAGING_REPOSITORY_ID}"
+fi
+
+RESOLVED_MAVEN_REPOSITORY_URL="${RESOLVED_MAVEN_REPOSITORY_URL%/}"
+MANIFEST_PATH="python/jar_manifest.json"
+
+"${PYTHON_BIN}" - "${MANIFEST_PATH}" "${RELEASE_VERSION}" "${RESOLVED_MAVEN_REPOSITORY_URL}" <<'PY'
+import hashlib
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+release_version = sys.argv[2]
+repository_url = sys.argv[3].rstrip("/")
+
+manifest = json.loads(manifest_path.read_text())
+group_path = manifest["group_id"].replace(".", "/")
+manifest["version"] = release_version
+
+for jar in manifest["jars"]:
+    artifact_id = jar["artifact_id"]
+    classifier = jar.get("classifier")
+    filename = f"{artifact_id}-{release_version}"
+    if classifier:
+        filename = f"{filename}-{classifier}"
+    filename = f"{filename}.jar"
+
+    artifact_url = (
+        f"{repository_url}/{group_path}/{artifact_id}/{release_version}/{filename}"
+    )
+    sha256 = hashlib.sha256()
+    with urllib.request.urlopen(artifact_url) as response:
+        for chunk in iter(lambda: response.read(1024 * 1024), b""):
+            sha256.update(chunk)
+    jar["sha256"] = sha256.hexdigest()
+
+manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+PY


### PR DESCRIPTION
Linked issue: 

### Purpose of change

This change updates the release tooling to match the new Python sdist-based release flow introduced by the JAR download during install design.

Specifically, it:
- adds `tools/releasing/update_jar_manifest.sh` to populate `python/jar_manifest.json` with the release version and SHA-256 checksums from the closed Maven staging repository
- updates `tools/releasing/create_binary_release.sh` to validate `jar_manifest.json`, build the Python sdist locally, and package/sign/hash the sdist instead of relying on manually downloaded wheel artifacts

### Tests


### API

This change does not modify any public APIs.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`
