### PR TITLE
[docs] Clarify Java toTable takes only Schema in integrate_with_flink

### DIFF
--- a/docs/content/docs/development/integrate_with_flink.md
+++ b/docs/content/docs/development/integrate_with_flink.md
@@ -172,7 +172,13 @@ Table outputTable =
 {{< /tabs >}}
 
 
-User should provide `KeySelector` in `from_table()` to tell how to convert the input `Table` to `KeyedStream` internally. And provide `Schema` and `TypeInformation` in `to_table()` to tell the output `Table` schema.
+User should provide `KeySelector` in `from_table()` to tell how to convert the input `Table` to `KeyedStream` internally.
+
+The arguments required by `to_table()` differ by language:
+
+- **Python**: provide both `Schema` and `TypeInformation` to define the output `Table` schema.
+- **Java**: provide only `Schema` (`toTable(Schema)`); `TypeInformation` is not required.
+
 {{< hint info >}}
-Currently, user should provide both `Schema` and `TypeInformation` when call `to_table()`, we will support only provide one of them in the future.
+In Python, `to_table()` currently requires both `Schema` and `TypeInformation`; we plan to support providing only one of them in the future.
 {{< /hint >}}


### PR DESCRIPTION
Linked issue: #772

### Purpose of change

The general-text paragraph after the `from_table`/`to_table` tabs in
`docs/content/docs/development/integrate_with_flink.md` sits outside the
`{{< /tabs >}}` block, so readers apply it to both languages. It claimed
`to_table()` requires both `Schema` and `TypeInformation`, which is true for
Python only — the Java API accepts only `Schema`:

- Java: `Table toTable(Schema schema)` (`api/src/main/java/org/apache/flink/agents/api/AgentBuilder.java:90`)
- Python: `def to_table(self, schema, output_type)` (`python/flink_agents/api/execution_environment.py:78`)
- e2e tests call single-arg `.toTable(outputSchema)` in `FlinkIntegrationTest`, `ReActAgentTest`, `SkillsIntegrationTest`.

This change scopes the "Schema + TypeInformation" requirement to Python, adds an
explicit note that Java's `toTable(Schema)` does not need `TypeInformation`, and
narrows the info hint to Python.

### Tests

Docs-only change. Verified locally by building the site with Hugo (`hugo` in
`docs/`); the page renders the per-language list and the info hint correctly.

### API

No. Documentation-only; no public API changed.

### Documentation

- [x] `doc-included`
