### PR TITLE
[hotfix] Cherry-pick #584 #585: fix CI by removing astral-sh/setup-uv and pinning uv version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: 3.11
       - name: Install uv
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
+          curl -LsSf https://astral.sh/uv/0.11.0/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Check code style
         run: ./tools/lint.sh -c
@@ -86,7 +86,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
+          curl -LsSf https://astral.sh/uv/0.11.0/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Run Python Tests
         run: tools/ut.sh -p
@@ -112,7 +112,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
+          curl -LsSf https://astral.sh/uv/0.11.0/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Build flink-agents
         run: bash tools/build.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,9 @@ jobs:
         with:
           python-version: 3.11
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          version: "latest"
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Check code style
         run: ./tools/lint.sh -c
 
@@ -85,9 +85,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          version: "latest"
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Run Python Tests
         run: tools/ut.sh -p
 
@@ -111,9 +111,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          version: "latest"
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Build flink-agents
         run: bash tools/build.sh
       - name: Run e2e tests

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -52,8 +52,9 @@ cp "${PROJECT_ROOT}/dist/target/flink-agents-dist-${PROJECT_VERSION}.jar" ${PYTH
 # build python
 cd python
 rm -rf dist/  # Clean old build artifacts before building
-pip install uv
+pip install uv==0.11.0
 uv sync --extra dev
+uv run python -m ensurepip --default-pip
 uv run python -m build
 uv pip install dist/*.whl
 


### PR DESCRIPTION
### Purpose of change
Cherry-pick of #584 and #585 to `release-0.1` to unblock CI.
<!-- What is the purpose of this change? -->

### Tests
No
<!-- How is this change verified? -->

### API
No
<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
