### PR TITLE
[docs] Clarify Workflow Agent event emission and event metadata

### DIFF
--- a/docs/content/docs/development/workflow_agent.md
+++ b/docs/content/docs/development/workflow_agent.md
@@ -266,34 +266,66 @@ public class ReviewAnalysisAgent extends Agent {
 
 In the function, user can also send new events, to trigger other actions, or output the data.
 
-{{< tabs "Send Event" >}}
+**Trigger another action** — send a built-in or custom event that another action listens to:
+
+{{< tabs "Trigger Another Action" >}}
 
 {{< tab "Python" >}}
 ```python
 @action(InputEvent.EVENT_TYPE)
 @staticmethod
 def process_input(event: Event, ctx: RunnerContext) -> None:
-    # send ChatRequestEvent
-    ctx.send_event(ChatRequestEvent(model=xxx, messages=xxx))
-    # output data to downstream
-    ctx.send_event(OutputEvent(output=xxx))
+    # send a ChatRequestEvent to trigger the built-in chat-model action
+    ctx.send_event(ChatRequestEvent(model="my_model", messages=messages))
 ```
 {{< /tab >}}
 
 {{< tab "Java" >}}
 ```java
 @Action(listenEventTypes = {InputEvent.EVENT_TYPE})
-public static void processInput(Event event, RunnerContext ctx) throws Exception {
-    InputEvent inputEvent = InputEvent.fromEvent(event);
-    // send ChatRequestEvent
+public static void processInput(Event event, RunnerContext ctx) {
+    // send a ChatRequestEvent to trigger the built-in chat-model action
     ctx.sendEvent(new ChatRequestEvent("my_model", messages));
-    // output data to downstream
-    ctx.sendEvent(new OutputEvent(xxx));
-}   
+}
 ```
 {{< /tab >}}
 
 {{< /tabs >}}
+
+**Emit downstream output** — send an `OutputEvent` to produce an output of the agent:
+
+{{< tabs "Emit Output" >}}
+
+{{< tab "Python" >}}
+```python
+@action(ChatResponseEvent.EVENT_TYPE)
+@staticmethod
+def emit_output(event: Event, ctx: RunnerContext) -> None:
+    # output data to downstream
+    ctx.send_event(OutputEvent(output=result))
+```
+{{< /tab >}}
+
+{{< tab "Java" >}}
+```java
+@Action(listenEventTypes = {ChatResponseEvent.EVENT_TYPE})
+public static void emitOutput(Event event, RunnerContext ctx) {
+    // output data to downstream
+    ctx.sendEvent(new OutputEvent(result));
+}
+```
+{{< /tab >}}
+
+{{< /tabs >}}
+
+{{< hint info >}}
+An `OutputEvent` is collected and emitted to the agent's downstream **immediately**, bypassing
+action routing, while other events (such as `ChatRequestEvent`) are routed to the actions that
+listen for them. Sending a `ChatRequestEvent` and an `OutputEvent` from the same action is valid
+API usage, but it produces both an immediate output and, once the chat response is handled, a
+later model-based output. For the normal chat request/response workflow, emit the `OutputEvent`
+from the action that handles the `ChatResponseEvent`, as shown above.
+{{< /hint >}}
 
 ### Durable Execution
 
@@ -630,7 +662,11 @@ class MyEvent(Event):
     @override
     def from_event(cls, event: Event) -> "MyEvent":
         assert "value" in event.attributes
-        return MyEvent(value=event.attributes["value"])
+        result = MyEvent(value=event.attributes["value"])
+        # Preserve the base event id. Assign it last: the content-based id is
+        # regenerated whenever another field changes.
+        result.id = event.id
+        return result
 
     @property
     def value(self) -> str:
@@ -648,8 +684,20 @@ public class MyEvent extends Event {
         setAttr("value", value);
     }
 
+    @JsonCreator
+    public MyEvent(
+            @JsonProperty("id") UUID id,
+            @JsonProperty("attributes") Map<String, Object> attributes) {
+        super(id, EVENT_TYPE, attributes);
+    }
+
     public static MyEvent fromEvent(Event event) {
-        MyEvent result = new MyEvent((String) event.getAttr("value"));
+        // Preserve the base event id (and sourceTimestamp) so event logs, listeners,
+        // correlation, deduplication, and timestamp propagation stay consistent.
+        MyEvent result = new MyEvent(event.getId(), new HashMap<>(event.getAttributes()));
+        if (event.hasSourceTimestamp()) {
+            result.setSourceTimestamp(event.getSourceTimestamp());
+        }
         return result;
     }
 
@@ -661,6 +709,19 @@ public class MyEvent extends Event {
 {{< /tab >}}
 
 {{< /tabs >}}
+
+{{< hint info >}}
+When reconstructing a typed event, preserve the base `Event` metadata so that event logs,
+listeners, correlation, deduplication, and downstream timestamp propagation stay consistent with
+built-in events:
+
+- **`id`**: copy the source event's `id` onto the reconstructed event, as all built-in events do
+  in both languages. In Python, assign `result.id = event.id` **last**, because the content-based
+  `id` is regenerated whenever any other field changes.
+- **`sourceTimestamp`** (Java only): carry it over with `setSourceTimestamp(...)` when
+  `hasSourceTimestamp()` is true, matching built-in Java events. This field is runtime-internal and
+  used for timestamp propagation; the Python `Event` has no equivalent.
+{{< /hint >}}
 
 {{< hint info >}}
 All attribute values must be JSON-serializable. In Python, this means `BaseModel`-serializable or primitive types. In Java, values must be Jackson-serializable.


### PR DESCRIPTION
Linked issue: #793

### Purpose of change

Two documentation/API-contract clarifications on `docs/content/docs/development/workflow_agent.md`, per #793 (docs-only, no runtime/API change):

- **Send Event snippet (Part 1)**: the previous snippet sent both a `ChatRequestEvent` and an `OutputEvent` from a single action, which is valid but misleading — at runtime an `OutputEvent` is emitted downstream immediately while the `ChatRequestEvent` continues through the chat-model path, so one input can produce both an immediate output and a later model-based output. Split it into two separate examples — **"Trigger another action"** (sends only `ChatRequestEvent`) and **"Emit downstream output"** (sends `OutputEvent` from the `ChatResponseEvent` handler) — and add a hint stating that `OutputEvent` is collected/emitted downstream immediately, bypassing action routing, while other events are routed to their listening actions.
- **Custom event metadata contract (Part 2)**: the `from_event` / `fromEvent` examples did not say whether base `Event` metadata should be preserved. Document the contract — reconstruction should preserve the base `id` (both languages) and `sourceTimestamp` (Java only, runtime-internal; the Python `Event` has no equivalent) — matching all built-in events, and update the `MyEvent` example to follow it (Python assigns `result.id = event.id` last because the content-based id regenerates on field changes; Java gains a `@JsonCreator` id-accepting constructor and carries `sourceTimestamp` when present).

### Tests

Documentation-only change; no runtime impact. Verified manually:

- Both claims audited against source: all 8 built-in Java events and 8 Python events preserve `id` in their `fromEvent` / `from_event`; Java additionally preserves `sourceTimestamp`; `ActionExecutionOperator.processEvent` collects `OutputEvent` downstream immediately and routes all other events to triggered actions.
- The updated `MyEvent` Java snippet compiles (JDK 11 + Flink 2.2.0 classpath) and runs — `fromEvent` preserves both `id` and `sourceTimestamp`. The Python snippet runs in the venv — `from_event` preserves a custom `id`.
- Hugo shortcodes are balanced (tabs/tab/hint), all tab-group ids are unique, and code fences are even.

### API

No public API changes.

### Documentation

- [ ] `doc-needed`
- [ ] `doc-not-needed`
- [x] `doc-included`

Closes #793
