### PR TITLE
[hotfix] Fix argument name mismatch in PythonVectorStore.

### DIFF
--- a/api/src/main/java/org/apache/flink/agents/api/vectorstores/python/PythonVectorStore.java
+++ b/api/src/main/java/org/apache/flink/agents/api/vectorstores/python/PythonVectorStore.java
@@ -86,7 +86,7 @@ public class PythonVectorStore extends BaseVectorStore implements PythonResource
         kwargs.put("documents", pythonDocuments);
 
         if (collection != null) {
-            kwargs.put("collection", collection);
+            kwargs.put("collection_name", collection);
         }
 
         return (List<String>) adapter.callMethod(vectorStore, "add", kwargs);
@@ -115,7 +115,7 @@ public class PythonVectorStore extends BaseVectorStore implements PythonResource
             kwargs.put("ids", ids);
         }
         if (collection != null) {
-            kwargs.put("collection", collection);
+            kwargs.put("collection_name", collection);
         }
 
         Object pythonDocuments = adapter.callMethod(vectorStore, "get", kwargs);
@@ -132,7 +132,7 @@ public class PythonVectorStore extends BaseVectorStore implements PythonResource
             kwargs.put("ids", ids);
         }
         if (collection != null) {
-            kwargs.put("collection", collection);
+            kwargs.put("collection_name", collection);
         }
         adapter.callMethod(vectorStore, "delete", kwargs);
     }

--- a/api/src/test/java/org/apache/flink/agents/api/vectorstores/python/PythonCollectionManageableVectorStoreTest.java
+++ b/api/src/test/java/org/apache/flink/agents/api/vectorstores/python/PythonCollectionManageableVectorStoreTest.java
@@ -261,7 +261,7 @@ public class PythonCollectionManageableVectorStoreTest {
                         argThat(
                                 kwargs -> {
                                     assertThat(kwargs).containsKey("documents");
-                                    assertThat(kwargs).containsKey("collection");
+                                    assertThat(kwargs).containsKey("collection_name");
                                     assertThat(kwargs).containsKey("batch_size");
                                     return true;
                                 }));
@@ -294,7 +294,7 @@ public class PythonCollectionManageableVectorStoreTest {
                         argThat(
                                 kwargs -> {
                                     assertThat(kwargs).containsKey("ids");
-                                    assertThat(kwargs).containsKey("collection");
+                                    assertThat(kwargs).containsKey("collection_name");
                                     return true;
                                 }));
     }
@@ -317,7 +317,7 @@ public class PythonCollectionManageableVectorStoreTest {
                         argThat(
                                 kwargs -> {
                                     assertThat(kwargs).containsKey("ids");
-                                    assertThat(kwargs).containsKey("collection");
+                                    assertThat(kwargs).containsKey("collection_name");
                                     return true;
                                 }));
     }


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->

### Purpose of change

Fix argument name mismatch in PythonVectorStore.

### Tests

ut & e2e

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
