### PR TITLE
[hotfix] Add missing license header line in bash tool and skill modules

### DIFF
--- a/python/flink_agents/plan/tools/bash/__init__.py
+++ b/python/flink_agents/plan/tools/bash/__init__.py
@@ -12,5 +12,6 @@
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################

--- a/python/flink_agents/plan/tools/bash/bash_tool.py
+++ b/python/flink_agents/plan/tools/bash/bash_tool.py
@@ -12,6 +12,7 @@
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
 """Standalone bash execution tool.

--- a/python/flink_agents/plan/tools/bash/bash_validator.py
+++ b/python/flink_agents/plan/tools/bash/bash_validator.py
@@ -12,6 +12,7 @@
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
 """AST-based bash command validation using tree-sitter-bash.

--- a/python/flink_agents/plan/tools/bash/tests/__init__.py
+++ b/python/flink_agents/plan/tools/bash/tests/__init__.py
@@ -12,5 +12,6 @@
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################

--- a/python/flink_agents/plan/tools/bash/tests/test_bash_tool.py
+++ b/python/flink_agents/plan/tools/bash/tests/test_bash_tool.py
@@ -12,6 +12,7 @@
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
 """Tests for BashTool and its AST-based command validation."""

--- a/python/flink_agents/runtime/skill/skill_tools.py
+++ b/python/flink_agents/runtime/skill/skill_tools.py
@@ -12,6 +12,7 @@
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
 """Built-in tools for skill loading."""


### PR DESCRIPTION
<!--
  * Thank you very much for contributing to Flink Agents.
  * Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
  -->
 
  ### Purpose of change

  Several files are missing the
  `See the License for the specific language governing permissions and` line in
  their Apache license header. Noticed while addressing review feedback on #815;
  Completes the header in:

  - `plan/tools/bash/` (`__init__.py`, `bash_tool.py`, `bash_validator.py`, `tests/__init__.py`, `tests/test_bash_tool.py`)
  - `runtime/skill/skill_tools.py`

  License-header text only  no code changes.
  
  ### Tests

  N/A - comment-only change.
  
  ### API

  No API changes.

  ### Documentation

  - [ ] `doc-needed`
  - [x] `doc-not-needed`
  - [ ] `doc-included