### PR TITLE
[hotfix] Update rsync for GHA to latest v8.0.2 (LTS)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,7 @@ jobs:
           docker run --rm --volume "$PWD:/root/flink-agents" chesnay/flink-ci:java_8_11_17_21_maven_386 bash -c "cd /root/flink-agents && chmod +x ./tools/docs.sh && ./tools/docs.sh"
 
       - name: Upload documentation
-        uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823
+        uses: burnett01/rsync-deployments@7659d600d8bdd035bb5cdfba1d4bd0dd4a307ca6 # 8.0.2
         with:
           switches: --archive --compress --delete
           path: docs/target/
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload documentation alias
         if: env.flink_alias != ''
-        uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823
+        uses: burnett01/rsync-deployments@7659d600d8bdd035bb5cdfba1d4bd0dd4a307ca6 # 8.0.2
         with:
           switches: --archive --compress --delete
           path: docs/target/


### PR DESCRIPTION
### Purpose of change
Update the rsync GitHub Action from a non-supported version to the latest LTS to resolve issues with documentation builds.
<!-- What is the purpose of this change? -->

### Tests

<!-- How is this change verified? -->

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
