### PR TITLE
[python][plan] Make AgentPlan.getResource thread-safe (backport #548 to release-0.2)

### DIFF
--- a/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
@@ -223,12 +223,17 @@ public class AgentPlan implements Serializable {
     /**
      * Get resource from agent plan.
      *
+     * <p>Synchronized so the check-create-cache sequence is atomic: concurrent first accesses to
+     * the same uncached resource invoke the provider once and share a single instance. The
+     * intrinsic lock is reentrant, so the nested resolution callback below can call back into this
+     * method on the same thread.
+     *
      * @param name the resource name
      * @param type the resource type
      * @return the resource instance
      * @throws Exception if the resource cannot be found or created
      */
-    public Resource getResource(String name, ResourceType type) throws Exception {
+    public synchronized Resource getResource(String name, ResourceType type) throws Exception {
         // Check cache first
         if (resourceCache.containsKey(type) && resourceCache.get(type).containsKey(name)) {
             return resourceCache.get(type).get(name);

--- a/plan/src/test/java/org/apache/flink/agents/plan/AgentPlanTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/AgentPlanTest.java
@@ -46,8 +46,16 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import pemja.core.object.PyObject;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -478,6 +486,53 @@ public class AgentPlanTest {
         // Test that resources are cached (should be the same instance)
         Resource myToolAgain = agentPlan.getResource("myTool", ResourceType.TOOL);
         assertThat(myTool).isSameAs(myToolAgain);
+    }
+
+    @Test
+    void getResourceShouldCreateOnlyOneInstanceUnderConcurrentAccess() throws Exception {
+        AtomicInteger created = new AtomicInteger();
+
+        ResourceProvider provider =
+                new ResourceProvider("shared-tool", ResourceType.TOOL) {
+                    @Override
+                    public Resource provide(BiFunction<String, ResourceType, Resource> getResource)
+                            throws Exception {
+                        // Sleep so both callers enter getResource before either caches.
+                        Thread.sleep(200);
+                        created.incrementAndGet();
+                        return new Resource() {
+                            @Override
+                            public ResourceType getResourceType() {
+                                return ResourceType.TOOL;
+                            }
+                        };
+                    }
+                };
+
+        Map<ResourceType, Map<String, ResourceProvider>> providers = new HashMap<>();
+        providers.put(ResourceType.TOOL, Map.of("shared-tool", provider));
+        AgentPlan plan = new AgentPlan(new HashMap<>(), new HashMap<>(), providers);
+
+        CyclicBarrier start = new CyclicBarrier(2);
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            Callable<Resource> task =
+                    () -> {
+                        start.await();
+                        return plan.getResource("shared-tool", ResourceType.TOOL);
+                    };
+
+            Future<Resource> first = pool.submit(task);
+            Future<Resource> second = pool.submit(task);
+
+            Resource firstResource = first.get(10, TimeUnit.SECONDS);
+            Resource secondResource = second.get(10, TimeUnit.SECONDS);
+
+            assertThat(firstResource).isSameAs(secondResource);
+            assertThat(created.get()).isEqualTo(1);
+        } finally {
+            pool.shutdownNow();
+        }
     }
 
     @Test

--- a/python/flink_agents/plan/agent_plan.py
+++ b/python/flink_agents/plan/agent_plan.py
@@ -15,6 +15,8 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 #################################################################################
+import threading
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, Dict, List, cast
 
 from pydantic import BaseModel, field_serializer, model_validator
@@ -61,6 +63,14 @@ class AgentPlan(BaseModel):
     config: AgentConfiguration | None = None
     __resources: Dict[ResourceType, Dict[str, Resource]] = {}
     __j_resource_adapter: Any = None
+
+    @cached_property
+    def _resource_lock(self) -> threading.RLock:
+        # Guards the lazy check-create-cache in get_resource so concurrent first
+        # accesses to the same uncached resource create a single instance.
+        # Reentrant because resource resolution can call back into get_resource
+        # on the same thread (e.g. a chat model setup resolving its connection).
+        return threading.RLock()
 
     @field_serializer("resource_providers")
     def __serialize_resource_providers(
@@ -209,17 +219,20 @@ class AgentPlan(BaseModel):
         type : ResourceType
             The type of the resource.
         """
-        if type not in self.__resources:
-            self.__resources[type] = {}
-        if name not in self.__resources[type]:
-            resource_provider = self.resource_providers[type][name]
-            if isinstance(resource_provider, JavaResourceProvider):
-                resource_provider.set_java_resource_adapter(self.__j_resource_adapter)
-            resource = resource_provider.provide(
-                get_resource=self.get_resource, config=self.config
-            )
-            self.__resources[type][name] = resource
-        return self.__resources[type][name]
+        with self._resource_lock:
+            if type not in self.__resources:
+                self.__resources[type] = {}
+            if name not in self.__resources[type]:
+                resource_provider = self.resource_providers[type][name]
+                if isinstance(resource_provider, JavaResourceProvider):
+                    resource_provider.set_java_resource_adapter(
+                        self.__j_resource_adapter
+                    )
+                resource = resource_provider.provide(
+                    get_resource=self.get_resource, config=self.config
+                )
+                self.__resources[type][name] = resource
+            return self.__resources[type][name]
 
     def set_java_resource_adapter(self, j_resource_adapter: Any) -> None:
         """Set java resource adapter for java resource provider."""

--- a/python/flink_agents/plan/tests/test_agent_plan.py
+++ b/python/flink_agents/plan/tests/test_agent_plan.py
@@ -16,6 +16,8 @@
 # limitations under the License.
 #################################################################################
 import json
+import threading
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Sequence
 
@@ -36,7 +38,7 @@ from flink_agents.api.embedding_models.embedding_model import (
     BaseEmbeddingModelSetup,
 )
 from flink_agents.api.events.event import Event, InputEvent, OutputEvent
-from flink_agents.api.resource import ResourceDescriptor, ResourceType
+from flink_agents.api.resource import Resource, ResourceDescriptor, ResourceType
 from flink_agents.api.runner_context import RunnerContext
 from flink_agents.api.vector_stores.vector_store import (
     BaseVectorStore,
@@ -45,6 +47,7 @@ from flink_agents.api.vector_stores.vector_store import (
 from flink_agents.plan.agent_plan import AgentPlan
 from flink_agents.plan.configuration import AgentConfiguration
 from flink_agents.plan.function import PythonFunction
+from flink_agents.plan.resource_provider import ResourceProvider
 
 
 class AgentForTest(Agent):  # noqa D101
@@ -260,6 +263,47 @@ def test_get_resource() -> None:  # noqa: D103
         mock.chat(ChatMessage(role=MessageRole.USER, content="")).content
         == "8.8.8.8 mock resource just for testing."
     )
+
+
+def test_get_resource_single_instance_under_concurrent_access() -> None:
+    """Concurrent first access to an uncached resource must create one instance."""
+    created: List[int] = []
+
+    class _DummyResource(Resource):
+        @classmethod
+        def resource_type(cls) -> ResourceType:
+            return ResourceType.TOOL
+
+    class _SlowCountingProvider(ResourceProvider):
+        def provide(self, get_resource: Any, config: Any) -> Resource:
+            # Widen the race window so both callers enter provide() before
+            # either caches the result.
+            time.sleep(0.2)
+            created.append(1)
+            return _DummyResource()
+
+    provider = _SlowCountingProvider(name="shared-tool", type=ResourceType.TOOL)
+    agent_plan = AgentPlan(
+        actions={},
+        actions_by_event={},
+        resource_providers={ResourceType.TOOL: {"shared-tool": provider}},
+    )
+
+    barrier = threading.Barrier(2)
+    results: List[Resource] = []
+
+    def task() -> None:
+        barrier.wait()
+        results.append(agent_plan.get_resource("shared-tool", ResourceType.TOOL))
+
+    threads = [threading.Thread(target=task) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert len(created) == 1
+    assert results[0] is results[1]
 
 
 def test_add_action_and_resource_to_agent() -> None:  # noqa: D103


### PR DESCRIPTION
Linked issue: #724

### Purpose of change

Backport the resource-cache thread-safety fix to `release-0.2`.

`AgentPlan#getResource` performs a non-atomic check-create-cache sequence. When two actions concurrently trigger the first access to the same uncached resource, both can invoke the provider and create duplicate instances (duplicate model/tool init, duplicate metric registration) before the last writer wins the cache.

On `main` this was addressed as a side effect of #548 (f8eac10), which moved resource caching out of `AgentPlan` into a dedicated `ResourceCache` whose `getResource` is synchronized. That refactor never landed on `release-0.2`, so the race is still live there. Backporting the full `ResourceCache` extraction to a maintenance branch is heavier than warranted; the minimal equivalent is to guard the lazy resolution with a reentrant lock — the same mechanism `main` relies on.

This PR applies that minimal guard on both language sides:

- Java: make `AgentPlan#getResource` `synchronized`. The intrinsic lock is reentrant, so the nested resolution callback can still call back into `getResource` on the same thread.
- Python: guard `AgentPlan.get_resource` with a per-instance reentrant lock. The async action thread pool runs actions on multiple threads, and `provider.provide` can release the GIL when it calls into Java via Pemja, so the same race exists. The lock is a `cached_property` (not a Pydantic private attribute) so it stays out of model equality.

### Tests

- Java: `AgentPlanTest#getResourceShouldCreateOnlyOneInstanceUnderConcurrentAccess` — two threads race on the first access to a shared resource whose provider sleeps; asserts a single instance is created and both callers see it.
- Python: `test_get_resource_single_instance_under_concurrent_access` — same contract via two threads and a `threading.Barrier`; asserts the provider runs once.

Both tests fail without the corresponding guard and pass with it.

### API

No public API changes.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`
