### PR TITLE
[integrations][api] Rename connection-layer chat() argument to modelParams

### DIFF
--- a/api/src/main/java/org/apache/flink/agents/api/chat/model/BaseChatModelConnection.java
+++ b/api/src/main/java/org/apache/flink/agents/api/chat/model/BaseChatModelConnection.java
@@ -50,9 +50,9 @@ public abstract class BaseChatModelConnection extends Resource {
      *
      * @param messages the input chat messages
      * @param tools the tools can be called by the model
-     * @param arguments the additional arguments passed to the model
+     * @param modelParams the additional arguments passed to the model
      * @return the chat response containing model outputs
      */
     public abstract ChatMessage chat(
-            List<ChatMessage> messages, List<Tool> tools, Map<String, Object> arguments);
+            List<ChatMessage> messages, List<Tool> tools, Map<String, Object> modelParams);
 }

--- a/api/src/main/java/org/apache/flink/agents/api/chat/model/python/PythonChatModelConnection.java
+++ b/api/src/main/java/org/apache/flink/agents/api/chat/model/python/PythonChatModelConnection.java
@@ -67,8 +67,8 @@ public class PythonChatModelConnection extends BaseChatModelConnection
 
     @Override
     public ChatMessage chat(
-            List<ChatMessage> messages, List<Tool> tools, Map<String, Object> arguments) {
-        Map<String, Object> kwargs = new HashMap<>(arguments);
+            List<ChatMessage> messages, List<Tool> tools, Map<String, Object> modelParams) {
+        Map<String, Object> kwargs = new HashMap<>(modelParams);
 
         List<Object> pythonMessages = new ArrayList<>();
         for (ChatMessage message : messages) {

--- a/api/src/test/java/org/apache/flink/agents/api/chat/model/BaseChatModelSetupSkillsTest.java
+++ b/api/src/test/java/org/apache/flink/agents/api/chat/model/BaseChatModelSetupSkillsTest.java
@@ -66,7 +66,7 @@ class BaseChatModelSetupSkillsTest {
 
         @Override
         public ChatMessage chat(
-                List<ChatMessage> messages, List<Tool> tools, Map<String, Object> arguments) {
+                List<ChatMessage> messages, List<Tool> tools, Map<String, Object> modelParams) {
             this.capturedMessages = new ArrayList<>(messages);
             this.capturedTools = new ArrayList<>(tools);
             return new ChatMessage(MessageRole.ASSISTANT, "ok");

--- a/api/src/test/java/org/apache/flink/agents/api/chat/model/BaseChatModelTest.java
+++ b/api/src/test/java/org/apache/flink/agents/api/chat/model/BaseChatModelTest.java
@@ -247,7 +247,7 @@ class BaseChatModelTest {
 
         @Override
         public ChatMessage chat(
-                List<ChatMessage> messages, List<Tool> tools, Map<String, Object> arguments) {
+                List<ChatMessage> messages, List<Tool> tools, Map<String, Object> modelParams) {
             this.capturedMessages = new ArrayList<>(messages);
             return new ChatMessage(MessageRole.ASSISTANT, "ok");
         }

--- a/api/src/test/java/org/apache/flink/agents/api/chat/model/python/PythonChatModelConnectionTest.java
+++ b/api/src/test/java/org/apache/flink/agents/api/chat/model/python/PythonChatModelConnectionTest.java
@@ -89,9 +89,9 @@ public class PythonChatModelConnectionTest {
         Tool mockTool = mock(Tool.class);
         List<ChatMessage> messages = Collections.singletonList(inputMessage);
         List<Tool> tools = Collections.singletonList(mockTool);
-        Map<String, Object> arguments = new HashMap<>();
-        arguments.put("temperature", 0.7);
-        arguments.put("max_tokens", 100);
+        Map<String, Object> modelParams = new HashMap<>();
+        modelParams.put("temperature", 0.7);
+        modelParams.put("max_tokens", 100);
 
         Object pythonInputMessage = new Object();
         Object pythonOutputMessage = new Object();
@@ -103,7 +103,7 @@ public class PythonChatModelConnectionTest {
                 .thenReturn(pythonOutputMessage);
         when(mockAdapter.fromPythonChatMessage(pythonOutputMessage)).thenReturn(outputMessage);
 
-        ChatMessage result = pythonChatModelConnection.chat(messages, tools, arguments);
+        ChatMessage result = pythonChatModelConnection.chat(messages, tools, modelParams);
 
         assertThat(result).isEqualTo(outputMessage);
 

--- a/integrations/chat-models/anthropic/src/main/java/org/apache/flink/agents/integrations/chatmodels/anthropic/AnthropicChatModelConnection.java
+++ b/integrations/chat-models/anthropic/src/main/java/org/apache/flink/agents/integrations/chatmodels/anthropic/AnthropicChatModelConnection.java
@@ -118,25 +118,25 @@ public class AnthropicChatModelConnection extends BaseChatModelConnection {
     public ChatMessage chat(
             List<ChatMessage> messages,
             List<org.apache.flink.agents.api.tools.Tool> tools,
-            Map<String, Object> arguments) {
+            Map<String, Object> modelParams) {
         try {
-            // Check if JSON prefill is requested before building request (arguments may be
+            // Check if JSON prefill is requested before building request (modelParams may be
             // modified).
             boolean jsonPrefillRequested =
-                    arguments != null && Boolean.TRUE.equals(arguments.get("json_prefill"));
+                    modelParams != null && Boolean.TRUE.equals(modelParams.get("json_prefill"));
             // JSON prefill is automatically disabled when tools are passed in the request,
             // because it interferes with native tool calling.
             boolean hasToolsInRequest = tools != null && !tools.isEmpty();
             boolean jsonPrefillApplied = jsonPrefillRequested && !hasToolsInRequest;
 
-            MessageCreateParams params = buildRequest(messages, tools, arguments);
+            MessageCreateParams params = buildRequest(messages, tools, modelParams);
             Message response = client.messages().create(params);
             ChatMessage result = convertResponse(response, jsonPrefillApplied);
 
             // Stash token usage
             String modelName = null;
-            if (arguments != null && arguments.get("model") != null) {
-                modelName = arguments.get("model").toString();
+            if (modelParams != null && modelParams.get("model") != null) {
+                modelName = modelParams.get("model").toString();
             }
             if (modelName == null || modelName.isBlank()) {
                 modelName = this.defaultModel;
@@ -156,11 +156,11 @@ public class AnthropicChatModelConnection extends BaseChatModelConnection {
     private MessageCreateParams buildRequest(
             List<ChatMessage> messages,
             List<org.apache.flink.agents.api.tools.Tool> tools,
-            Map<String, Object> rawArguments) {
-        Map<String, Object> arguments =
-                rawArguments != null ? new HashMap<>(rawArguments) : new HashMap<>();
+            Map<String, Object> rawModelParams) {
+        Map<String, Object> modelParams =
+                rawModelParams != null ? new HashMap<>(rawModelParams) : new HashMap<>();
 
-        Object modelObj = arguments.remove("model");
+        Object modelObj = modelParams.remove("model");
         String modelName = modelObj != null ? modelObj.toString() : this.defaultModel;
         if (modelName == null || modelName.isBlank()) {
             modelName = this.defaultModel;
@@ -184,7 +184,7 @@ public class AnthropicChatModelConnection extends BaseChatModelConnection {
         }
 
         // Handle strict tools - enables structured outputs for tool use
-        Object strictTools = arguments.remove("strict_tools");
+        Object strictTools = modelParams.remove("strict_tools");
         boolean strictToolsEnabled = Boolean.TRUE.equals(strictTools);
 
         if (tools != null && !tools.isEmpty()) {
@@ -199,19 +199,19 @@ public class AnthropicChatModelConnection extends BaseChatModelConnection {
             builder.putAdditionalHeader("anthropic-beta", "structured-outputs-2025-11-13");
         }
 
-        Object maxTokens = arguments.remove("max_tokens");
+        Object maxTokens = modelParams.remove("max_tokens");
         if (maxTokens instanceof Number) {
             builder.maxTokens(((Number) maxTokens).longValue());
         }
 
-        Object temperature = arguments.remove("temperature");
+        Object temperature = modelParams.remove("temperature");
         if (temperature instanceof Number) {
             builder.temperature(((Number) temperature).doubleValue());
         }
 
         @SuppressWarnings("unchecked")
         Map<String, Object> additionalKwargs =
-                (Map<String, Object>) arguments.remove("additional_kwargs");
+                (Map<String, Object>) modelParams.remove("additional_kwargs");
         if (additionalKwargs != null) {
             applyAdditionalKwargs(builder, additionalKwargs);
         }
@@ -220,7 +220,7 @@ public class AnthropicChatModelConnection extends BaseChatModelConnection {
         // output. Note: JSON prefill is incompatible with tool use as it forces the model to output
         // JSON text instead of using native tool_use content blocks. Automatically disable
         // json_prefill when tools are actually passed in the request.
-        Object jsonPrefill = arguments.remove("json_prefill");
+        Object jsonPrefill = modelParams.remove("json_prefill");
         boolean hasToolsInRequest = tools != null && !tools.isEmpty();
         if (Boolean.TRUE.equals(jsonPrefill) && !hasToolsInRequest) {
             anthropicMessages.add(

--- a/integrations/chat-models/azureai/src/main/java/org/apache/flink/agents/integrations/chatmodels/azureai/AzureAIChatModelConnection.java
+++ b/integrations/chat-models/azureai/src/main/java/org/apache/flink/agents/integrations/chatmodels/azureai/AzureAIChatModelConnection.java
@@ -161,7 +161,7 @@ public class AzureAIChatModelConnection extends BaseChatModelConnection {
 
     @Override
     public ChatMessage chat(
-            List<ChatMessage> messages, List<Tool> tools, Map<String, Object> arguments) {
+            List<ChatMessage> messages, List<Tool> tools, Map<String, Object> modelParams) {
         try {
             final List<ChatCompletionsToolDefinition> azureTools = convertToAzureAITools(tools);
             final List<ChatRequestMessage> chatMessages =
@@ -169,7 +169,7 @@ public class AzureAIChatModelConnection extends BaseChatModelConnection {
                             .map(this::convertToChatRequestMessage)
                             .collect(Collectors.toList());
 
-            final String modelName = (String) arguments.get("model");
+            final String modelName = (String) modelParams.get("model");
             ChatCompletionsOptions options =
                     new ChatCompletionsOptions(chatMessages)
                             .setModel(modelName)

--- a/integrations/chat-models/bedrock/src/main/java/org/apache/flink/agents/integrations/chatmodels/bedrock/BedrockChatModelConnection.java
+++ b/integrations/chat-models/bedrock/src/main/java/org/apache/flink/agents/integrations/chatmodels/bedrock/BedrockChatModelConnection.java
@@ -119,8 +119,8 @@ public class BedrockChatModelConnection extends BaseChatModelConnection {
 
     @Override
     public ChatMessage chat(
-            List<ChatMessage> messages, List<Tool> tools, Map<String, Object> arguments) {
-        String modelId = resolveModel(arguments);
+            List<ChatMessage> messages, List<Tool> tools, Map<String, Object> modelParams) {
+        String modelId = resolveModel(modelParams);
 
         List<ChatMessage> systemMsgs =
                 messages.stream()
@@ -154,14 +154,14 @@ public class BedrockChatModelConnection extends BaseChatModelConnection {
         }
 
         // Inference config: temperature and max_tokens
-        if (arguments != null) {
+        if (modelParams != null) {
             InferenceConfiguration.Builder inferenceBuilder = null;
-            Object temp = arguments.get("temperature");
+            Object temp = modelParams.get("temperature");
             if (temp instanceof Number) {
                 inferenceBuilder = InferenceConfiguration.builder();
                 inferenceBuilder.temperature(((Number) temp).floatValue());
             }
-            Object maxTokens = arguments.get("max_tokens");
+            Object maxTokens = modelParams.get("max_tokens");
             if (maxTokens instanceof Number) {
                 if (inferenceBuilder == null) {
                     inferenceBuilder = InferenceConfiguration.builder();
@@ -202,8 +202,8 @@ public class BedrockChatModelConnection extends BaseChatModelConnection {
         this.client.close();
     }
 
-    private String resolveModel(Map<String, Object> arguments) {
-        String model = arguments != null ? (String) arguments.get("model") : null;
+    private String resolveModel(Map<String, Object> modelParams) {
+        String model = modelParams != null ? (String) modelParams.get("model") : null;
         if (model == null || model.isBlank()) {
             model = this.defaultModel;
         }

--- a/integrations/chat-models/ollama/src/main/java/org/apache/flink/agents/integrations/chatmodels/ollama/OllamaChatModelConnection.java
+++ b/integrations/chat-models/ollama/src/main/java/org/apache/flink/agents/integrations/chatmodels/ollama/OllamaChatModelConnection.java
@@ -175,10 +175,10 @@ public class OllamaChatModelConnection extends BaseChatModelConnection {
 
     @Override
     public ChatMessage chat(
-            List<ChatMessage> messages, List<Tool> tools, Map<String, Object> arguments) {
+            List<ChatMessage> messages, List<Tool> tools, Map<String, Object> modelParams) {
         try {
             // convert think to think mode.
-            final Object think = arguments.getOrDefault("think", true);
+            final Object think = modelParams.getOrDefault("think", true);
             ThinkMode thinkMode = ThinkMode.ENABLED;
             for (ThinkMode mode : ThinkMode.values()) {
                 if (mode.getValue().equals(think)) {
@@ -188,7 +188,7 @@ public class OllamaChatModelConnection extends BaseChatModelConnection {
             }
 
             final boolean extractReasoning =
-                    (boolean) arguments.getOrDefault("extract_reasoning", true);
+                    (boolean) modelParams.getOrDefault("extract_reasoning", true);
 
             final List<Tools.Tool> ollamaTools = this.convertToOllamaTools(tools);
             final List<OllamaChatMessage> ollamaChatMessages =
@@ -196,7 +196,7 @@ public class OllamaChatModelConnection extends BaseChatModelConnection {
                             .map(this::convertToOllamaChatMessages)
                             .collect(Collectors.toList());
 
-            final String modelName = (String) arguments.get("model");
+            final String modelName = (String) modelParams.get("model");
             final OllamaChatRequest chatRequest =
                     OllamaChatRequest.builder()
                             .withMessages(ollamaChatMessages)

--- a/integrations/chat-models/openai/src/main/java/org/apache/flink/agents/integrations/chatmodels/openai/AzureOpenAIChatModelConnection.java
+++ b/integrations/chat-models/openai/src/main/java/org/apache/flink/agents/integrations/chatmodels/openai/AzureOpenAIChatModelConnection.java
@@ -153,10 +153,10 @@ public class AzureOpenAIChatModelConnection extends BaseChatModelConnection {
 
     @Override
     public ChatMessage chat(
-            List<ChatMessage> messages, List<Tool> tools, Map<String, Object> arguments) {
+            List<ChatMessage> messages, List<Tool> tools, Map<String, Object> modelParams) {
         try {
             Map<String, Object> mutableArgs =
-                    arguments != null ? new HashMap<>(arguments) : new HashMap<>();
+                    modelParams != null ? new HashMap<>(modelParams) : new HashMap<>();
 
             String azureDeployment = (String) mutableArgs.remove("model");
             if (azureDeployment == null || azureDeployment.isBlank()) {

--- a/integrations/chat-models/openai/src/main/java/org/apache/flink/agents/integrations/chatmodels/openai/OpenAICompletionsConnection.java
+++ b/integrations/chat-models/openai/src/main/java/org/apache/flink/agents/integrations/chatmodels/openai/OpenAICompletionsConnection.java
@@ -121,9 +121,9 @@ public class OpenAICompletionsConnection extends BaseChatModelConnection {
 
     @Override
     public ChatMessage chat(
-            List<ChatMessage> messages, List<Tool> tools, Map<String, Object> arguments) {
+            List<ChatMessage> messages, List<Tool> tools, Map<String, Object> modelParams) {
         try {
-            ChatCompletionCreateParams params = buildRequest(messages, tools, arguments);
+            ChatCompletionCreateParams params = buildRequest(messages, tools, modelParams);
             ChatCompletion completion = client.chat().completions().create(params);
             ChatMessage response =
                     OpenAIChatCompletionsUtils.convertFromOpenAIMessage(
@@ -131,7 +131,7 @@ public class OpenAICompletionsConnection extends BaseChatModelConnection {
 
             // Stash token usage
             if (completion.usage().isPresent()) {
-                String modelName = arguments != null ? (String) arguments.get("model") : null;
+                String modelName = modelParams != null ? (String) modelParams.get("model") : null;
                 if (modelName == null || modelName.isBlank()) {
                     modelName = this.defaultModel;
                 }
@@ -151,12 +151,12 @@ public class OpenAICompletionsConnection extends BaseChatModelConnection {
     }
 
     private ChatCompletionCreateParams buildRequest(
-            List<ChatMessage> messages, List<Tool> tools, Map<String, Object> rawArguments) {
-        Map<String, Object> arguments =
-                rawArguments != null ? new HashMap<>(rawArguments) : new HashMap<>();
+            List<ChatMessage> messages, List<Tool> tools, Map<String, Object> rawModelParams) {
+        Map<String, Object> modelParams =
+                rawModelParams != null ? new HashMap<>(rawModelParams) : new HashMap<>();
 
-        boolean strictMode = Boolean.TRUE.equals(arguments.remove("strict"));
-        String modelName = (String) arguments.remove("model");
+        boolean strictMode = Boolean.TRUE.equals(modelParams.remove("strict"));
+        String modelName = (String) modelParams.remove("model");
         if (modelName == null || modelName.isBlank()) {
             modelName = this.defaultModel;
         }
@@ -170,36 +170,36 @@ public class OpenAICompletionsConnection extends BaseChatModelConnection {
             builder.tools(convertTools(tools, strictMode));
         }
 
-        Object temperature = arguments.remove("temperature");
+        Object temperature = modelParams.remove("temperature");
         if (temperature instanceof Number) {
             builder.temperature(((Number) temperature).doubleValue());
         }
 
-        Object maxTokens = arguments.remove("max_tokens");
+        Object maxTokens = modelParams.remove("max_tokens");
         if (maxTokens instanceof Number) {
             builder.maxCompletionTokens(((Number) maxTokens).longValue());
         }
 
-        Object logprobs = arguments.remove("logprobs");
+        Object logprobs = modelParams.remove("logprobs");
         boolean logprobsEnabled = Boolean.TRUE.equals(logprobs);
         if (logprobsEnabled) {
             builder.logprobs(true);
-            Object topLogprobs = arguments.remove("top_logprobs");
+            Object topLogprobs = modelParams.remove("top_logprobs");
             if (topLogprobs instanceof Number) {
                 builder.topLogprobs(((Number) topLogprobs).longValue());
             }
         } else {
-            arguments.remove("top_logprobs");
+            modelParams.remove("top_logprobs");
         }
 
-        Object reasoningEffort = arguments.remove("reasoning_effort");
+        Object reasoningEffort = modelParams.remove("reasoning_effort");
         if (reasoningEffort instanceof String) {
             builder.reasoningEffort(ReasoningEffort.of((String) reasoningEffort));
         }
 
         @SuppressWarnings("unchecked")
         Map<String, Object> additionalKwargs =
-                (Map<String, Object>) arguments.remove("additional_kwargs");
+                (Map<String, Object>) modelParams.remove("additional_kwargs");
         if (additionalKwargs != null) {
             additionalKwargs.forEach(
                     (key, value) -> builder.putAdditionalBodyProperty(key, toJsonValue(value)));

--- a/integrations/chat-models/openai/src/main/java/org/apache/flink/agents/integrations/chatmodels/openai/OpenAIResponsesModelConnection.java
+++ b/integrations/chat-models/openai/src/main/java/org/apache/flink/agents/integrations/chatmodels/openai/OpenAIResponsesModelConnection.java
@@ -128,14 +128,14 @@ public class OpenAIResponsesModelConnection extends BaseChatModelConnection {
     public ChatMessage chat(
             List<ChatMessage> messages,
             List<org.apache.flink.agents.api.tools.Tool> tools,
-            Map<String, Object> arguments) {
+            Map<String, Object> modelParams) {
         try {
-            ResponseCreateParams params = buildRequest(messages, tools, arguments);
+            ResponseCreateParams params = buildRequest(messages, tools, modelParams);
             Response response = client.responses().create(params);
             ChatMessage result = convertResponse(response);
 
             if (response.usage().isPresent()) {
-                String modelName = arguments != null ? (String) arguments.get("model") : null;
+                String modelName = modelParams != null ? (String) modelParams.get("model") : null;
                 if (modelName == null || modelName.isBlank()) {
                     modelName = this.defaultModel;
                 }
@@ -156,12 +156,12 @@ public class OpenAIResponsesModelConnection extends BaseChatModelConnection {
     private ResponseCreateParams buildRequest(
             List<ChatMessage> messages,
             List<org.apache.flink.agents.api.tools.Tool> tools,
-            Map<String, Object> rawArguments) {
-        Map<String, Object> arguments =
-                rawArguments != null ? new HashMap<>(rawArguments) : new HashMap<>();
+            Map<String, Object> rawModelParams) {
+        Map<String, Object> modelParams =
+                rawModelParams != null ? new HashMap<>(rawModelParams) : new HashMap<>();
 
-        boolean strictMode = Boolean.TRUE.equals(arguments.remove("strict"));
-        String modelName = (String) arguments.remove("model");
+        boolean strictMode = Boolean.TRUE.equals(modelParams.remove("strict"));
+        String modelName = (String) modelParams.remove("model");
         if (modelName == null || modelName.isBlank()) {
             modelName = this.defaultModel;
         }
@@ -177,17 +177,17 @@ public class OpenAIResponsesModelConnection extends BaseChatModelConnection {
             builder.tools(convertTools(tools, strictMode));
         }
 
-        Object temperature = arguments.remove("temperature");
+        Object temperature = modelParams.remove("temperature");
         if (temperature instanceof Number) {
             builder.temperature(((Number) temperature).doubleValue());
         }
 
-        Object maxTokens = arguments.remove("max_tokens");
+        Object maxTokens = modelParams.remove("max_tokens");
         if (maxTokens instanceof Number) {
             builder.maxOutputTokens(((Number) maxTokens).longValue());
         }
 
-        Object reasoningEffort = arguments.remove("reasoning_effort");
+        Object reasoningEffort = modelParams.remove("reasoning_effort");
         if (reasoningEffort instanceof String) {
             builder.reasoning(
                     Reasoning.builder()
@@ -195,19 +195,19 @@ public class OpenAIResponsesModelConnection extends BaseChatModelConnection {
                             .build());
         }
 
-        Object store = arguments.remove("store");
+        Object store = modelParams.remove("store");
         if (Boolean.TRUE.equals(store)) {
             builder.store(true);
         }
 
-        Object instructions = arguments.remove("instructions");
+        Object instructions = modelParams.remove("instructions");
         if (instructions instanceof String) {
             builder.instructions((String) instructions);
         }
 
         @SuppressWarnings("unchecked")
         Map<String, Object> additionalKwargs =
-                (Map<String, Object>) arguments.remove("additional_kwargs");
+                (Map<String, Object>) modelParams.remove("additional_kwargs");
         if (additionalKwargs != null) {
             additionalKwargs.forEach(
                     (key, value) -> builder.putAdditionalBodyProperty(key, toJsonValue(value)));


### PR DESCRIPTION
Linked issue: #715

### Purpose of change

After #698 renamed the setup-layer `BaseChatModelSetup.chat()` model-parameters argument to `modelParams`, the connection layer still named the same value `arguments` — the setup's `modelParams` was passed straight into `BaseChatModelConnection.chat(... Map<String, Object> arguments)`, i.e. one concept under two names across a single call hop, and `arguments` also collided with the (now-renamed) prompt-template and the tool-call `arguments`.

This renames the connection-layer model-parameters identifier `arguments` → `modelParams` so the concept has one consistent name end-to-end. It covers the `BaseChatModelConnection.chat(...)` abstract method (signature + Javadoc), the Pemja bridge override, the seven provider connections (Anthropic, Ollama, Bedrock, OpenAI Responses/Completions/AzureOpenAI, AzureAI), and their in-file model-params locals/helper params (including `rawArguments` → `rawModelParams` in the `buildRequest` helpers).

Unrelated `arguments` are deliberately left untouched: tool-call `"arguments"` JSON keys, the `parseArguments`/`serializeArguments` tool-call helpers, MCP `arguments`, and `JavaResourceAdapter`'s tool-call `arguments`.

**Compatibility:** `BaseChatModelConnection.chat(...)` is a public abstract method, so custom connection implementations update their override's parameter name. The change is erasure-compatible (positional), so call sites are unaffected, and it is invisible across the Python boundary — the Pemja bridge forwards the map contents, never a key named `"arguments"`, so the Python connection layer (which already uses `**kwargs`) needs no change.

### Tests

No new tests — this is a behavior-preserving, name-only positional rename; existing tests recompiling and passing against the new signature is the correctness guarantee. Verified locally:
- `mvn -pl api -am test-compile` and `test-compile` of the five chat-model modules: pass
- `mvn -pl api test -Dtest='BaseChatModelSetupSkillsTest,BaseChatModelTest,PythonChatModelConnectionTest'`: 20/20 pass
- `spotless:check` on all touched modules: clean

### API

Yes — renames the parameter of the public abstract method `BaseChatModelConnection.chat(...)` (and all provider overrides) from `arguments` to `modelParams`. Erasure-compatible/positional: call sites unaffected; only custom subclass overrides update the parameter name.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`
