### PR TITLE
[doc] Fix installation guide: Maven version, Python 3.12, macOS arm64 pip

### DIFF
--- a/docs/content/docs/get-started/installation.md
+++ b/docs/content/docs/get-started/installation.md
@@ -55,7 +55,7 @@ When using the **Java API**, there are some functionality limitations for earlie
 | Java 11-20   | Async execution is unavailable. |
 
 {{< hint info >}}
-**Note**: If you want to use python 3.12, you need install Flink above 2.1 (including 2.1).
+**Note**: Python 3.12 requires Flink 2.1 or above and Flink Agents 0.3 or above.
 {{< /hint >}}
 
 ## Quick install (recommended)
@@ -136,6 +136,15 @@ Install Flink Agents using pip:
 # Install Flink Agents and Flink Python package
 pip install flink-agents apache-flink==${FLINK_VERSION}
 ```
+
+{{< hint warning >}}
+**Apple Silicon (macOS arm64) + Python 3.12**: `apache-flink` depends on `apache-beam`, which ships no macOS arm64 wheel for Python 3.12, so pip builds it from source. The build pulls the latest `setuptools` (>=82), which removed `pkg_resources`, causing `ModuleNotFoundError: No module named 'pkg_resources'` (an upstream issue — see [setuptools#5174](https://github.com/pypa/setuptools/issues/5174)). Constrain the build's setuptools to fix it:
+
+```shell
+echo "setuptools<82" > /tmp/constraint.txt
+PIP_CONSTRAINT=/tmp/constraint.txt pip install flink-agents apache-flink==${FLINK_VERSION}
+```
+{{< /hint >}}
 
 #### From Source
 
@@ -278,8 +287,8 @@ For execution in IDE, enable the feature `add dependencies with provided scope t
 
 ```xml
 <properties>
-    <flink.version>2.2</flink.version>
-    <flink-agents.version>0.2.0</flink-agents.version>
+    <flink.version>2.2.1</flink.version>
+    <flink-agents.version>0.3.0</flink-agents.version>
 </properties>
 
 <dependencies>


### PR DESCRIPTION
## Linked issue
[#801](https://github.com/apache/flink-agents/issues/801)

## Purpose of change

Fix three issues in `docs/content/docs/get-started/installation.md` found during get-started verification:

- The Maven `pom.xml` example used `flink.version` `2.2`, which is not published on Maven Central (only `2.2.0`/`2.2.1` exist), causing dependency-resolution failure. Bumped to `2.2.1`; also bumped `flink-agents.version` to `0.3.0`.
- Clarified that Python 3.12 requires Flink 2.1+ and Flink Agents 0.3+.
- Documented the macOS arm64 + Python 3.12 pip failure: `apache-flink` pulls `apache-beam`, which ships no arm64 wheel, so pip builds from source; the isolated build pulls `setuptools>=82` (which removed `pkg_resources`), breaking it. Added a `PIP_CONSTRAINT` workaround.

Note: install.sh still rejects Python 3.12 — there is no installable flink-agents wheel for 3.12 until 0.3 is released, so updating install.sh is deferred until then.

## Tests

no (docs only)

## API

no

## Documentation

- `doc-included`