### PR TITLE
[docs] Fix uncompilable x::getId in integrate_with_flink DataStream snippet

### DIFF
--- a/docs/content/docs/development/integrate_with_flink.md
+++ b/docs/content/docs/development/integrate_with_flink.md
@@ -80,7 +80,7 @@ DataStream<YourPojo> inputStream = env.fromSource(...);
 // integrate agent with input datastream, and return output datastream
 DataStream<Object> outputStream =
         agentsEnv
-                .fromDataStream(inputStream, (KeySelector<YourPojo, String>) x::getId)
+                .fromDataStream(inputStream, (KeySelector<YourPojo, String>) YourPojo::getId)
                 .apply(yourAgent)
                 .toDataStream();
 


### PR DESCRIPTION
## What is the purpose of the change

Found during integrate_with_flink doc verification (#743), reported in #773.

The Java DataStream snippet in `docs/content/docs/development/integrate_with_flink.md`
used `x::getId` — a *bound* method reference on an undefined variable `x`. Copying
the snippet into a real Java class fails to compile:

```
error: cannot find symbol
  symbol:   variable x
```

This fixes it by switching to the *unbound* method reference `YourPojo::getId`,
which matches the function signature of `KeySelector<YourPojo, String>` and is
consistent with the existing working example in `docs/content/docs/development/yaml.md`.

## Brief change log

- `integrate_with_flink.md`: `(KeySelector<YourPojo, String>) x::getId`
  → `(KeySelector<YourPojo, String>) YourPojo::getId`

## Verifying this change

This is a documentation-only change. The corrected form is the same unbound
method-reference pattern already used (and verified) in `yaml.md:349`.

## Does this pull request potentially affect one of the following parts:

No runtime/API impact — documentation only.

Closes #773
