### PR TITLE
[integrations][mcp] Read MCP server timeout from the "timeout" descriptor argument

### DIFF
--- a/integrations/mcp/src/main/java/org/apache/flink/agents/integrations/mcp/MCPServer.java
+++ b/integrations/mcp/src/main/java/org/apache/flink/agents/integrations/mcp/MCPServer.java
@@ -81,7 +81,7 @@ public class MCPServer extends Resource {
 
     private static final String FIELD_ENDPOINT = "endpoint";
     private static final String FIELD_HEADERS = "headers";
-    private static final String FIELD_TIMEOUT_SECONDS = "timeoutSeconds";
+    private static final String FIELD_TIMEOUT = "timeout";
     private static final String FIELD_AUTH = "auth";
     private static final String FIELD_MAX_RETRIES = "maxRetries";
     private static final String FIELD_INITIAL_BACKOFF_MS = "initialBackoffMs";
@@ -95,7 +95,7 @@ public class MCPServer extends Resource {
     @JsonProperty(FIELD_HEADERS)
     private final Map<String, String> headers;
 
-    @JsonProperty(FIELD_TIMEOUT_SECONDS)
+    @JsonProperty(FIELD_TIMEOUT)
     private final long timeoutSeconds;
 
     @JsonProperty(FIELD_AUTH)
@@ -180,7 +180,7 @@ public class MCPServer extends Resource {
                         descriptor.getArgument(FIELD_ENDPOINT), "endpoint cannot be null");
         Map<String, String> headers = descriptor.getArgument(FIELD_HEADERS);
         this.headers = headers != null ? new HashMap<>(headers) : new HashMap<>();
-        Object timeoutArg = descriptor.getArgument(FIELD_TIMEOUT_SECONDS);
+        Object timeoutArg = descriptor.getArgument(FIELD_TIMEOUT);
         this.timeoutSeconds =
                 timeoutArg instanceof Number
                         ? ((Number) timeoutArg).longValue()
@@ -215,7 +215,7 @@ public class MCPServer extends Resource {
     public MCPServer(
             @JsonProperty(FIELD_ENDPOINT) String endpoint,
             @JsonProperty(FIELD_HEADERS) Map<String, String> headers,
-            @JsonProperty(FIELD_TIMEOUT_SECONDS) Long timeoutSeconds,
+            @JsonProperty(FIELD_TIMEOUT) Long timeoutSeconds,
             @JsonProperty(FIELD_AUTH) Auth auth,
             @JsonProperty(FIELD_MAX_RETRIES) Integer maxRetries,
             @JsonProperty(FIELD_INITIAL_BACKOFF_MS) Long initialBackoffMs,

--- a/integrations/mcp/src/test/java/org/apache/flink/agents/integrations/mcp/MCPServerTest.java
+++ b/integrations/mcp/src/test/java/org/apache/flink/agents/integrations/mcp/MCPServerTest.java
@@ -19,6 +19,9 @@
 package org.apache.flink.agents.integrations.mcp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.agents.api.resource.ResourceContext;
+import org.apache.flink.agents.api.resource.ResourceDescriptor;
+import org.apache.flink.agents.api.resource.ResourceName;
 import org.apache.flink.agents.api.resource.ResourceType;
 import org.apache.flink.agents.integrations.mcp.auth.ApiKeyAuth;
 import org.apache.flink.agents.integrations.mcp.auth.BasicAuth;
@@ -69,6 +72,28 @@ class MCPServerTest {
         assertThat(server.getHeaders()).isEmpty();
         assertThat(server.getTimeoutSeconds()).isEqualTo(30);
         assertThat(server.getAuth()).isNull();
+    }
+
+    @Test
+    @DisabledOnJre(JRE.JAVA_11)
+    @DisplayName("Read timeout from ResourceDescriptor")
+    void testTimeoutFromResourceDescriptor() {
+        ResourceDescriptor descriptor =
+                ResourceDescriptor.Builder.newBuilder(ResourceName.MCP_SERVER)
+                        .addInitialArgument("endpoint", DEFAULT_ENDPOINT)
+                        .addInitialArgument("timeout", 60)
+                        .build();
+
+        MCPServer server =
+                new MCPServer(
+                        descriptor,
+                        ResourceContext.fromGetResource(
+                                (name, type) -> {
+                                    throw new UnsupportedOperationException(
+                                            "No dependencies expected");
+                                }));
+
+        assertThat(server.getTimeoutSeconds()).isEqualTo(60);
     }
 
     @Test


### PR DESCRIPTION
Linked issue: Closes #770, refs #762

### Purpose of change

Java `MCPServer` read its connection timeout from the `ResourceDescriptor` using the key
`"timeoutSeconds"`, while the docs, the test, the Python implementation and all other
connections use `"timeout"`. As a result `addInitialArgument("timeout", N)` was silently
ignored and the hard-coded 30s default always applied.

This renames the descriptor/JSON key to `"timeout"` — a single constant in `MCPServer.java`,
which also aligns the Jackson wire key with the Python side. The documentation already uses
`"timeout"` and needs no change.

### Tests

Added regression test `MCPServerTest#testTimeoutFromResourceDescriptor`: builds an `MCPServer`
from a `ResourceDescriptor` with `timeout=60` and asserts `getTimeoutSeconds() == 60` (returns
`30` before the fix). Verified locally:
- `mvn -pl integrations/mcp test`: 38/38 pass
- `spotless:check` on the module: clean

### API

No public API changes. Only the internal descriptor-argument / JSON key string changes; the
`MCPServer` Java field, the `getTimeoutSeconds()` getter and the default value are unchanged.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`
