### PR TITLE
[FLINK-AGENTS][api] Add ResourceName constants for AWS integrations

### DIFF
--- a/api/src/main/java/org/apache/flink/agents/api/resource/ResourceName.java
+++ b/api/src/main/java/org/apache/flink/agents/api/resource/ResourceName.java
@@ -59,6 +59,12 @@ public final class ResourceName {
         public static final String AZURE_SETUP =
                 "org.apache.flink.agents.integrations.chatmodels.azureai.AzureAIChatModelSetup";
 
+        // Bedrock
+        public static final String BEDROCK_CONNECTION =
+                "org.apache.flink.agents.integrations.chatmodels.bedrock.BedrockChatModelConnection";
+        public static final String BEDROCK_SETUP =
+                "org.apache.flink.agents.integrations.chatmodels.bedrock.BedrockChatModelSetup";
+
         // Ollama
         public static final String OLLAMA_CONNECTION =
                 "org.apache.flink.agents.integrations.chatmodels.ollama.OllamaChatModelConnection";
@@ -131,6 +137,12 @@ public final class ResourceName {
         public static final String OLLAMA_SETUP =
                 "org.apache.flink.agents.integrations.embeddingmodels.ollama.OllamaEmbeddingModelSetup";
 
+        // Bedrock
+        public static final String BEDROCK_CONNECTION =
+                "org.apache.flink.agents.integrations.embeddingmodels.bedrock.BedrockEmbeddingModelConnection";
+        public static final String BEDROCK_SETUP =
+                "org.apache.flink.agents.integrations.embeddingmodels.bedrock.BedrockEmbeddingModelSetup";
+
         // Python Wrapper
         public static final String PYTHON_WRAPPER_CONNECTION =
                 "org.apache.flink.agents.api.embedding.model.python.PythonEmbeddingModelConnection";
@@ -170,6 +182,14 @@ public final class ResourceName {
         // Elasticsearch
         public static final String ELASTICSEARCH_VECTOR_STORE =
                 "org.apache.flink.agents.integrations.vectorstores.elasticsearch.ElasticsearchVectorStore";
+
+        // Amazon OpenSearch (Serverless or Service domains)
+        public static final String OPENSEARCH_VECTOR_STORE =
+                "org.apache.flink.agents.integrations.vectorstores.opensearch.OpenSearchVectorStore";
+
+        // Amazon S3 Vectors
+        public static final String S3_VECTORS_VECTOR_STORE =
+                "org.apache.flink.agents.integrations.vectorstores.s3vectors.S3VectorsVectorStore";
 
         // Python Wrapper
         public static final String PYTHON_WRAPPER_VECTOR_STORE =

--- a/python/flink_agents/api/resource.py
+++ b/python/flink_agents/api/resource.py
@@ -276,6 +276,10 @@ class ResourceName:
             AZURE_CONNECTION = "org.apache.flink.agents.integrations.chatmodels.azureai.AzureAIChatModelConnection"
             AZURE_SETUP = "org.apache.flink.agents.integrations.chatmodels.azureai.AzureAIChatModelSetup"
 
+            # Bedrock
+            BEDROCK_CONNECTION = "org.apache.flink.agents.integrations.chatmodels.bedrock.BedrockChatModelConnection"
+            BEDROCK_SETUP = "org.apache.flink.agents.integrations.chatmodels.bedrock.BedrockChatModelSetup"
+
             # Ollama
             OLLAMA_CONNECTION = "org.apache.flink.agents.integrations.chatmodels.ollama.OllamaChatModelConnection"
             OLLAMA_SETUP = "org.apache.flink.agents.integrations.chatmodels.ollama.OllamaChatModelSetup"
@@ -313,6 +317,10 @@ class ResourceName:
             OLLAMA_CONNECTION = "org.apache.flink.agents.integrations.embeddingmodels.ollama.OllamaEmbeddingModelConnection"
             OLLAMA_SETUP = "org.apache.flink.agents.integrations.embeddingmodels.ollama.OllamaEmbeddingModelSetup"
 
+            # Bedrock
+            BEDROCK_CONNECTION = "org.apache.flink.agents.integrations.embeddingmodels.bedrock.BedrockEmbeddingModelConnection"
+            BEDROCK_SETUP = "org.apache.flink.agents.integrations.embeddingmodels.bedrock.BedrockEmbeddingModelSetup"
+
     class VectorStore:
         """VectorStore resource names."""
 
@@ -330,6 +338,12 @@ class ResourceName:
 
             # Elasticsearch
             ELASTICSEARCH_VECTOR_STORE = "org.apache.flink.agents.integrations.vectorstores.elasticsearch.ElasticsearchVectorStore"
+
+            # Amazon OpenSearch (Serverless or Service domains)
+            OPENSEARCH_VECTOR_STORE = "org.apache.flink.agents.integrations.vectorstores.opensearch.OpenSearchVectorStore"
+
+            # Amazon S3 Vectors
+            S3_VECTORS_VECTOR_STORE = "org.apache.flink.agents.integrations.vectorstores.s3vectors.S3VectorsVectorStore"
 
     # MCP resource names
     MCP_SERVER = "flink_agents.integrations.mcp.mcp.MCPServer"


### PR DESCRIPTION
fixes #675 

Adds the missing constants so AWS integrations match every other built-in provider:

    ResourceName.ChatModel.BEDROCK_CONNECTION / BEDROCK_SETUP
    ResourceName.EmbeddingModel.BEDROCK_CONNECTION / BEDROCK_SETUP
    ResourceName.VectorStore.OPENSEARCH_VECTOR_STORE
    ResourceName.VectorStore.S3_VECTORS_VECTOR_STORE

Plus matching Python-side entries for cross-language usage. 