### PR TITLE
[hotfix] Move chat-model os.environ mutations out of module scope in e2e tests

### DIFF
--- a/python/flink_agents/e2e_tests/e2e_tests_integration/chat_model_integration_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/chat_model_integration_test.py
@@ -29,17 +29,12 @@ from flink_agents.e2e_tests.test_utils import pull_model
 current_dir = Path(__file__).parent
 
 TONGYI_MODEL = os.environ.get("TONGYI_CHAT_MODEL", "qwen-plus")
-os.environ["TONGYI_CHAT_MODEL"] = TONGYI_MODEL
 OLLAMA_MODEL = os.environ.get("OLLAMA_CHAT_MODEL", "qwen3:1.7b")
-os.environ["OLLAMA_CHAT_MODEL"] = OLLAMA_MODEL
 OPENAI_MODEL = os.environ.get("OPENAI_CHAT_MODEL", "gpt-3.5-turbo")
-os.environ["OPENAI_CHAT_MODEL"] = OPENAI_MODEL
 AZURE_OPENAI_MODEL = os.environ.get("AZURE_OPENAI_CHAT_MODEL", "gpt-5")
-os.environ["AZURE_OPENAI_CHAT_MODEL"] = AZURE_OPENAI_MODEL
 AZURE_OPENAI_API_VERSION = os.environ.get(
     "AZURE_OPENAI_API_VERSION", "2025-04-01-preview"
 )
-os.environ["AZURE_OPENAI_API_VERSION"] = AZURE_OPENAI_API_VERSION
 
 DASHSCOPE_API_KEY = os.environ.get("DASHSCOPE_API_KEY")
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
@@ -78,8 +73,15 @@ client = pull_model(OLLAMA_MODEL)
         ),
     ],
 )
-def test_chat_model_integration(model_provider: str) -> None:
-    os.environ["MODEL_PROVIDER"] = model_provider
+def test_chat_model_integration(
+    model_provider: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TONGYI_CHAT_MODEL", TONGYI_MODEL)
+    monkeypatch.setenv("OLLAMA_CHAT_MODEL", OLLAMA_MODEL)
+    monkeypatch.setenv("OPENAI_CHAT_MODEL", OPENAI_MODEL)
+    monkeypatch.setenv("AZURE_OPENAI_CHAT_MODEL", AZURE_OPENAI_MODEL)
+    monkeypatch.setenv("AZURE_OPENAI_API_VERSION", AZURE_OPENAI_API_VERSION)
+    monkeypatch.setenv("MODEL_PROVIDER", model_provider)
     env = AgentsExecutionEnvironment.get_execution_environment()
     input_list = []
     agent = ChatModelTestAgent()

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/react_agent_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/react_agent_test.py
@@ -51,7 +51,6 @@ current_dir = Path(__file__).parent
 os.environ["PYTHONPATH"] = sysconfig.get_paths()["purelib"]
 
 OLLAMA_MODEL = os.environ.get("REACT_OLLAMA_MODEL", "qwen3:1.7b")
-os.environ["OLLAMA_CHAT_MODEL"] = OLLAMA_MODEL
 
 
 class InputData(BaseModel):
@@ -78,7 +77,8 @@ client = pull_model(OLLAMA_MODEL)
 @pytest.mark.skipif(
     client is None, reason="Ollama client is not available or test model is missing"
 )
-def test_react_agent_on_local_runner() -> None:
+def test_react_agent_on_local_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OLLAMA_CHAT_MODEL", OLLAMA_MODEL)
     env = AgentsExecutionEnvironment.get_execution_environment()
     env.get_config().set(
         AgentExecutionOptions.ERROR_HANDLING_STRATEGY, ErrorHandlingStrategy.RETRY
@@ -138,7 +138,10 @@ def test_react_agent_on_local_runner() -> None:
 @pytest.mark.skipif(
     client is None, reason="Ollama client is not available or test model is missing"
 )
-def test_react_agent_on_remote_runner(tmp_path: Path) -> None:
+def test_react_agent_on_remote_runner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OLLAMA_CHAT_MODEL", OLLAMA_MODEL)
     stream_env = StreamExecutionEnvironment.get_execution_environment()
 
     stream_env.set_parallelism(1)

--- a/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/chat_model_cross_language_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/chat_model_cross_language_test.py
@@ -41,7 +41,6 @@ from flink_agents.e2e_tests.test_utils import pull_model
 current_dir = Path(__file__).parent
 
 OLLAMA_MODEL = os.environ.get("OLLAMA_CHAT_MODEL", "qwen3:1.7b")
-os.environ["OLLAMA_CHAT_MODEL"] = OLLAMA_MODEL
 
 client = pull_model(OLLAMA_MODEL)
 
@@ -51,7 +50,10 @@ os.environ["PYTHONPATH"] = sysconfig.get_paths()["purelib"]
 @pytest.mark.skipif(
     client is None, reason="Ollama client is not available or test model is missing."
 )
-def test_java_chat_model_integration(tmp_path: Path) -> None:
+def test_java_chat_model_integration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OLLAMA_CHAT_MODEL", OLLAMA_MODEL)
     env = StreamExecutionEnvironment.get_execution_environment()
     env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
     env.set_parallelism(1)

--- a/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/yaml_cross_language_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/yaml_cross_language_test.py
@@ -69,7 +69,6 @@ _TEST_JAR = (
 os.environ["PYTHONPATH"] = sysconfig.get_paths()["purelib"]
 
 OLLAMA_MODEL = os.environ.get("OLLAMA_CHAT_MODEL", "qwen3:1.7b")
-os.environ["OLLAMA_CHAT_MODEL"] = OLLAMA_MODEL
 
 _client = pull_model(OLLAMA_MODEL)
 
@@ -86,13 +85,16 @@ _client = pull_model(OLLAMA_MODEL)
         "flink-agents-end-to-end-tests-resource-cross-language' first."
     ),
 )
-def test_yaml_cross_language_agent(tmp_path: Path) -> None:
+def test_yaml_cross_language_agent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """``load_yaml`` → ``apply(by name)`` with a YAML-declared Java tool.
 
     Exercises a Python Ollama chat model that calls a Java
     ``calculateBMI`` tool declared in YAML and resolved against the
     cross-language test JAR.
     """
+    monkeypatch.setenv("OLLAMA_CHAT_MODEL", OLLAMA_MODEL)
     config = Configuration()
     config.set_string("python.pythonpath", sysconfig.get_paths()["purelib"])
     env = StreamExecutionEnvironment.get_execution_environment(config)


### PR DESCRIPTION
### Purpose of change

`os.environ[X] = Y` mutations at module scope in e2e test files leak into the rest of the pytest process at collection time. The mechanism:

- `tools/ut.sh` runs `pytest flink_agents -k "not e2e_tests"`.
- `-k` only filters which tests **execute**, not which files are **collected**. Pytest imports every matching test file during the collection phase.
- Importing an e2e module that does `os.environ[X] = Y` at module scope executes the assignment as a side effect, polluting `X` for every later-collected test (e.g. the `integrations/` tests).

PR #686 fixed this for `OLLAMA_EMBEDDING_MODEL`. This PR covers the same pattern for the chat-model-side env vars.

### Files fixed

| File | Env var(s) moved out of module scope |
|---|---|
| `e2e_tests_resource_cross_language/chat_model_cross_language_test.py:44` | `OLLAMA_CHAT_MODEL` |
| `e2e_tests_resource_cross_language/yaml_cross_language_test.py:72` | `OLLAMA_CHAT_MODEL` |
| `e2e_tests_integration/chat_model_integration_test.py:32,34,36,38,42` | `TONGYI_CHAT_MODEL`, `OLLAMA_CHAT_MODEL`, `OPENAI_CHAT_MODEL`, `AZURE_OPENAI_CHAT_MODEL`, `AZURE_OPENAI_API_VERSION` |
| `e2e_tests_integration/react_agent_test.py:54` | `OLLAMA_CHAT_MODEL` |

### Approach

Used `monkeypatch.setenv(...)` inside the test function bodies. This:

- Sets the env var only when the test actually runs (no collection-time pollution)
- Auto-restores the original value after the test (no inter-test leakage either)
- Preserves runtime propagation to the Flink subprocess

In `chat_model_integration_test.py` also converted the already-inside-function `os.environ["MODEL_PROVIDER"] = model_provider` to `monkeypatch.setenv` for consistency — otherwise the `parametrize` iterations (Ollama / Tongyi / OpenAI / AzureOpenAI) would leak `MODEL_PROVIDER` between runs.

### Tests

- `./tools/lint.sh -c` clean
- AST parse of all 4 files clean
- The actual proof comes when CI runs and the chat-model tests no longer pollute the integrations test process. (No new test added because the underlying behavior — running an e2e test — is unchanged; the fix is purely about test-process hygiene.)

### API

No API changes — test files only.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`
