### PR TITLE
[test] Mitigate flaky live-LLM e2e/cross-language CI tests

### DIFF
--- a/e2e-test/flink-agents-end-to-end-tests-resource-cross-language/src/test/java/org/apache/flink/agents/resource/test/ChatModelCrossLanguageAgent.java
+++ b/e2e-test/flink-agents-end-to-end-tests-resource-cross-language/src/test/java/org/apache/flink/agents/resource/test/ChatModelCrossLanguageAgent.java
@@ -78,6 +78,7 @@ public class ChatModelCrossLanguageAgent extends Agent {
         return ResourceDescriptor.Builder.newBuilder(
                         ResourceName.ChatModel.PYTHON_WRAPPER_CONNECTION)
                 .addInitialArgument("pythonClazz", ResourceName.ChatModel.Python.OLLAMA_CONNECTION)
+                .addInitialArgument("request_timeout", 240)
                 .build();
     }
 

--- a/e2e-test/test-scripts/test_resource_cross_language.sh
+++ b/e2e-test/test-scripts/test_resource_cross_language.sh
@@ -30,7 +30,7 @@ echo "Root directory: $root_dir"
 cd "$root_dir/e2e-test/flink-agents-end-to-end-tests-resource-cross-language"
 
 echo "Running all tests in resource-cross-language module..."
-mvn -T16 --batch-mode --no-transfer-progress test
+mvn -T16 --batch-mode --no-transfer-progress test -Dsurefire.rerunFailingTestsCount=2
 
 ret=$?
 if [ "$ret" != "0" ]; then

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -90,6 +90,7 @@ build = [
 # Test dependencies
 test = [
     "pytest==9.0.3",
+    "pytest-rerunfailures==16.3",
 ]
 
 # Lint dependencies

--- a/tools/e2e.sh
+++ b/tools/e2e.sh
@@ -81,7 +81,7 @@ function run_resource_cross_language_test_in_python {
       return 1
     fi
 
-    cd "$python_dir" && uv run --no-sync pytest flink_agents -s -k "e2e_tests_resource_cross_language"
+    cd "$python_dir" && uv run --no-sync pytest flink_agents -s -k "e2e_tests_resource_cross_language" --reruns 2 --reruns-delay 5
 }
 
 function run_resource_name_consistency_check {

--- a/tools/ut.sh
+++ b/tools/ut.sh
@@ -155,7 +155,7 @@ java_tests() {
         local all_passed=true
         for version in "${flink_versions[@]}"; do
             echo "Running E2E tests for Flink ${version}..."
-            mvn --batch-mode --no-transfer-progress test -pl 'e2e-test/flink-agents-end-to-end-tests-integration' -Pflink-${version} ${SPOTLESS_FLAG}
+            mvn --batch-mode --no-transfer-progress test -pl 'e2e-test/flink-agents-end-to-end-tests-integration' -Pflink-${version} -Dsurefire.rerunFailingTestsCount=2 ${SPOTLESS_FLAG}
 
             if [ $? -ne 0 ]; then
                 echo "E2E tests failed for Flink ${version}" >&2
@@ -232,6 +232,8 @@ python_tests() {
                 uv run --no-sync pytest flink_agents \
                 -s \
                 -k "e2e_tests_integration" \
+                --reruns 2 \
+                --reruns-delay 5 \
                 -o log_cli=true \
                 -o log_cli_level=${LOG_LEVEL:-CRITICAL}
             else
@@ -259,7 +261,7 @@ python_tests() {
                 echo "Running tests with pytest..."
             fi
             if $run_e2e; then
-                pytest flink_agents -k "e2e_tests_integration" -o log_cli=true -o log_cli_level=${LOG_LEVEL:-OFF}
+                pytest flink_agents -k "e2e_tests_integration" --reruns 2 --reruns-delay 5 -o log_cli=true -o log_cli_level=${LOG_LEVEL:-OFF}
             else
                 pytest flink_agents -k "not e2e_tests" -o log_cli=true -o log_cli_level=${LOG_LEVEL:-OFF}
             fi


### PR DESCRIPTION
Linked issue: #716

### Purpose of change

The live-LLM e2e and cross-language CI tests run a small Ollama model (`qwen3:1.7b`) and fail intermittently — either the model returns a wrong tool-call result (e.g. `assert <varies> == 1386528`) or an Ollama call exceeds its read timeout (`httpx.ReadTimeout`). These flakes reproduce across many branches including `main`, turning CI red on unrelated PRs. See #716 for the failure statistics and evidence.

This PR mitigates the flakiness without masking real, deterministic failures:

1. **Per-test retry, scoped to the live-LLM e2e/cross-language suites only.** Python uses `pytest-rerunfailures` (`--reruns 2 --reruns-delay 5`); Java uses Surefire `-Dsurefire.rerunFailingTestsCount=2`. Both are applied only at the e2e/cross-language test invocations — the unit and style invocations are untouched, so a genuine regression still fails immediately. A test that passes on retry produces a green build but is reported as a flake (pytest `R` markers / Surefire "Flakes"), so the signal is preserved, not hidden.

2. **Close the one remaining 30 s timeout gap.** The cross-language test's Python-wrapped Ollama connection fell back to the Python default `request_timeout` of 30 s; this sets it to 240 s, matching the Java-native connection already configured in the same test agent.

Loosening exact-equality assertions on LLM output (asserting tool-call shape rather than an exact value) is noted in #716 as longer-term hardening and is intentionally out of scope here.

### Tests

This is a CI/test-configuration change, so no new product tests are added (a test asserting "retry is configured" would be tautological). Verified:
- The retry flags are scoped correctly — a deliberately-failing test is retried 3× under an e2e selector but runs once under the unit selector; the unit pytest (`-k "not e2e_tests"`) and unit mvn (`-pl "${exclude_list}"`) invocations are unchanged.
- `pytest-rerunfailures==16.3` resolves against `pytest==9.0.3`, and the e2e jobs install it via `tools/build.sh`'s `uv sync --extra dev` (the `dev` extra composes `test`) before the `--no-sync` pytest runs.
- `mvn ... -Dsurefire.rerunFailingTestsCount=2 test-compile` is accepted on Surefire 3.5.2; the cross-language module compiles with the timeout change.

### API

No public API change. All changes are test-configuration (CI scripts, the Python test extra, and one e2e test agent).

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`
