### PR TITLE
[hotfix] Remove unused DurableExecutionManager.maybePruneState helper

### DIFF
--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/DurableExecutionManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/DurableExecutionManager.java
@@ -319,12 +319,6 @@ class DurableExecutionManager implements ActionStatePersister, AutoCloseable {
         }
     }
 
-    void maybePruneState(Object key, long sequenceNum) throws Exception {
-        if (actionStateStore != null) {
-            actionStateStore.pruneState(key, sequenceNum);
-        }
-    }
-
     /**
      * Prunes durable state for all per-key sequence numbers that were captured at the time of the
      * given checkpoint.

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DurableExecutionManagerTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DurableExecutionManagerTest.java
@@ -64,7 +64,6 @@ class DurableExecutionManagerTest {
         // Every maybe* method must be a silent no-op.
         assertThat(dem.maybeGetActionState("k", 0L, action, event)).isNull();
         dem.maybeInitActionState("k", 0L, action, event);
-        dem.maybePruneState("k", 0L);
         dem.notifyCheckpointComplete(1L);
         dem.snapshotRecoveryMarker();
         dem.close();


### PR DESCRIPTION
`DurableExecutionManager.maybePruneState(Object, long)` has no production callers and is not part of the `ActionStatePersister` interface — only a single test method references it. It is a leftover from the #546 refactor.

Timeline (from `git log -S "maybePruneState"`):
- #138 introduced `maybePruneState(...)` as a `private` helper on `ActionExecutionOperator`, called from the per-key completion path: `maybePruneState(key, sequenceNumber);`.
- #603 ("Fix prune state corner cases around checkpoints") deliberately removed both the call site and the helper. The fix moved pruning from the per-key path to the checkpoint-driven path inside `notifyCheckpointComplete`, where it now prunes using `lastCompletedSequenceNumber` captured at the checkpoint barrier via `snapshotLastCompletedSequenceNumbers`. That is the current/correct architecture.
- #546 ("Refactor ActionExecutionOperator into focused manager classes") extracted `DurableExecutionManager` and re-surfaced `maybePruneState(...)` on the new class — but no caller was re-added, correctly so. This commit removes the orphan.

Changes:
- Delete `DurableExecutionManager.maybePruneState(Object, long)`.
- Drop the `dem.maybePruneState("k", 0L);` line from the existing `noStoreModeMakesAllMaybeOperationsNoOp` no-op coverage test. The remaining `maybe*` no-op assertions still cover the null-store invariant for every `maybe*` method on the class today.

<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->


### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
