### PR TITLE
[ci] Replace burnett01/rsync-deployments with local composite action

### DIFF
--- a/.github/actions/rsync-deployments/LICENSE
+++ b/.github/actions/rsync-deployments/LICENSE
@@ -1,0 +1,26 @@
+The local composite action at .github/actions/rsync-deployments/action.yml
+was inspired by the rsync-deployments GitHub Action, which is distributed
+under the MIT License reproduced below.
+
+MIT License
+
+Copyright (c) 2019-2022 Contention
+Copyright (c) 2019-2025 Burnett01
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.github/actions/rsync-deployments/action.yml
+++ b/.github/actions/rsync-deployments/action.yml
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This implementation took inspiration from https://github.com/Burnett01/rsync-deployments/blob/7.1.0/action.yml
+name: Rsync Deploy (local)
+description: Upload a folder to a single remote destination via rsync over SSH.
+inputs:
+  switches:
+    description: rsync switches
+    required: false
+    default: "--archive --compress"
+  path:
+    description: Local source directory
+    required: true
+  remote_path:
+    description: Remote destination directory
+    required: true
+  remote_host:
+    description: SSH host
+    required: true
+  remote_port:
+    description: SSH port
+    required: false
+    default: "22"
+  remote_user:
+    description: SSH username
+    required: true
+  remote_key:
+    description: SSH private key (OpenSSH/PEM)
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: rsync via ssh-agent
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # Start agent and load the key
+        eval "$(ssh-agent -s)"
+        ssh-add - <<< "${{ inputs.remote_key }}"
+
+        # SSH command with host key checking disabled (matches your reference impl)
+        RSH="ssh -o StrictHostKeyChecking=no -p ${{ inputs.remote_port }}"
+
+        # Resolve paths and DSN
+        LOCAL_PATH="$GITHUB_WORKSPACE/${{ inputs.path }}"
+        DSN="${{ inputs.remote_user }}@${{ inputs.remote_host }}"
+
+        # Deploy
+        sh -c "rsync ${{ inputs.switches }} -e '$RSH' $LOCAL_PATH $DSN:${{ inputs.remote_path }}"
+
+        # Cleanup identities from the agent
+        ssh-add -D || true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,7 @@ jobs:
           docker run --rm --volume "$PWD:/root/flink-agents" chesnay/flink-ci:java_8_11_17_21_maven_386 bash -c "cd /root/flink-agents && chmod +x ./tools/docs.sh && ./tools/docs.sh"
 
       - name: Upload documentation
-        uses: burnett01/rsync-deployments@7659d600d8bdd035bb5cdfba1d4bd0dd4a307ca6 # 8.0.2
+        uses: ./.github/actions/rsync-deployments
         with:
           switches: --archive --compress --delete
           path: docs/target/
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload documentation alias
         if: env.flink_alias != ''
-        uses: burnett01/rsync-deployments@7659d600d8bdd035bb5cdfba1d4bd0dd4a307ca6 # 8.0.2
+        uses: ./.github/actions/rsync-deployments
         with:
           switches: --archive --compress --delete
           path: docs/target/


### PR DESCRIPTION
### Purpose of change

The nightly `Build Documentation` workflow fails because `burnett01/rsync-deployments` is not in the ASF allowed-actions list. Replace it with a local composite action under `.github/actions/rsync-deployments/`, ported from [apache/flink-kubernetes-operator#1035](https://github.com/apache/flink-kubernetes-operator/pull/1035).

### 🔔 Note for committer

Please **cherry-pick the first commit only** (`Add local rsync-deployments composite action`) onto `release-0.1` and `release-0.2`. The matrix job checks those branches out and resolves the local action from the workspace, so the action file must exist on each branch. The second commit (workflow change) is only needed on `main` — cron always reads the workflow from the default branch.

### Tests

Verified on a [personal fork](https://github.com/GreatEugenius/flink-agents/actions/runs/26379754648): the local action loads and runs. It fails at `ssh-add` with `error in libcrypto` because the `NIGHTLIES_RSYNC_KEY` secret only exists in `apache/flink-agents`. Full verification needs a `workflow_dispatch` on the Apache repo after merge.

### API
No

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
