### PR TITLE
[bugfix][prompts] Fix format_string {text} variable collision

### DIFF
--- a/python/flink_agents/api/prompts/utils.py
+++ b/python/flink_agents/api/prompts/utils.py
@@ -35,7 +35,7 @@ class SafeFormatter:
         return str(self.kwargs.get(key, match.group(0)))
 
 
-def format_string(text: str, **kwargs: str) -> str:
+def format_string(_template: str, **kwargs: str) -> str:
     """Format a string with kwargs."""
     formatter = SafeFormatter(kwargs=kwargs)
-    return formatter.format(text)
+    return formatter.format(_template)

--- a/python/flink_agents/api/tests/test_prompt.py
+++ b/python/flink_agents/api/tests/test_prompt.py
@@ -128,3 +128,12 @@ def test_prompt_contain_json_schema() -> None:
         text=f"The json schema is {LocalPrompt.model_json_schema(mode='serialization')}",
     )
     prompt.format_string()
+
+
+def test_prompt_variable_collides_with_internal_param() -> None:
+    # `text` and `template` are natural template variables that must not collide
+    # with the internal positional parameter of format_string.
+    prompt = Prompt.from_text(text="Summarize this {text}, using {template}")
+    assert prompt.format_string(text="article", template="bullets") == (
+        "Summarize this article, using bullets"
+    )


### PR DESCRIPTION
## What is the purpose of the change

Fix #785. `Prompt.format_string(text=...)` raised `TypeError: format_string() got multiple values for argument 'text'` whenever the template used `{text}` (or `{template}`) as a variable, because the internal positional parameter `text` collided with the user-passed kwarg.

## Brief change log

- Rename the positional parameter in `utils.format_string` from `text` to `_template` — internal, non-public, called positionally everywhere, so no compatibility impact.
- Add a regression test covering `{text}`/`{template}` template variables.

## Verifying this change

`python -m pytest flink_agents/api/tests/test_prompt.py` — 7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)