### PR TITLE
[infra] Skip spotless in non-lint CI jobs to isolate code-style failures

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -47,6 +47,8 @@ jobs:
   java_tests:
     name: java tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      SKIP_SPOTLESS_CHECK: true
     strategy:
       fail-fast: false
       matrix:
@@ -90,6 +92,8 @@ jobs:
   e2e_tests:
     name: e2e tests on ${{ matrix.os }} ${{ matrix.python-version}}
     runs-on: ${{ matrix.os }}
+    env:
+      SKIP_SPOTLESS_CHECK: true
     strategy:
       fail-fast: false
       matrix:
@@ -118,6 +122,8 @@ jobs:
   build_python_wheels:
     name: "Build Python Wheels"
     runs-on: ubuntu-latest
+    env:
+      SKIP_SPOTLESS_CHECK: true
     steps:
       - name: "Checkout the repository"
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
   java_tests:
     name: ut-java [${{ matrix.os }}] [java-${{ matrix.java-version}}] [python-3.12]
     runs-on: ${{ matrix.os }}
+    env:
+      SKIP_SPOTLESS_CHECK: true
     strategy:
       fail-fast: false
       matrix:
@@ -136,6 +138,8 @@ jobs:
   python_it_tests:
     name: it-python [${{ matrix.os }}] [java-17] [python-${{ matrix.python-version}}] [flink-${{ matrix.flink-version}}]
     runs-on: ${{ matrix.os }}
+    env:
+      SKIP_SPOTLESS_CHECK: true
     strategy:
       fail-fast: false
       matrix:
@@ -179,6 +183,8 @@ jobs:
   java_it_tests:
     name: it-java [${{ matrix.os }}] [java-${{ matrix.java-version}}] [flink-${{ matrix.flink-version}}]
     runs-on: ${{ matrix.os }}
+    env:
+      SKIP_SPOTLESS_CHECK: true
     strategy:
       fail-fast: false
       matrix:
@@ -214,6 +220,8 @@ jobs:
   cross_language_tests:
     name: cross-language [${{ matrix.os }}] [python-${{ matrix.python-version}}] [java-${{ matrix.java-version}}]
     runs-on: ${{ matrix.os }}
+    env:
+      SKIP_SPOTLESS_CHECK: true
     services:
       elasticsearch:
         image: docker.elastic.co/elasticsearch/elasticsearch:8.19.0

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -41,10 +41,20 @@ CURR_DIR=`pwd`
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 PROJECT_ROOT="${BASE_DIR}/../"
 
+# Skip spotless code-style check when SKIP_SPOTLESS_CHECK is set.
+# Style enforcement is owned by the dedicated `Code Style Check` CI job
+# (and `tools/lint.sh` locally), so other CI jobs append this flag to
+# every mvn invocation to avoid masking real test failures with style
+# violations. Unset (default) preserves local-dev behavior.
+SPOTLESS_FLAG=""
+if [ "${SKIP_SPOTLESS_CHECK}" = "true" ] || [ "${SKIP_SPOTLESS_CHECK}" = "1" ]; then
+    SPOTLESS_FLAG="-Dspotless.skip=true"
+fi
+
 # build java
 if $build_java; then
     mvn --version
-    mvn clean install -DskipTests -B
+    mvn clean install -DskipTests -B ${SPOTLESS_FLAG}
 fi
 
 if $build_python; then

--- a/tools/ut.sh
+++ b/tools/ut.sh
@@ -119,6 +119,16 @@ if $verbose; then
     echo "Will run tests for Flink versions: ${flink_versions[*]}"
 fi
 
+# Skip spotless code-style check when SKIP_SPOTLESS_CHECK is set.
+# Style enforcement is owned by the dedicated `Code Style Check` CI job
+# (and `tools/lint.sh` locally), so other CI jobs append this flag to
+# every mvn invocation to avoid masking real test failures with style
+# violations. Unset (default) preserves local-dev behavior.
+SPOTLESS_FLAG=""
+if [ "${SKIP_SPOTLESS_CHECK}" = "true" ] || [ "${SKIP_SPOTLESS_CHECK}" = "1" ]; then
+    SPOTLESS_FLAG="-Dspotless.skip=true"
+fi
+
 java_tests() {
     if $verbose; then
         echo "Running Java tests..."
@@ -135,7 +145,7 @@ java_tests() {
         done
         dist_modules="${dist_modules#,}"
 
-        mvn --batch-mode --no-transfer-progress install -pl "$dist_modules" -DskipTests
+        mvn --batch-mode --no-transfer-progress install -pl "$dist_modules" -DskipTests ${SPOTLESS_FLAG}
         install_code=$?
         if [ $install_code -ne 0 ]; then
             echo "Failed to install dist packages" >&2
@@ -145,7 +155,7 @@ java_tests() {
         local all_passed=true
         for version in "${flink_versions[@]}"; do
             echo "Running E2E tests for Flink ${version}..."
-            mvn --batch-mode --no-transfer-progress test -pl 'e2e-test/flink-agents-end-to-end-tests-integration' -Pflink-${version}
+            mvn --batch-mode --no-transfer-progress test -pl 'e2e-test/flink-agents-end-to-end-tests-integration' -Pflink-${version} ${SPOTLESS_FLAG}
 
             if [ $? -ne 0 ]; then
                 echo "E2E tests failed for Flink ${version}" >&2
@@ -159,7 +169,7 @@ java_tests() {
         testcode=0
     else
         echo "Installing all modules (including test-jars) to local repository..."
-        mvn --batch-mode --no-transfer-progress test-compile jar:test-jar install -DskipTests
+        mvn --batch-mode --no-transfer-progress test-compile jar:test-jar install -DskipTests ${SPOTLESS_FLAG}
         install_code=$?
         if [ $install_code -ne 0 ]; then
             echo "Failed to install modules to local repository" >&2
@@ -170,7 +180,7 @@ java_tests() {
 
         exclude_list="!e2e-test/flink-agents-end-to-end-tests-integration,!e2e-test/flink-agents-end-to-end-tests-resource-cross-language"
 
-        mvn -T16 --batch-mode --no-transfer-progress test -fae -pl "${exclude_list}"
+        mvn -T16 --batch-mode --no-transfer-progress test -fae -pl "${exclude_list}" ${SPOTLESS_FLAG}
         testcode=$?
     fi
     case $testcode in


### PR DESCRIPTION
Linked issue: #597

### Purpose of change

Decouples code-style enforcement from non-style CI jobs. Today every `mvn install` / `mvn test` triggers `spotless-maven-plugin` because its `check` goal is bound to Maven's `validate` phase (`pom.xml:298-302`). A single style violation cascades across UT, IT, and cross-language jobs and masks genuine test failures — defeating the purpose of having a dedicated `Code Style Check` CI.

After this PR, only the dedicated `Code Style Check` job runs spotless. Every other non-lint CI job sets `SKIP_SPOTLESS_CHECK: true` at the job level, and `tools/ut.sh` / `tools/build.sh` honor it by appending `-Dspotless.skip=true` to every `mvn` invocation.

**Behavior summary**

| Caller | Before | After |
|--------|--------|-------|
| Non-lint CI jobs | Run spotless redundantly via `validate` phase | Skip spotless |
| `Code Style Check` CI job | Enforces spotless | Unchanged |
| Local `tools/ut.sh` / `tools/build.sh` | Run spotless | Unchanged (env var unset) |
| `tools/lint.sh -c` | Run spotless via `mvn spotless:check` | Unchanged |

The skip mechanism reuses `pom.xml:42-43`'s existing `spotless.skip` property — the same knob the JDK-21 profile (`pom.xml:122-131`) already uses for plugin compatibility.

**Files modified** (4 files, +39 / -5):

- `tools/ut.sh` — Read `SKIP_SPOTLESS_CHECK` env var; append `${SPOTLESS_FLAG}` to the 4 mvn invocations
- `tools/build.sh` — Same pattern; 1 mvn invocation
- `.github/workflows/ci.yml` — Job-level `env: { SKIP_SPOTLESS_CHECK: true }` on 4 jobs (`java_tests`, `python_it_tests`, `java_it_tests`, `cross_language_tests`)
- `.github/workflows/build_wheel.yml` — Same on 3 jobs (`java_tests`, `e2e_tests`, `build_python_wheels`)

**Why job-level (not step-level) env**: a job-level placement covers every step in the job, including the latent `tools/e2e.sh` fallback path that may call `bash tools/build.sh` (`tools/e2e.sh:101, 114`). Step-level fragmentation risks missing a second mvn-invoking step in a multi-step job — exactly the bug class this PR is meant to prevent.

### Tests

This is CI-infrastructure-only. No unit tests added (the repo has no shell-script test framework; existing scripts like `tools/ut.sh`, `tools/build.sh`, `tools/lint.sh` are also untested by any framework).

Verified locally:

- `bash -n tools/ut.sh && bash -n tools/build.sh` — syntax OK.
- YAML parse via `python3 -c "import yaml; yaml.safe_load(...)"` on both workflows.
- Env-var conditional truth table — only `true` and `1` set the flag; `false`, `0`, empty, `TRUE`, `yes` leave it unset.
- `mvn -pl api validate -Dspotless.skip=true` — emits `[INFO] Spotless check skipped`.
- `mvn -pl api validate` (control) — spotless runs as before.
- `mvn help:evaluate -Dexpression=spotless.skip -DforceStdout` — `true` with `-D`, `false` without.
- `./tools/lint.sh -c` — `### FORMAT CHECK PASSED ###` (lint script unchanged).
- Grep audit: `lint` job sections in both workflows untouched; `tools/lint.sh` does not read `SKIP_SPOTLESS_CHECK`; no env-var name collision repo-wide.

Post-merge CI verification: the PR's CI run should show `Code Style Check` still executing spotless and every other job's mvn log free of spotless lines.

### API

No API changes.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`
