### PR TITLE
[bugfix][docs] Add missing Skills Agent Quickstart link to overview page

### DIFF
--- a/docs/content/docs/get-started/overview.md
+++ b/docs/content/docs/get-started/overview.md
@@ -45,4 +45,5 @@ To get started with Apache Flink Agents, you can checkout the following quicksta
 
 - [Workflow Agent Quickstart]({{< ref "docs/get-started/quickstart/workflow_agent" >}})
 - [ReAct Agent Quickstart]({{< ref "docs/get-started/quickstart/react_agent" >}})
+- [Skills Agent Quickstart]({{< ref "docs/get-started/quickstart/skills_agent" >}})
 - [YAML Agent Quickstart]({{< ref "docs/get-started/quickstart/yaml_agent" >}})


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #798 

### Purpose of change

The "Getting Started" section in the overview page (`overview.md`) lists three quickstart links (Workflow Agent, ReAct Agent, YAML Agent), but the Skills Agent Quickstart (`skills_agent.md`) exists and is not linked. A new user visiting the overview page has no way to discover it.

This PR adds the missing `Skills Agent Quickstart` link between the ReAct Agent and YAML Agent entries.

### Tests

- Verified `quickstart/skills_agent.md` exists and the ref path is correct
- No code changes

### API

No public API changes.

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
