### PR TITLE
[infra] Ensure pip is installed in venv.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: 3.12
       - name: Install uv
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
+          curl -LsSf https://astral.sh/uv/0.11.0/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Check code style
         run: ./tools/lint.sh -c
@@ -59,7 +59,7 @@ jobs:
           python-version: '3.12'
       - name: Install uv
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
+          curl -LsSf https://astral.sh/uv/0.11.0/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Run build-backend tests
         working-directory: python
@@ -90,7 +90,7 @@ jobs:
           python-version: '3.12'
       - name: Install uv
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
+          curl -LsSf https://astral.sh/uv/0.11.0/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Install Python dependencies for MCP tests
         run: |
@@ -126,7 +126,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
+          curl -LsSf https://astral.sh/uv/0.11.0/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Run Python Tests
         env:  
@@ -165,7 +165,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
+          curl -LsSf https://astral.sh/uv/0.11.0/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Install flink-agents
         run: bash tools/build.sh
@@ -257,7 +257,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
+          curl -LsSf https://astral.sh/uv/0.11.0/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Build flink-agents
         run: bash tools/build.sh

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -89,7 +89,7 @@ if $build_python; then
   # build python
   cd python
   rm -rf dist/  # Clean old build artifacts before building
-  pip install uv
+  pip install uv==0.11.0
   uv lock
   uv sync --extra dev
   uv run python -m ensurepip --default-pip


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->

### Purpose of change
It appears that after the pulled uv version changed (0.11.0 -> 0.11.1), uv no longer installs pip by default in the virtual environment, causing subsequent builds to fail.

<img width="2172" height="450" alt="image" src="https://github.com/user-attachments/assets/099e253b-4a1a-411e-a264-d287770fd039" />

I added the following command to built.sh to ensure that pip is installed: `uv run python -m ensurepip --default-pip`

### Tests

<!-- How is this change verified? -->

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
