### PR TITLE
[release-0.2][runtime] Prune restored processing keys before snapshot

### DIFF
--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -96,9 +96,11 @@ import pemja.core.PythonInterpreter;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.apache.flink.agents.api.configuration.AgentConfigOptions.ACTION_STATE_STORE_BACKEND;
 import static org.apache.flink.agents.api.configuration.AgentConfigOptions.BASE_LOG_DIR;
@@ -935,14 +937,19 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
             int maxParallelism = getRuntimeContext().getTaskInfo().getMaxNumberOfParallelSubtasks();
             KeyGroupRange currentSubtaskKeyGroupRange =
                     getCurrentSubtaskKeyGroupRange(maxParallelism);
+            Set<Object> ownedKeys = new LinkedHashSet<>();
             for (Object key : keys) {
                 if (!isKeyOwnedByCurrentSubtask(key, maxParallelism, currentSubtaskKeyGroupRange)) {
+                    continue;
+                }
+                if (!ownedKeys.add(key)) {
                     continue;
                 }
                 keySegmentQueue.addKeyToLastSegment(key);
                 mailboxExecutor.submit(
                         () -> tryProcessActionTaskForKey(key), "process action task");
             }
+            currentProcessingKeysOpState.update(new ArrayList<>(ownedKeys));
         }
 
         getKeyedStateBackend()

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperatorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperatorTest.java
@@ -217,6 +217,31 @@ public class ActionExecutionOperatorTest {
 
             assertThat(ownerHarness.getTaskMailbox().size()).isEqualTo(1);
             assertThat(nonOwnerHarness.getTaskMailbox().size()).isZero();
+
+            OperatorSubtaskState secondCheckpoint =
+                    AbstractStreamOperatorTestHarness.repackageState(
+                            ownerHarness.snapshot(2L, 2L), nonOwnerHarness.snapshot(2L, 2L));
+            OperatorSubtaskState secondRestoreOwnerState =
+                    AbstractStreamOperatorTestHarness.repartitionOperatorState(
+                            secondCheckpoint,
+                            maxParallelism,
+                            newParallelism,
+                            newParallelism,
+                            ownerSubtask);
+
+            try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> restoredOwnerHarness =
+                    new KeyedOneInputStreamOperatorTestHarness<>(
+                            new ActionExecutionOperatorFactory(TestAgent.getAgentPlan(false), true),
+                            (KeySelector<Long, Long>) value -> value,
+                            TypeInformation.of(Long.class),
+                            maxParallelism,
+                            newParallelism,
+                            ownerSubtask)) {
+                restoredOwnerHarness.initializeState(secondRestoreOwnerState);
+                restoredOwnerHarness.open();
+
+                assertThat(restoredOwnerHarness.getTaskMailbox().size()).isEqualTo(1);
+            }
         }
     }
 


### PR DESCRIPTION
Linked issue: #824

### Purpose of change

This is the release-0.2 follow-up for #825.

This PR fixes duplicate processing-key recovery after rescale or restore.

`currentProcessingKeysOpState` is union list state, so every restored subtask sees the union of all previous subtasks' processing keys. The existing restore logic skips non-owned keys when scheduling recovery work, but non-owner subtasks still kept those keys in their local operator state. If a checkpoint is taken before the owner finishes the key, non-owner subtasks can snapshot stale processing keys again. A later restore can then see duplicate entries for the same key, causing duplicate recovery mailbox submissions and eventually making `removeProcessingKey` return a count greater than one.

The fix keeps only distinct keys owned by the current subtask in the local operator state after restore. This prevents non-owner subtasks from re-publishing stale keys into later checkpoints.

### Tests

- `mvn -pl runtime -am -Dtest=ActionExecutionOperatorTest#testRestoreOnlyResumesKeysOwnedByCurrentSubtask -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl runtime -am -Dtest=ActionExecutionOperatorTest -Dsurefire.failIfNoSpecifiedTests=false test`

### API

No public API changes.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`
