### PR TITLE
[bugfix][docs] Align skills agent quickstart doc model name with code (qwen3:8b → qwen3.5:9b)

### DIFF
--- a/docs/content/docs/get-started/quickstart/skills_agent.md
+++ b/docs/content/docs/get-started/quickstart/skills_agent.md
@@ -99,7 +99,7 @@ class MathAgent(Agent):
         return ResourceDescriptor(
             clazz=ResourceName.ChatModel.OLLAMA_SETUP,
             connection="ollama_server",
-            model="qwen3:8b",
+            model="qwen3.5:9b",
             prompt="system_prompt",
             # Expose the declared skill to this model by name.
             skills=["math-calculator"],
@@ -157,7 +157,7 @@ public class MathAgent extends Agent {
     public static ResourceDescriptor mathModel() {
         return ResourceDescriptor.Builder.newBuilder(ResourceName.ChatModel.OLLAMA_SETUP)
                 .addInitialArgument("connection", "ollamaChatModelConnection")
-                .addInitialArgument("model", "qwen3:8b")
+                .addInitialArgument("model", "qwen3.5:9b")
                 .addInitialArgument("prompt", "systemPrompt")
                 // Expose the declared skill to this model by name.
                 .addInitialArgument("skills", List.of("math-calculator"))
@@ -324,10 +324,11 @@ Download and install Ollama from the official [website](https://ollama.com/downl
 Ollama server **0.9.0** or higher is required.
 {{< /hint >}}
 
-Then pull the qwen3:8b model, which is required by the quickstart examples.
+Then pull the qwen3:8b and qwen3.5:9b models, which are required by the quickstart examples.
 
 ```bash
 ollama pull qwen3:8b
+ollama pull qwen3.5:9b
 ```
 
 ### Submit Flink Agents Job to Standalone Flink Cluster

--- a/docs/content/docs/get-started/quickstart/skills_agent.md
+++ b/docs/content/docs/get-started/quickstart/skills_agent.md
@@ -324,10 +324,9 @@ Download and install Ollama from the official [website](https://ollama.com/downl
 Ollama server **0.9.0** or higher is required.
 {{< /hint >}}
 
-Then pull the qwen3:8b and qwen3.5:9b models, which are required by the quickstart examples.
+Then pull the qwen3.5:9b model, which is required by the quickstart examples.
 
 ```bash
-ollama pull qwen3:8b
 ollama pull qwen3.5:9b
 ```
 


### PR DESCRIPTION


<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #795 

### Purpose of change
The Skills Agent quickstart doc (`skills_agent.md`) tells users to pull `qwen3:8b`, but `MathAgent` in both Java and Python hardcodes `qwen3.5:9b`. Users who follow the doc exactly hit a model-not-found error at runtime.

This PR updates the documentation to match the code:

| Location in `skills_agent.md` | Line | Before | After |
|---|---|---|---|
| Python code block | 102 | `model="qwen3:8b"` | `model="qwen3.5:9b"` |
| Java code block | 160 | `"model", "qwen3:8b"` | `"model", "qwen3.5:9b"` |
| "Prepare Ollama" description | 327 | `qwen3:8b` | `qwen3:8b` and `qwen3.5:9b` |
| `ollama pull` command | 330 | `ollama pull qwen3:8b` | adds `ollama pull qwen3.5:9b` |

The Skills Agent example uses `qwen3.5:9b` (a tool-calling-capable model suited for the math-calculator skill), which differs from the `qwen3:8b` used by other quickstart examples. The "Prepare Ollama" section now instructs users to pull both models.
### Tests

- Verified all model references in `skills_agent.md` now match the corresponding source files
- No code changes

### API

No public API changes.

### Documentation

- [ ] `doc-needed`
- [ ] `doc-not-needed`
- [x] `doc-included`