### PR TITLE
[bugfix][examples] Add static import for copyResource in YamlWorkflow…

### DIFF
--- a/examples/src/main/java/org/apache/flink/agents/examples/YamlWorkflowAgentExample.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/YamlWorkflowAgentExample.java
@@ -28,6 +28,8 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
 import java.io.File;
 
+import static org.apache.flink.agents.examples.WorkflowSingleAgentExample.copyResource;
+
 /**
  * Java example demonstrating a YAML-declared workflow agent.
  *
@@ -59,13 +61,12 @@ public class YamlWorkflowAgentExample {
         // Load the YAML — the declared agent and its chat-model connection,
         // chat-model setup, prompt, tool, and actions are all registered on
         // the environment in this single call.
-        File yamlFile =
-                WorkflowSingleAgentExample.copyResource("yaml/yaml_review_analysis_agent.yaml");
+        File yamlFile = copyResource("yaml/yaml_review_analysis_agent.yaml");
         agentsEnv.loadYaml(yamlFile.toPath());
 
         // Read product reviews from input_data.txt file as a streaming source.
         // Each element represents a ProductReview.
-        File inputDataFile = WorkflowSingleAgentExample.copyResource("input_data.txt");
+        File inputDataFile = copyResource("input_data.txt");
         DataStream<String> productReviewStream =
                 env.fromSource(
                         FileSource.forRecordStreamFormat(


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #797 

### Purpose of change

The YAML Agent quickstart doc shows bare `copyResource(...)` calls, but `YamlWorkflowAgentExample.java` uses `WorkflowSingleAgentExample.copyResource(...)` without a static import. Users copying the doc snippet will get a compile error.

`ReActAgentExample` and `WorkflowMultipleAgentExample` already use `import static` for the same method. This PR aligns `YamlWorkflowAgentExample` with them:

| File | Change |
|---|---|
| `YamlWorkflowAgentExample.java` | Add `import static ...WorkflowSingleAgentExample.copyResource` |
| `YamlWorkflowAgentExample.java:63` | `WorkflowSingleAgentExample.copyResource(...)` → `copyResource(...)` |
| `YamlWorkflowAgentExample.java:68` | `WorkflowSingleAgentExample.copyResource(...)` → `copyResource(...)` |

### Tests

 - mvn compile -pl examples -am -DskipTests passes

### API

No public API changes.

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
