### PR TITLE
[api][runtime][java] Persist reconciler exceptions as failures

### DIFF
--- a/api/src/main/java/org/apache/flink/agents/api/context/DurableCallable.java
+++ b/api/src/main/java/org/apache/flink/agents/api/context/DurableCallable.java
@@ -68,7 +68,7 @@ public interface DurableCallable<T> {
      *   <li>Return the result to provide the recovered successful outcome for this durable call.
      *       The runtime persists and replays that recovered result.
      *   <li>Throw an exception to provide the recovered failed outcome for this durable call. The
-     *       runtime persists that recovered failure and replays it on subsequent recovery.
+     *       runtime persists and replays that recovered failure.
      * </ul>
      */
     default @Nullable Callable<T> reconciler() {

--- a/api/src/main/java/org/apache/flink/agents/api/context/DurableCallable.java
+++ b/api/src/main/java/org/apache/flink/agents/api/context/DurableCallable.java
@@ -67,9 +67,8 @@ public interface DurableCallable<T> {
      * <ul>
      *   <li>Return the result to provide the recovered successful outcome for this durable call.
      *       The runtime persists and replays that recovered result.
-     *   <li>Throw an exception if reconcile cannot provide a successful outcome. The exception is
-     *       propagated to the caller, and the runtime does not persist a recovered terminal outcome
-     *       for this durable call.
+     *   <li>Throw an exception to provide the recovered failed outcome for this durable call. The
+     *       runtime persists that recovered failure and replays it on subsequent recovery.
      * </ul>
      */
     default @Nullable Callable<T> reconciler() {

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/context/RunnerContextImpl.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/context/RunnerContextImpl.java
@@ -482,8 +482,8 @@ public class RunnerContextImpl implements RunnerContext {
      *
      * @param durableCallable durable call that provides the durable execution identity and result
      *     metadata
-     * @param reconcileCallable reconcile boundary used to recover a successful outcome from a
-     *     pending durable call
+     * @param reconcileCallable reconcile boundary used to recover a terminal outcome from a pending
+     *     durable call
      * @param executionCallable concrete execution boundary for the current path when recovery
      *     starts or restarts the original durable call
      */
@@ -523,8 +523,23 @@ public class RunnerContextImpl implements RunnerContext {
                             durableExecutionContext.getCurrentCallIndex(), functionId, argsDigest));
         }
 
-        T reconcileResult = reconcileCallable.call();
-        finalizeCurrentCall(functionId, argsDigest, serializeDurableResult(reconcileResult), null);
+        T reconcileResult = null;
+        Exception reconcileException = null;
+        try {
+            reconcileResult = reconcileCallable.call();
+        } catch (Exception e) {
+            reconcileException = e;
+        }
+
+        finalizeCurrentCall(
+                functionId,
+                argsDigest,
+                serializeDurableResult(reconcileResult),
+                serializeDurableException(reconcileException));
+
+        if (reconcileException != null) {
+            throw reconcileException;
+        }
         return reconcileResult;
     }
 

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/context/RunnerContextImpl.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/context/RunnerContextImpl.java
@@ -523,24 +523,7 @@ public class RunnerContextImpl implements RunnerContext {
                             durableExecutionContext.getCurrentCallIndex(), functionId, argsDigest));
         }
 
-        T reconcileResult = null;
-        Exception reconcileException = null;
-        try {
-            reconcileResult = reconcileCallable.call();
-        } catch (Exception e) {
-            reconcileException = e;
-        }
-
-        finalizeCurrentCall(
-                functionId,
-                argsDigest,
-                serializeDurableResult(reconcileResult),
-                serializeDurableException(reconcileException));
-
-        if (reconcileException != null) {
-            throw reconcileException;
-        }
-        return reconcileResult;
+        return executeAndFinalizeCurrentCall(functionId, argsDigest, reconcileCallable);
     }
 
     protected <T> T executeAndFinalizeCurrentCall(

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/context/JavaRunnerContextImplDurableExecuteAsyncTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/context/JavaRunnerContextImplDurableExecuteAsyncTest.java
@@ -156,7 +156,7 @@ class JavaRunnerContextImplDurableExecuteAsyncTest {
     }
 
     @Test
-    void testDurableExecuteAsyncReconcilableReconcileExceptionPropagates() throws Exception {
+    void testDurableExecuteAsyncReconcilableReconcileExceptionPersistsFailure() throws Exception {
         InspectingContinuationActionExecutor executor = new InspectingContinuationActionExecutor();
         ActionState actionState = new ActionState(null);
         actionState.addCallResult(CallResult.pending("recon-async", ""));
@@ -188,11 +188,11 @@ class JavaRunnerContextImplDurableExecuteAsyncTest {
         assertEquals(0, callable.getCallCount());
         assertEquals(1, callable.getReconcileCount());
         assertEquals(0, executor.getExecuteAsyncCallCount());
-        assertEquals(0, persistCallCount.get());
+        assertEquals(1, persistCallCount.get());
         CallResult persisted =
                 context.getDurableExecutionContext().getActionState().getCallResults().get(0);
-        assertTrue(persisted.isPending());
-        assertEquals(0, context.getDurableExecutionContext().getCurrentCallIndex());
+        assertTrue(persisted.isFailure());
+        assertEquals(1, context.getDurableExecutionContext().getCurrentCallIndex());
     }
 
     private JavaRunnerContextImpl createContext(

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/context/RunnerContextImplDurableExecuteTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/context/RunnerContextImplDurableExecuteTest.java
@@ -217,7 +217,7 @@ class RunnerContextImplDurableExecuteTest {
     }
 
     @Test
-    void testDurableExecuteReconcilableReconcileExceptionPropagates() throws Exception {
+    void testDurableExecuteReconcilableReconcileExceptionPersistsFailure() throws Exception {
         ActionState actionState = new ActionState(null);
         actionState.addCallResult(CallResult.pending("recon-call", ""));
         RunnerContextImpl context = createContext(actionState);
@@ -237,11 +237,11 @@ class RunnerContextImplDurableExecuteTest {
         assertSame(failure, thrown);
         assertEquals(0, callable.getCallCount());
         assertEquals(1, callable.getReconcileCount());
-        assertEquals(0, persistCallCount.get());
+        assertEquals(1, persistCallCount.get());
         CallResult persisted =
                 context.getDurableExecutionContext().getActionState().getCallResults().get(0);
-        assertTrue(persisted.isPending());
-        assertEquals(0, context.getDurableExecutionContext().getCurrentCallIndex());
+        assertTrue(persisted.isFailure());
+        assertEquals(1, context.getDurableExecutionContext().getCurrentCallIndex());
     }
 
     @Test


### PR DESCRIPTION
Linked Issus: #612
Follow-up to #600.

### Purpose of change

- persist reconciler exceptions as recovered terminal failures before rethrowing them
- align the Java reconciler contract and runtime behavior with that exception semantics
- update the sync and async reconciler tests to cover failure persistence instead of pending retention

### Tests

- mvn -pl runtime -am spotless:apply
- mvn -pl runtime -am -Dtest=RunnerContextImplDurableExecuteTest,JavaRunnerContextImplDurableExecuteAsyncTest -Dsurefire.failIfNoSpecifiedTests=false test

### Notes

- This change only covers the Java side. Python runtime and documentation alignment will follow separately.

### Documentation

- [x] `doc-needed`
- [ ] `doc-not-needed`
- [ ] `doc-included`