### PR TITLE
[hotfix] Make cross-language e2e test order-insensitive and add request time

### DIFF
--- a/e2e-test/flink-agents-end-to-end-tests-resource-cross-language/src/test/java/org/apache/flink/agents/resource/test/ChatModelCrossLanguageAgent.java
+++ b/e2e-test/flink-agents-end-to-end-tests-resource-cross-language/src/test/java/org/apache/flink/agents/resource/test/ChatModelCrossLanguageAgent.java
@@ -78,7 +78,7 @@ public class ChatModelCrossLanguageAgent extends Agent {
         return ResourceDescriptor.Builder.newBuilder(
                         ResourceName.ChatModel.PYTHON_WRAPPER_CONNECTION)
                 .addInitialArgument("pythonClazz", ResourceName.ChatModel.Python.OLLAMA_CONNECTION)
-                .addInitialArgument("requestTimeout", 240)
+                .addInitialArgument("request_timeout", 240)
                 .build();
     }
 

--- a/e2e-test/flink-agents-end-to-end-tests-resource-cross-language/src/test/java/org/apache/flink/agents/resource/test/ChatModelCrossLanguageAgent.java
+++ b/e2e-test/flink-agents-end-to-end-tests-resource-cross-language/src/test/java/org/apache/flink/agents/resource/test/ChatModelCrossLanguageAgent.java
@@ -78,6 +78,7 @@ public class ChatModelCrossLanguageAgent extends Agent {
         return ResourceDescriptor.Builder.newBuilder(
                         ResourceName.ChatModel.PYTHON_WRAPPER_CONNECTION)
                 .addInitialArgument("pythonClazz", ResourceName.ChatModel.Python.OLLAMA_CONNECTION)
+                .addInitialArgument("requestTimeout", 240)
                 .build();
     }
 

--- a/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/chat_model_cross_language_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/chat_model_cross_language_test.py
@@ -106,5 +106,6 @@ def test_java_chat_model_integration(
             with file.open() as f:
                 actual_result.extend(f.readlines())
 
-    assert "3" in actual_result[0]
-    assert "cat" in actual_result[1]
+    joined = "\n".join(actual_result).lower()
+    assert "3" in joined, f"math answer missing '3': {actual_result!r}"
+    assert "cat" in joined, f"creative answer missing 'cat': {actual_result!r}"

--- a/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/yaml_cross_language_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/yaml_cross_language_test.py
@@ -154,8 +154,10 @@ def test_yaml_cross_language_agent(
 
     # Math path went through the Java ``calculateBMI`` tool:
     # 70 / (1.75 * 1.75) ≈ 22.86, so the final answer should mention 22.
-    assert "22" in actual_result[0], f"math answer missing '22': {actual_result[0]!r}"
     # Creative path doesn't use any tool.
-    assert "cat" in actual_result[1].lower(), (
-        f"creative answer missing 'cat': {actual_result[1]!r}"
-    )
+    # NOTE: We join all results and search without relying on order, because
+    # StreamingFileSink may produce multiple part files and iterdir() does not
+    # guarantee a deterministic traversal order across platforms.
+    joined = "\n".join(actual_result).lower()
+    assert "22" in joined, f"math answer missing '22': {actual_result!r}"
+    assert "cat" in joined, f"creative answer missing 'cat': {actual_result!r}"


### PR DESCRIPTION
## Summary

Fix flaky `YamlCrossLanguageTest` Python e2e test on CI.

## Root cause

1. `StreamingFileSink` emits multiple part files across checkpoints, and `Path.iterdir()` returns them in non-deterministic order — the original assertion indexed into `actual_result[0]` / `actual_result[1]` and broke whenever traversal order differed.
2. On slow CI runners, the default 30s request timeout on the Python Ollama chat model connection can elapse before the model finishes generating.

## Changes

- **Python** `yaml_cross_language_test.py` — join all part-file outputs and search for expected substrings, instead of relying on positional index.
- **Java** `ChatModelCrossLanguageAgent.java` — extend the request timeout on `pythonChatModelConnection()` to 240s, mirroring `javaChatModelConnection()`.

## Linked issue

N/A (CI flaky test fix).

## Tests

Re-runs existing e2e `yaml_cross_language_test.py`. No new tests needed.

## API

No public API changes.

## Documentation

- [x] `doc-not-needed`