### PR TITLE
[runtime] Prune restored processing keys before snapshot

### DIFF
--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -55,8 +55,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.apache.flink.agents.api.configuration.AgentConfigOptions.JOB_IDENTIFIER;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -557,15 +560,20 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
             KeyGroupRange currentSubtaskKeyGroupRange =
                     stateManager.getCurrentSubtaskKeyGroupRange(
                             maxParallelism, getRuntimeContext());
+            Set<Object> ownedKeys = new LinkedHashSet<>();
             for (Object key : keys) {
                 if (!stateManager.isKeyOwnedByCurrentSubtask(
                         key, maxParallelism, currentSubtaskKeyGroupRange)) {
+                    continue;
+                }
+                if (!ownedKeys.add(key)) {
                     continue;
                 }
                 eventRouter.getKeySegmentQueue().addKeyToLastSegment(key);
                 mailboxExecutor.submit(
                         () -> tryProcessActionTaskForKey(key), "process action task");
             }
+            stateManager.replaceProcessingKeys(new ArrayList<>(ownedKeys));
         }
 
         stateManager.forEachPendingInputEventKey(

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/OperatorStateManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/OperatorStateManager.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import javax.annotation.Nullable;
 
 import java.time.Duration;
+import java.util.List;
 
 import static org.apache.flink.agents.runtime.utils.StateUtil.*;
 
@@ -263,6 +264,10 @@ class OperatorStateManager {
 
     void addProcessingKey(Object key) throws Exception {
         currentProcessingKeysOpState.add(key);
+    }
+
+    void replaceProcessingKeys(List<Object> keys) throws Exception {
+        currentProcessingKeysOpState.update(keys);
     }
 
     int removeProcessingKey(Object key) throws Exception {

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperatorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperatorTest.java
@@ -232,6 +232,41 @@ public class ActionExecutionOperatorTest {
 
             assertThat(ownerHarness.getTaskMailbox().size()).isEqualTo(1);
             assertThat(nonOwnerHarness.getTaskMailbox().size()).isZero();
+            assertThat(
+                            ((ActionExecutionOperator<Long, Object>) ownerHarness.getOperator())
+                                    .getOperatorStateManager()
+                                    .getProcessingKeys())
+                    .containsExactly(key);
+            assertThat(
+                            ((ActionExecutionOperator<Long, Object>) nonOwnerHarness.getOperator())
+                                    .getOperatorStateManager()
+                                    .getProcessingKeys())
+                    .isEmpty();
+
+            OperatorSubtaskState secondCheckpoint =
+                    AbstractStreamOperatorTestHarness.repackageState(
+                            ownerHarness.snapshot(2L, 2L), nonOwnerHarness.snapshot(2L, 2L));
+            OperatorSubtaskState secondRestoreOwnerState =
+                    AbstractStreamOperatorTestHarness.repartitionOperatorState(
+                            secondCheckpoint,
+                            maxParallelism,
+                            newParallelism,
+                            newParallelism,
+                            ownerSubtask);
+
+            try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> restoredOwnerHarness =
+                    new KeyedOneInputStreamOperatorTestHarness<>(
+                            new ActionExecutionOperatorFactory(TestAgent.getAgentPlan(false), true),
+                            (KeySelector<Long, Long>) value -> value,
+                            TypeInformation.of(Long.class),
+                            maxParallelism,
+                            newParallelism,
+                            ownerSubtask)) {
+                restoredOwnerHarness.initializeState(secondRestoreOwnerState);
+                restoredOwnerHarness.open();
+
+                assertThat(restoredOwnerHarness.getTaskMailbox().size()).isEqualTo(1);
+            }
         }
     }
 


### PR DESCRIPTION
Linked issue: #824

### Purpose of change

This PR fixes duplicate processing-key recovery after rescale or restore.

`currentProcessingKeysOpState` is union list state, so every restored subtask sees the union of all previous subtasks' processing keys. The existing restore logic skips non-owned keys when scheduling recovery work, but non-owner subtasks still kept those keys in their local operator state. If a checkpoint is taken before the owner finishes the key, non-owner subtasks can snapshot stale processing keys again. A later restore can then see duplicate entries for the same key, causing duplicate recovery mailbox submissions and eventually making `removeProcessingKey` return a count greater than one.

The fix keeps only distinct keys owned by the current subtask in the local operator state after restore. This prevents non-owner subtasks from re-publishing stale keys into later checkpoints.

### Tests

- `mvn -pl runtime -am -Dtest=ActionExecutionOperatorTest#testRestoreOnlyResumesKeysOwnedByCurrentSubtask -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl runtime -am -Dtest=ActionExecutionOperatorTest -Dsurefire.failIfNoSpecifiedTests=false test`

### API

No public API changes. The change only adds a package-private helper in `OperatorStateManager`.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`
