### PR TITLE
[examples] Quickstart process_chat_response fails fast on malformed JSON

### DIFF
--- a/examples/src/main/java/org/apache/flink/agents/examples/agents/ProductSuggestionAgent.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/agents/ProductSuggestionAgent.java
@@ -98,6 +98,11 @@ public class ProductSuggestionAgent extends Agent {
     @Action(listenEventTypes = {ChatResponseEvent.EVENT_TYPE})
     public static void processChatResponse(Event event, RunnerContext ctx) throws Exception {
         ChatResponseEvent chatResponse = ChatResponseEvent.fromEvent(event);
+        // Fail fast on a malformed LLM response: a parse error here propagates and fails the
+        // agent, so a dropped input is surfaced instead of silently lost. In production, choose
+        // the handling that fits your pipeline: raise to fail the input (as below), emit an
+        // OutputEvent carrying an error sentinel, or send a custom error event so downstream
+        // operators can detect the failure.
         JsonNode jsonNode = MAPPER.readTree(chatResponse.getResponse().getContent());
         JsonNode suggestionsNode = jsonNode.findValue("suggestion_list");
         List<String> suggestions = new ArrayList<>();

--- a/examples/src/main/java/org/apache/flink/agents/examples/agents/ReviewAnalysisAgent.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/agents/ReviewAnalysisAgent.java
@@ -111,6 +111,11 @@ public class ReviewAnalysisAgent extends Agent {
     @Action(listenEventTypes = {ChatResponseEvent.EVENT_TYPE})
     public static void processChatResponse(Event event, RunnerContext ctx) throws Exception {
         ChatResponseEvent chatResponse = ChatResponseEvent.fromEvent(event);
+        // Fail fast on a malformed LLM response: a parse error here propagates and fails the
+        // agent, so a dropped input is surfaced instead of silently lost. In production, choose
+        // the handling that fits your pipeline: raise to fail the input (as below), emit an
+        // OutputEvent carrying an error sentinel, or send a custom error event so downstream
+        // operators can detect the failure.
         JsonNode jsonNode = MAPPER.readTree(chatResponse.getResponse().getContent());
         JsonNode scoreNode = jsonNode.findValue("score");
         JsonNode reasonsNode = jsonNode.findValue("reasons");

--- a/examples/src/main/java/org/apache/flink/agents/examples/agents/TableReviewAnalysisAgent.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/agents/TableReviewAnalysisAgent.java
@@ -131,6 +131,11 @@ public class TableReviewAnalysisAgent extends Agent {
     @Action(listenEventTypes = {ChatResponseEvent.EVENT_TYPE})
     public static void processChatResponse(Event event, RunnerContext ctx) throws Exception {
         ChatResponseEvent chatResponse = ChatResponseEvent.fromEvent(event);
+        // Fail fast on a malformed LLM response: a parse error here propagates and fails the
+        // agent, so a dropped input is surfaced instead of silently lost. In production, choose
+        // the handling that fits your pipeline: raise to fail the input (as below), emit an
+        // OutputEvent carrying an error sentinel, or send a custom error event so downstream
+        // operators can detect the failure.
         JsonNode jsonNode = MAPPER.readTree(chatResponse.getResponse().getContent());
         JsonNode scoreNode = jsonNode.findValue("score");
         JsonNode reasonsNode = jsonNode.findValue("reasons");

--- a/python/flink_agents/examples/quickstart/agents/product_suggestion_agent.py
+++ b/python/flink_agents/examples/quickstart/agents/product_suggestion_agent.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 #################################################################################
 import json
-import logging
 
 from flink_agents.api.agents.agent import Agent
 from flink_agents.api.chat_message import ChatMessage, MessageRole
@@ -93,20 +92,19 @@ class ProductSuggestionAgent(Agent):
     def process_chat_response(event: Event, ctx: RunnerContext) -> None:
         """Process chat response event."""
         chat_response = ChatResponseEvent.from_event(event)
-        try:
-            json_content = json.loads(chat_response.response.content)
-            ctx.send_event(
-                OutputEvent(
-                    output=ProductSuggestion(
-                        id=ctx.short_term_memory.get("id"),
-                        score_hist=ctx.short_term_memory.get("score_hist"),
-                        suggestions=json_content["suggestion_list"],
-                    )
+        # Fail fast on a malformed LLM response: a parse error here propagates
+        # and fails the agent, so a dropped input is surfaced instead of
+        # silently lost. In production, choose the handling that fits your
+        # pipeline: raise to fail the input (as below), emit an OutputEvent
+        # carrying an error sentinel, or send a custom error event so
+        # downstream operators can detect the failure.
+        json_content = json.loads(chat_response.response.content)
+        ctx.send_event(
+            OutputEvent(
+                output=ProductSuggestion(
+                    id=ctx.short_term_memory.get("id"),
+                    score_hist=ctx.short_term_memory.get("score_hist"),
+                    suggestions=json_content["suggestion_list"],
                 )
             )
-        except Exception:
-            logging.exception(
-                f"Error processing chat response {chat_response.response.content}"
-            )
-
-            # To fail the agent, you can raise an exception here.
+        )

--- a/python/flink_agents/examples/quickstart/agents/review_analysis_agent.py
+++ b/python/flink_agents/examples/quickstart/agents/review_analysis_agent.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 #################################################################################
 import json
-import logging
 
 from flink_agents.api.agents.agent import Agent
 from flink_agents.api.chat_message import ChatMessage, MessageRole
@@ -109,20 +108,19 @@ class ReviewAnalysisAgent(Agent):
     def process_chat_response(event: Event, ctx: RunnerContext) -> None:
         """Process chat response event and send output event."""
         chat_response = ChatResponseEvent.from_event(event)
-        try:
-            json_content = json.loads(chat_response.response.content)
-            ctx.send_event(
-                OutputEvent(
-                    output=ProductReviewAnalysisRes(
-                        id=ctx.short_term_memory.get("id"),
-                        score=json_content["score"],
-                        reasons=json_content["reasons"],
-                    )
+        # Fail fast on a malformed LLM response: a parse error here propagates
+        # and fails the agent, so a dropped input is surfaced instead of
+        # silently lost. In production, choose the handling that fits your
+        # pipeline: raise to fail the input (as below), emit an OutputEvent
+        # carrying an error sentinel, or send a custom error event so
+        # downstream operators can detect the failure.
+        json_content = json.loads(chat_response.response.content)
+        ctx.send_event(
+            OutputEvent(
+                output=ProductReviewAnalysisRes(
+                    id=ctx.short_term_memory.get("id"),
+                    score=json_content["score"],
+                    reasons=json_content["reasons"],
                 )
             )
-        except Exception:
-            logging.exception(
-                f"Error processing chat response {chat_response.response.content}"
-            )
-
-            # To fail the agent, you can raise an exception here.
+        )

--- a/python/flink_agents/examples/quickstart/agents/table_review_analysis_agent.py
+++ b/python/flink_agents/examples/quickstart/agents/table_review_analysis_agent.py
@@ -17,7 +17,6 @@
 #################################################################################
 
 import json
-import logging
 from typing import Any
 
 from pyflink.datastream import KeySelector
@@ -141,19 +140,19 @@ class TableReviewAnalysisAgent(Agent):
     def process_chat_response(event: Event, ctx: RunnerContext) -> None:
         """Process chat response event and send output event."""
         chat_response = ChatResponseEvent.from_event(event)
-        try:
-            json_content = json.loads(chat_response.response.content)
-            ctx.send_event(
-                OutputEvent(
-                    output=ProductReviewAnalysisRes(
-                        id=ctx.short_term_memory.get("id"),
-                        score=json_content["score"],
-                        reasons=json_content["reasons"],
-                    )
+        # Fail fast on a malformed LLM response: a parse error here propagates
+        # and fails the agent, so a dropped input is surfaced instead of
+        # silently lost. In production, choose the handling that fits your
+        # pipeline: raise to fail the input (as below), emit an OutputEvent
+        # carrying an error sentinel, or send a custom error event so
+        # downstream operators can detect the failure.
+        json_content = json.loads(chat_response.response.content)
+        ctx.send_event(
+            OutputEvent(
+                output=ProductReviewAnalysisRes(
+                    id=ctx.short_term_memory.get("id"),
+                    score=json_content["score"],
+                    reasons=json_content["reasons"],
                 )
             )
-        except Exception:
-            logging.exception(
-                f"Error processing chat response {chat_response.response.content}"
-            )
-            # To fail the agent, you can raise an exception here.
+        )


### PR DESCRIPTION
Linked issue: #780

### Purpose of change

The quickstart `process_chat_response` sample caught every exception, logged it, and emitted no `OutputEvent`. A malformed LLM response then silently produced fewer outputs than inputs with no surface (DLQ event, error event, metric) for downstream operators to detect the missing record — a copy-paste anti-pattern for the recommended learning sample.

- Replace `try/except: log()` with fail-fast in the Python quickstart agents (`review_analysis_agent`, `table_review_analysis_agent`, `product_suggestion_agent`); a parse error now propagates and fails the agent. Remove the unused `logging` imports.
- Document production alternatives in the comment (raise to fail the input, emit an OutputEvent with an error sentinel, send a custom error event).
- The Java samples already fail fast; align their comments with the Python ones so the intent is explicit.

### Tests

Existing ut & e2e; quickstart examples run unchanged on valid responses and now fail loudly on malformed JSON.

### API

no

### Documentation

- [ ] `doc-needed`
- [ ] `doc-not-needed`
- [x] `doc-included`
