### PR TITLE
[bugfix][examples] Point quickstart FileSource at product_review.txt instead of the resources dir

### DIFF
--- a/docs/content/docs/get-started/quickstart/react_agent.md
+++ b/docs/content/docs/get-started/quickstart/react_agent.md
@@ -134,7 +134,7 @@ Produce a source DataStream by reading a product review text file, and use the R
 product_review_stream = env.from_source(
     source=FileSource.for_record_stream_format(
         StreamFormat.text_line_format(),
-        f"file:///{current_dir}/resources/",
+        f"file:///{current_dir}/resources/product_review.txt",
     )
     .monitor_continuously(Duration.of_minutes(1))
     .build(),

--- a/docs/content/docs/get-started/quickstart/react_agent.md
+++ b/docs/content/docs/get-started/quickstart/react_agent.md
@@ -132,6 +132,8 @@ Produce a source DataStream by reading a product review text file, and use the R
 # Read product reviews from a text file as a streaming source.
 # Each line in the file should be a JSON string representing a ProductReview.
 product_review_stream = env.from_source(
+    # Target the single file, not the resources/ dir: Flink's enumerator
+    # recurses, so files like skills/SKILL.md would be parsed as reviews.
     source=FileSource.for_record_stream_format(
         StreamFormat.text_line_format(),
         f"file:///{current_dir}/resources/product_review.txt",

--- a/docs/content/docs/get-started/quickstart/workflow_agent.md
+++ b/docs/content/docs/get-started/quickstart/workflow_agent.md
@@ -285,7 +285,8 @@ Create the input DataStream by reading the product reviews from a text file as a
 # Each line in the file should be a JSON string representing a ProductReview.
 product_review_stream = env.from_source(
     source=FileSource.for_record_stream_format(
-        StreamFormat.text_line_format(), f"file:///{current_dir}/resources"
+        StreamFormat.text_line_format(),
+        f"file:///{current_dir}/resources/product_review.txt",
     )
     .monitor_continuously(Duration.of_minutes(1))
     .build(),

--- a/docs/content/docs/get-started/quickstart/workflow_agent.md
+++ b/docs/content/docs/get-started/quickstart/workflow_agent.md
@@ -284,6 +284,8 @@ Create the input DataStream by reading the product reviews from a text file as a
 # Read product reviews from a text file as a streaming source.
 # Each line in the file should be a JSON string representing a ProductReview.
 product_review_stream = env.from_source(
+    # Target the single file, not the resources/ dir: Flink's enumerator
+    # recurses, so files like skills/SKILL.md would be parsed as reviews.
     source=FileSource.for_record_stream_format(
         StreamFormat.text_line_format(),
         f"file:///{current_dir}/resources/product_review.txt",

--- a/docs/content/docs/get-started/quickstart/yaml_agent.md
+++ b/docs/content/docs/get-started/quickstart/yaml_agent.md
@@ -212,6 +212,8 @@ agents_env.load_yaml(current_dir / "yaml_review_analysis_agent.yaml")
 
 # Read product reviews from a text file as a streaming source.
 product_review_stream = env.from_source(
+    # Target the single file, not the resources/ dir: Flink's enumerator
+    # recurses, so files like skills/SKILL.md would be parsed as reviews.
     source=FileSource.for_record_stream_format(
         StreamFormat.text_line_format(),
         f"file:///{current_dir}/resources/product_review.txt",

--- a/docs/content/docs/get-started/quickstart/yaml_agent.md
+++ b/docs/content/docs/get-started/quickstart/yaml_agent.md
@@ -213,7 +213,8 @@ agents_env.load_yaml(current_dir / "yaml_review_analysis_agent.yaml")
 # Read product reviews from a text file as a streaming source.
 product_review_stream = env.from_source(
     source=FileSource.for_record_stream_format(
-        StreamFormat.text_line_format(), f"file:///{current_dir}/resources"
+        StreamFormat.text_line_format(),
+        f"file:///{current_dir}/resources/product_review.txt",
     )
     .monitor_continuously(Duration.of_minutes(1))
     .build(),

--- a/python/flink_agents/examples/quickstart/react_agent_example.py
+++ b/python/flink_agents/examples/quickstart/react_agent_example.py
@@ -76,7 +76,7 @@ def main() -> None:
     product_review_stream = env.from_source(
         source=FileSource.for_record_stream_format(
             StreamFormat.text_line_format(),
-            f"file:///{current_dir}/resources/",
+            f"file:///{current_dir}/resources/product_review.txt",
         )
         .monitor_continuously(Duration.of_minutes(1))
         .build(),

--- a/python/flink_agents/examples/quickstart/react_agent_example.py
+++ b/python/flink_agents/examples/quickstart/react_agent_example.py
@@ -74,6 +74,8 @@ def main() -> None:
     # Read product reviews from a text file as a streaming source.
     # Each line in the file should be a JSON string representing a ProductReview.
     product_review_stream = env.from_source(
+        # Target the single file, not the resources/ dir: Flink's enumerator
+        # recurses, so files like skills/SKILL.md would be parsed as reviews.
         source=FileSource.for_record_stream_format(
             StreamFormat.text_line_format(),
             f"file:///{current_dir}/resources/product_review.txt",

--- a/python/flink_agents/examples/quickstart/workflow_single_agent_example.py
+++ b/python/flink_agents/examples/quickstart/workflow_single_agent_example.py
@@ -61,6 +61,8 @@ def main() -> None:
     # Read product reviews from a text file as a streaming source.
     # Each line in the file should be a JSON string representing a ProductReview.
     product_review_stream = env.from_source(
+        # Target the single file, not the resources/ dir: Flink's enumerator
+        # recurses, so files like skills/SKILL.md would be parsed as reviews.
         source=FileSource.for_record_stream_format(
             StreamFormat.text_line_format(),
             f"file:///{current_dir}/resources/product_review.txt",

--- a/python/flink_agents/examples/quickstart/workflow_single_agent_example.py
+++ b/python/flink_agents/examples/quickstart/workflow_single_agent_example.py
@@ -62,7 +62,8 @@ def main() -> None:
     # Each line in the file should be a JSON string representing a ProductReview.
     product_review_stream = env.from_source(
         source=FileSource.for_record_stream_format(
-            StreamFormat.text_line_format(), f"file:///{current_dir}/resources"
+            StreamFormat.text_line_format(),
+            f"file:///{current_dir}/resources/product_review.txt",
         )
         .monitor_continuously(Duration.of_minutes(1))
         .build(),

--- a/python/flink_agents/examples/quickstart/yaml_workflow_agent_example.py
+++ b/python/flink_agents/examples/quickstart/yaml_workflow_agent_example.py
@@ -54,6 +54,8 @@ def main() -> None:
     # Read product reviews from a text file as a streaming source.
     # Each line in the file should be a JSON string representing a ProductReview.
     product_review_stream = env.from_source(
+        # Target the single file, not the resources/ dir: Flink's enumerator
+        # recurses, so files like skills/SKILL.md would be parsed as reviews.
         source=FileSource.for_record_stream_format(
             StreamFormat.text_line_format(),
             f"file:///{current_dir}/resources/product_review.txt",

--- a/python/flink_agents/examples/quickstart/yaml_workflow_agent_example.py
+++ b/python/flink_agents/examples/quickstart/yaml_workflow_agent_example.py
@@ -55,7 +55,8 @@ def main() -> None:
     # Each line in the file should be a JSON string representing a ProductReview.
     product_review_stream = env.from_source(
         source=FileSource.for_record_stream_format(
-            StreamFormat.text_line_format(), f"file:///{current_dir}/resources"
+            StreamFormat.text_line_format(),
+            f"file:///{current_dir}/resources/product_review.txt",
         )
         .monitor_continuously(Duration.of_minutes(1))
         .build(),


### PR DESCRIPTION
Linked issue: #776

### Purpose of change

The three product-review quickstart examples build a `FileSource` over the whole
`resources/` directory. Flink's default file enumerator recurses into
subdirectories, so after #707 added `skills/math-calculator/SKILL.md` under
`resources/`, the source reads that markdown file and feeds each line to
`ProductReview.model_validate_json()`, which raises a `ValidationError` and fails
the job.

This affects all three Python quickstart examples that read the directory, not
just the one in the issue:
- `workflow_single_agent_example.py`
- `yaml_workflow_agent_example.py`
- `react_agent_example.py`

The fix points each `FileSource` at the specific `resources/product_review.txt`
file — the same single-file targeting the Java examples already use via
`copyResource`. The `skills/` resources and packaging are left untouched, so the
skills example keeps working.

For reference, the following are **not** affected and need no change:
- The 3 Java examples (`WorkflowSingleAgentExample` / `ReActAgentExample` /
  `YamlWorkflowAgentExample`) — their `resources/` is polluted the same way, but
  they copy a single `input_data.txt` to a temp dir and target that one file.
- The e2e tests — each `FileSource` targets a dedicated single-record input
  subdir (`execute_test_input/`, `input/`, `java_chat_module_input/`, …).

### Tests

- `ruff check` and `ruff format --check` pass on the changed examples.
- `python -m py_compile` passes on the three examples.
- Root cause verified against the bundled Flink 2.2.1 `flink-connector-files`
  jar: the default `NonSplittingRecursiveEnumerator` + `DefaultFileFilter`
  recurse into `skills/` and emit `SKILL.md` (only names starting with `.`/`_`
  are skipped). Narrowing the source to the single file avoids it.

### API

No public API changes.

### Documentation

- [ ] `doc-needed`
- [ ] `doc-not-needed`
- [x] `doc-included` <!-- the matching Python snippets in docs/.../quickstart/{workflow_agent,yaml_agent,react_agent}.md are updated in this PR -->
