### PR TITLE
[hotfix] Make Ollama embedding test actually run in CI

### DIFF
--- a/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/embedding_model_cross_language_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/embedding_model_cross_language_test.py
@@ -41,7 +41,6 @@ from flink_agents.e2e_tests.test_utils import pull_model
 current_dir = Path(__file__).parent
 
 OLLAMA_MODEL = os.environ.get("OLLAMA_EMBEDDING_MODEL", "nomic-embed-text:latest")
-os.environ["OLLAMA_EMBEDDING_MODEL"] = OLLAMA_MODEL
 
 client = pull_model(OLLAMA_MODEL)
 
@@ -51,7 +50,10 @@ os.environ["PYTHONPATH"] = sysconfig.get_paths()["purelib"]
 @pytest.mark.skipif(
     client is None, reason="Ollama client is not available or test model is missing."
 )
-def test_java_embedding_model_integration(tmp_path: Path) -> None:
+def test_java_embedding_model_integration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OLLAMA_EMBEDDING_MODEL", OLLAMA_MODEL)
     env = StreamExecutionEnvironment.get_execution_environment()
     env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
     env.set_parallelism(1)

--- a/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/vector_store_cross_language_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/vector_store_cross_language_test.py
@@ -41,7 +41,6 @@ from flink_agents.e2e_tests.test_utils import pull_model
 current_dir = Path(__file__).parent
 
 OLLAMA_MODEL = os.environ.get("OLLAMA_EMBEDDING_MODEL", "nomic-embed-text:latest")
-os.environ["OLLAMA_EMBEDDING_MODEL"] = OLLAMA_MODEL
 
 ES_HOST = os.environ.get("ES_HOST")
 
@@ -55,7 +54,10 @@ os.environ["PYTHONPATH"] = sysconfig.get_paths()["purelib"]
     reason="Ollama client or Elasticsearch host is missing.",
 )
 @pytest.mark.parametrize("embedding_type", ["JAVA", "PYTHON"])
-def test_java_vector_store_integration(tmp_path: Path, embedding_type: str) -> None:
+def test_java_vector_store_integration(
+    tmp_path: Path, embedding_type: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OLLAMA_EMBEDDING_MODEL", OLLAMA_MODEL)
     os.environ["EMBEDDING_TYPE"] = embedding_type
 
     env = StreamExecutionEnvironment.get_execution_environment()

--- a/python/flink_agents/integrations/embedding_models/local/tests/start_ollama_server.sh
+++ b/python/flink_agents/integrations/embedding_models/local/tests/start_ollama_server.sh
@@ -36,5 +36,4 @@ if [[ $os == "Linux" ]]; then
   fi
 
   ollama pull all-minilm:22m
-  ollama run all-minilm:22m
 fi

--- a/python/flink_agents/integrations/embedding_models/local/tests/test_ollama_embedding_model.py
+++ b/python/flink_agents/integrations/embedding_models/local/tests/test_ollama_embedding_model.py
@@ -78,6 +78,7 @@ def test_ollama_embedding_setup() -> None:
         truncate=True,
         resource_context=mock_ctx,
     )
+    setup.open()
 
     # Test embedding through setup
     embedding = setup.embed("This is a test sentence for embedding.")

--- a/python/flink_agents/integrations/embedding_models/tests/test_openai_embedding_model.py
+++ b/python/flink_agents/integrations/embedding_models/tests/test_openai_embedding_model.py
@@ -48,6 +48,7 @@ def test_openai_embedding_model() -> None:
     embedding_model = OpenAIEmbeddingModelSetup(
         name="openai", model=test_model, connection="openai", resource_context=mock_ctx
     )
+    embedding_model.open()
 
     response = embedding_model.embed("Hello, Flink Agent!")
     assert response is not None


### PR DESCRIPTION


### Purpose of change

`test_ollama_embedding_setup` was effectively dead in CI — silently skipped by a broken preload script, and would have failed on `_get_connection()` if it ever ran. This PR makes it actually run and pass on the Python 3.10 / Ubuntu UT job.

**Fix 1 — `ab62944`** — Add `setup.open()` calls in the embedding setup tests.

`test_ollama_embedding_setup` and `test_openai_embedding_model` both construct a `BaseEmbeddingModelSetup` subclass with `connection` set to a resource-name string, then call `setup.embed(...)` directly. `BaseEmbeddingModelSetup.open()` is what resolves `self.connection` from the descriptor-supplied resource name into the actual `BaseEmbeddingModelConnection` instance; without it, `_get_connection()` raises `TypeError("Expect BaseEmbeddingModelConnection, but is str")`. `test_tongyi_embedding_model` already follows the correct pattern. (The OpenAI test is gated by `TEST_API_KEY` so the latent bug was masked, but the fix applies identically.)

**Fix 2 — `3ade7fa`** — Drop the failing `ollama run` line from `start_ollama_server.sh`.

The CI preload script ran `ollama run all-minilm:22m`, which exits non-zero against an embedding model with `Error: embedding models require input text`. `test_ollama_embedding_model.py`'s module-level setup uses `subprocess.run(..., check=True)`, so the failure fell into the `except` block and set `client = None`, which made `@pytest.mark.skipif(client is None, ...)` silently skip the test in every CI run. The preceding `ollama pull all-minilm:22m` is sufficient to make the model discoverable via `client.list()`, which is what the gate actually checks; the parallel chat-model `start_ollama_server.sh` already follows that minimal pattern.

 **Fix 3 — `acfd146`** — Move `OLLAMA_EMBEDDING_MODEL` out of module scope in two e2e tests.
After Fix 2 the test was still being skipped. Root cause was module-level `os.environ["OLLAMA_EMBEDDING_MODEL"] = OLLAMA_MODEL` in `e2e_tests_resource_cross_language/embedding_model_cross_language_test.py:43-44` and `vector_store_cross_language_test.py:43-44`. Because `tools/ut.sh` runs `pytest flink_agents -k "not e2e_tests"` and `-k` only filters which tests *execute* (not which files are *collected*), pytest imported the e2e modules during collection and executed the assignment as a side effect — polluting `OLLAMA_EMBEDDING_MODEL` to `"nomic-embed-text:latest"` before `test_ollama_embedding_model.py:34` read it with its `"all-minilm:22m"` default. Fix: removed the module-scope assignment; moved the assignment into the test function body via `monkeypatch.setenv`, which preserves runtime propagation to the Flink subprocess while auto-restoring after each test.

### Tests

- `cd python && uv run pytest flink_agents/integrations/embedding_models/local/tests/test_ollama_embedding_model.py -v` — passes locally when an Ollama daemon is reachable (previously raised `TypeError`).
- `cd python && uv run pytest flink_agents/integrations/embedding_models/tests/test_openai_embedding_model.py -v` — gated by `TEST_API_KEY`; latent bug fixed.
- `./tools/lint.sh -c` clean.
- Next CI run on this PR will exercise the embedding test for real on Python 3.10 / Ubuntu.

### API

No API changes — test/CI fixes only.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`

