### PR TITLE
[infra] Use GHA workflow triggers to run pull request labeler workflow

### DIFF
--- a/.github/workflows/pr_edit_trigger.yml
+++ b/.github/workflows/pr_edit_trigger.yml
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: PR-Edit-Trigger
+on:
+  pull_request:
+    types: [edited]
+    branches:
+      - main
+      - release-*
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Do nothing. Just triggers corresponding workflow."
+        run: echo

--- a/.github/workflows/pr_open_trigger.yml
+++ b/.github/workflows/pr_open_trigger.yml
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: PR-Open-Trigger
+on:
+  pull_request:
+    types: [opened]
+    branches:
+      - main
+      - release-*
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Do nothing. Just triggers corresponding workflow."
+        run: echo


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #563 

### Purpose of change
Add PR trigger workflows to enable labeling on release-0.1 branch PRs.

<!-- What is the purpose of this change? -->

### Tests
Test in my repository: https://github.com/GreatEugenius/flink-agents/pull/37
<!-- How is this change verified? -->

### API
No
<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
