### PR TITLE
[docs][examples] Add parallel LLM quickstart and examples for multi-action fan-out

### DIFF
--- a/docs/content/docs/get-started/quickstart/parallel_llm.md
+++ b/docs/content/docs/get-started/quickstart/parallel_llm.md
@@ -84,13 +84,13 @@ agentsEnv.addResource(
 
 ### Create the Agent
 
-Below is the example code for the `ParallelChatAgent`. Two system prompts — `PARALLEL_SYSTEM_PROMPT` for the parallel aspect judgments and `AGGREGATE_SYSTEM_PROMPT` for the aggregation call — are packaged into `ChatRequestEvent`s by `_build_aspect_request` / `buildAspectRequest` and `_build_summarize_request` / `buildSummarizeRequest`. The agent defines a chat model and four actions: `request_aspect_judgments` initializes the row state and emits a single `SentimentInputEvent`; `handle_taste_input` and `handle_service_input` each listen on `SentimentInputEvent` and independently dispatch one `ChatRequestEvent`, recording a `{request_id → aspect}` entry in the shared `aspect_map`; and `handle_response` looks up the dispatched aspect by `request_id`, accumulates the results, and emits the final output. For more details, please refer to the [Workflow Agent]({{< ref "docs/development/workflow_agent" >}}) documentation.
+Below is the example code for the `ParallelChatAgent`. Two system prompts — `PARALLEL_SYSTEM_PROMPT` for the parallel aspect judgments and `AGGREGATE_SYSTEM_PROMPT` for the aggregation call — are packaged into `ChatRequestEvent`s by `_build_aspect_request` / `buildAspectRequest` and `_build_summarize_request` / `buildSummarizeRequest`. The agent defines a chat model and four actions: `request_aspect_judgments` stores the review `id` and `text` in sensory memory and emits a single `SentimentInputEvent`; `handle_taste_input` and `handle_service_input` each listen on `SentimentInputEvent` and independently dispatch one `ChatRequestEvent`, recording a `{request_id → aspect}` entry using path-based memory access (`aspect_map.<request_id>`); and `handle_response` looks up the dispatched aspect, stores the result under `sentiments.<aspect>`, and triggers aggregation once all aspects are collected. For more details, please refer to the [Workflow Agent]({{< ref "docs/development/workflow_agent" >}}) documentation.
 
 {{< tabs "Create the Agent" >}}
 
 {{< tab "Python" >}}
 ```python
-ASPECTS: Tuple[str, ...] = ("taste", "service")
+ASPECTS: tuple = ("taste", "service")
 N_ASPECTS = len(ASPECTS)
 
 PARALLEL_SYSTEM_PROMPT = (
@@ -107,9 +107,12 @@ AGGREGATE_SYSTEM_PROMPT = (
 
 
 class SentimentInputEvent(Event):
+    """Intermediate event that broadcasts the review input to all aspect handlers."""
+
     EVENT_TYPE: ClassVar[str] = "SentimentInputEvent"
 
     def __init__(self, input_id: int, text: str) -> None:
+        """Initialize with the review id and text."""
         super().__init__(
             type=SentimentInputEvent.EVENT_TYPE,
             attributes={"input_id": input_id, "text": text},
@@ -131,11 +134,10 @@ def _build_aspect_request(text: str, aspect: str) -> ChatRequestEvent:
     )
 
 
-def _build_summarize_request(row: Dict[str, Any]) -> ChatRequestEvent:
+def _build_summarize_request(text: str, sentiments: Dict[str, str]) -> ChatRequestEvent:
     """Build a ChatRequestEvent for the aggregation phase."""
-    sentiments = row["sentiments"]
     body = (
-        f"Original: {row['text']}\n"
+        f"Original: {text}\n"
         + "Judgments: "
         + " ".join(f"{a}:{sentiments[a]}" for a in ASPECTS)
     )
@@ -181,32 +183,27 @@ class ParallelChatAgent(Agent):
     @action(InputEvent.EVENT_TYPE)
     @staticmethod
     def request_aspect_judgments(event: Event, ctx: RunnerContext) -> None:
-        """Process input event and dispatch a SentimentInputEvent for each aspect handler."""
-        row = _init_row(event)
-        # Sensory memory requires JSON serialization across the Pemja JVM boundary.
-        ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
-        ctx.send_event(SentimentInputEvent(input_id=row["id"], text=row["text"]))
+        """Process input event and dispatch SentimentInputEvent to aspect handlers."""
+        payload = InputEvent.from_event(event).input
+        # Primitive types (int, str) cross the Pemja JVM boundary without serialization.
+        ctx.sensory_memory.set("id", payload["id"])
+        ctx.sensory_memory.set("text", payload["text"])
+        ctx.send_event(SentimentInputEvent(input_id=payload["id"], text=payload["text"]))
 
     @action(SentimentInputEvent.EVENT_TYPE)
     @staticmethod
     def handle_taste_input(event: Event, ctx: RunnerContext) -> None:
         """Handle taste aspect: build and send ChatRequestEvent for taste judgment."""
-        row = json.loads(ctx.sensory_memory.get("res"))
         req = _build_aspect_request(event.get_attr("text"), "taste")
-        row["aspect_map"][str(req.id)] = "taste"
-        # Sensory memory requires JSON serialization across the Pemja JVM boundary.
-        ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
+        ctx.sensory_memory.set(f"aspect_map.{req.id}", "taste")
         ctx.send_event(req)
 
     @action(SentimentInputEvent.EVENT_TYPE)
     @staticmethod
     def handle_service_input(event: Event, ctx: RunnerContext) -> None:
-        """Handle service aspect: build and send ChatRequestEvent for service judgment."""
-        row = json.loads(ctx.sensory_memory.get("res"))
+        """Handle service aspect: build and send ChatRequestEvent for service."""
         req = _build_aspect_request(event.get_attr("text"), "service")
-        row["aspect_map"][str(req.id)] = "service"
-        # Sensory memory requires JSON serialization across the Pemja JVM boundary.
-        ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
+        ctx.sensory_memory.set(f"aspect_map.{req.id}", "service")
         ctx.send_event(req)
 
     @action(ChatResponseEvent.EVENT_TYPE)
@@ -216,7 +213,7 @@ class ParallelChatAgent(Agent):
         ...
 ```
 
-The complete source including `_init_row`, `_build_output_event`, `_all_aspects_received`, and other supporting functions can be found in [`parallel_chat_agent.py`](https://github.com/apache/flink-agents/blob/main/python/flink_agents/examples/quickstart/agents/parallel_chat_agent.py).
+The complete source including `_build_output_event` and other supporting functions can be found in [`parallel_chat_agent.py`](https://github.com/apache/flink-agents/blob/main/python/flink_agents/examples/quickstart/agents/parallel_chat_agent.py).
 {{< /tab >}}
 
 {{< tab "Java" >}}
@@ -229,7 +226,7 @@ The complete source including `_init_row`, `_build_output_event`, `_all_aspects_
  *   <li>InputEvent → requestAspectJudgments → emits SentimentInputEvent
  *   <li>SentimentInputEvent triggers handlers in parallel:
  *       <ul>
- *         <li>handleTasteInput   → ChatRequestEvent (taste LLM call)
+ *         <li>handleTasteInput → ChatRequestEvent (taste LLM call)
  *         <li>handleServiceInput → ChatRequestEvent (service LLM call)
  *       </ul>
  *   <li>Each ChatResponseEvent → handleResponse (accumulates aspect results)
@@ -239,7 +236,6 @@ The complete source including `_init_row`, `_build_output_event`, `_all_aspects_
 public class ParallelChatAgent extends Agent {
 
     private static final String[] ASPECTS = {"taste", "service"};
-    private static final int N_ASPECTS = ASPECTS.length;
 
     private static final String PARALLEL_SYSTEM_PROMPT =
             "You are a sentiment analysis assistant. Return JSON: "
@@ -283,14 +279,13 @@ public class ParallelChatAgent extends Agent {
                 "sentimentModel", messages, CustomTypesAndResources.AspectResponse.class);
     }
 
-    @SuppressWarnings("unchecked")
-    private static ChatRequestEvent buildSummarizeRequest(Map<String, Object> row) {
-        Map<String, String> sentiments = (Map<String, String>) row.get("sentiments");
+    private static ChatRequestEvent buildSummarizeRequest(
+            String text, Map<String, String> sentiments) {
         StringJoiner sj = new StringJoiner(" ");
         for (String aspect : ASPECTS) {
             sj.add(aspect + ":" + sentiments.get(aspect));
         }
-        String body = "Original: " + row.get("text") + "\nJudgments: " + sj;
+        String body = "Original: " + text + "\nJudgments: " + sj;
         List<ChatMessage> messages =
                 List.of(
                         new ChatMessage(MessageRole.SYSTEM, AGGREGATE_SYSTEM_PROMPT),
@@ -302,41 +297,31 @@ public class ParallelChatAgent extends Agent {
     /** Process input event and dispatch a SentimentInputEvent for each aspect handler. */
     @Action(listenEventTypes = {InputEvent.EVENT_TYPE})
     public static void requestAspectJudgments(Event event, RunnerContext ctx) throws Exception {
-        Map<String, Object> row = initRow(event);
-        // Sensory memory stores the Map directly in Java; no JSON serialization required.
-        ctx.getSensoryMemory().set("res", row);
-        ctx.sendEvent(new SentimentInputEvent((int) row.get("id"), (String) row.get("text")));
+        CustomTypesAndResources.SentimentRequest request =
+                (CustomTypesAndResources.SentimentRequest) InputEvent.fromEvent(event).getInput();
+        ctx.getSensoryMemory().set("id", request.getId());
+        ctx.getSensoryMemory().set("text", request.getText());
+        ctx.sendEvent(new SentimentInputEvent(request.getId(), request.getText()));
     }
 
     /** Handle taste aspect: build and send ChatRequestEvent for taste judgment. */
-    @SuppressWarnings("unchecked")
     @Action(listenEventTypes = {SentimentInputEvent.EVENT_TYPE})
     public static void handleTasteInput(Event event, RunnerContext ctx) throws Exception {
         SentimentInputEvent in = (SentimentInputEvent) event;
-        Map<String, Object> row =
-                (Map<String, Object>) ctx.getSensoryMemory().get("res").getValue();
         ChatRequestEvent req = buildAspectRequest(in.text, "taste");
-        ((Map<String, String>) row.get("aspect_map")).put(req.getId().toString(), "taste");
-        // Sensory memory stores the Map directly in Java; no JSON serialization required.
-        ctx.getSensoryMemory().set("res", row);
+        ctx.getSensoryMemory().set("aspect_map." + req.getId(), "taste");
         ctx.sendEvent(req);
     }
 
     /** Handle service aspect: build and send ChatRequestEvent for service judgment. */
-    @SuppressWarnings("unchecked")
     @Action(listenEventTypes = {SentimentInputEvent.EVENT_TYPE})
     public static void handleServiceInput(Event event, RunnerContext ctx) throws Exception {
         SentimentInputEvent in = (SentimentInputEvent) event;
-        Map<String, Object> row =
-                (Map<String, Object>) ctx.getSensoryMemory().get("res").getValue();
         ChatRequestEvent req = buildAspectRequest(in.text, "service");
-        ((Map<String, String>) row.get("aspect_map")).put(req.getId().toString(), "service");
-        // Sensory memory stores the Map directly in Java; no JSON serialization required.
-        ctx.getSensoryMemory().set("res", row);
+        ctx.getSensoryMemory().set("aspect_map." + req.getId(), "service");
         ctx.sendEvent(req);
     }
 
-    @SuppressWarnings("unchecked")
     @Action(listenEventTypes = {ChatResponseEvent.EVENT_TYPE})
     public static void handleResponse(Event event, RunnerContext ctx) throws Exception {
         ...
@@ -344,7 +329,7 @@ public class ParallelChatAgent extends Agent {
 }
 ```
 
-Other private helpers (`initRow`, `buildOutputEvent`, `allAspectsReceived`) are omitted above; the full source is at [`ParallelChatAgent.java`](https://github.com/apache/flink-agents/blob/main/examples/src/main/java/org/apache/flink/agents/examples/agents/ParallelChatAgent.java).
+Other private helpers (`buildOutputEvent`) are omitted above; the full source is at [`ParallelChatAgent.java`](https://github.com/apache/flink-agents/blob/main/examples/src/main/java/org/apache/flink/agents/examples/agents/ParallelChatAgent.java).
 {{< /tab >}}
 
 {{< /tabs >}}
@@ -352,8 +337,8 @@ Other private helpers (`initRow`, `buildOutputEvent`, `allAspectsReceived`) are 
 {{< hint warning >}}
 **Constraints when using parallel actions:**
 - **Dispatch action must exit immediately after sending events.** The action that emits `SentimentInputEvent` (i.e. `request_aspect_judgments`) should return right after calling `ctx.send_event(...)`. Do not `await`, block, or perform further business logic in the same action — the framework needs control back to schedule the parallel chat actions.
-- **Action handlers on the same key execute sequentially.** Multiple action invocations triggered by the same key are processed one at a time, not concurrently. This means `handle_taste_input` and `handle_service_input` are called in sequence, making the read-modify-write pattern on sensory memory (e.g. `load_row → update → save_row`) safe and free from concurrent overwrites. The actual LLM calls dispatched by these handlers still execute in parallel.
-- **Response handlers on the same key execute sequentially.** Multiple `ChatResponseEvent` triggers for the same key are processed one at a time, not concurrently. This means the read-modify-write pattern on sensory memory in `handle_response` is safe and will not suffer from concurrent overwrites.
+- **Action handlers on the same key execute sequentially.** Multiple action invocations triggered by the same key are processed one at a time, not concurrently. This means `handle_taste_input` and `handle_service_input` are called in sequence. Each handler writes a single path-based entry (`aspect_map.<request_id>`) to sensory memory without reading back, so there is no conflict between the two. The actual LLM calls dispatched by these handlers still execute in parallel.
+- **Response handlers on the same key execute sequentially.** Multiple `ChatResponseEvent` triggers for the same key are processed one at a time, not concurrently. This means the path-based writes to `sentiments.<aspect>` in `handle_response` are safe and will not suffer from concurrent overwrites.
 {{< /hint >}}
 
 ### Integrate the Agent with Flink

--- a/docs/content/docs/get-started/quickstart/parallel_llm.md
+++ b/docs/content/docs/get-started/quickstart/parallel_llm.md
@@ -191,6 +191,12 @@ public class ParallelChatAgent extends Agent {
 
 {{< /tabs >}}
 
+{{< hint warning >}}
+**Constraints when using multi-action fan-out:**
+- **Fan-out action must exit immediately after sending events.** The action that emits multiple `ChatRequestEvent` events (e.g. `request_aspect_judgments`) should return right after calling `ctx.send_event(...)`. Do not `await`, block, or perform further business logic in the same action — the framework needs control back to schedule the parallel chat actions.
+- **Response handlers on the same key execute sequentially.** Multiple `ChatResponseEvent` triggers for the same key are processed one at a time, not concurrently. This means the read-modify-write pattern on sensory memory (e.g. `load_row → update → save_row`) is safe and will not suffer from concurrent overwrites.
+  {{< /hint >}}
+
 ### Integrate the Agent with Flink
 
 Create the input data, use the `ParallelChatAgent` to analyze the review with parallel LLM calls, and print the results.

--- a/docs/content/docs/get-started/quickstart/parallel_llm.md
+++ b/docs/content/docs/get-started/quickstart/parallel_llm.md
@@ -45,12 +45,9 @@ Create the agents execution environment, and register the available chat model c
 {{< tab "Python" >}}
 ```python
 # Set up the Flink streaming environment and the Agents execution environment.
-stream_env = StreamExecutionEnvironment.get_execution_environment()
-stream_env.set_parallelism(1)
-t_env = StreamTableEnvironment.create(stream_execution_environment=stream_env)
-agents_env = AgentsExecutionEnvironment.get_execution_environment(
-    env=stream_env, t_env=t_env
-)
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_parallelism(1)
+agents_env = AgentsExecutionEnvironment.get_execution_environment(env)
 
 # Add Ollama chat model connection to be used by the ParallelChatAgent.
 agents_env.add_resource(
@@ -205,26 +202,25 @@ Create the input data, use the `ParallelChatAgent` to analyze the review with pa
 
 {{< tab "Python" >}}
 ```python
-# Create input table with a single restaurant review.
-input_table = t_env.from_elements(
-    elements=[(1, INPUT_TEXT)],
-    schema=DataTypes.ROW(
-        [
-            DataTypes.FIELD("id", DataTypes.INT()),
-            DataTypes.FIELD("text", DataTypes.STRING()),
-        ]
-    ),
+# Create input stream with a single restaurant review.
+input_stream = env.from_collection(
+    collection=[{"id": 1, "text": INPUT_TEXT}],
 )
 
 # Use the ParallelChatAgent to analyze the review with parallel LLM calls.
-output_table = (
-    agents_env.from_table(input=input_table, key_selector=ParallelChatKeySelector())
+output_stream = (
+    agents_env.from_datastream(
+        input=input_stream, key_selector=lambda x: x["id"]
+    )
     .apply(ParallelChatAgent())
-    .to_table(schema=output_schema, output_type=output_type)
+    .to_datastream()
 )
 
+# Print the analysis results to stdout.
+output_stream.print()
+
 # Execute the Flink pipeline.
-output_table.execute_insert("sink").wait()
+agents_env.execute()
 ```
 {{< /tab >}}
 

--- a/docs/content/docs/get-started/quickstart/parallel_llm.md
+++ b/docs/content/docs/get-started/quickstart/parallel_llm.md
@@ -90,6 +90,9 @@ Below is the example code for the `ParallelChatAgent`. Two system prompts — `P
 
 {{< tab "Python" >}}
 ```python
+ASPECTS: Tuple[str, ...] = ("taste", "service", "price")
+N_ASPECTS = len(ASPECTS)
+
 PARALLEL_SYSTEM_PROMPT = (
     "You are a sentiment analysis assistant. Return JSON: "
     '{"aspect":"<dimension>", "result":"<positive|negative|not_mentioned>"}'

--- a/docs/content/docs/get-started/quickstart/parallel_llm.md
+++ b/docs/content/docs/get-started/quickstart/parallel_llm.md
@@ -84,7 +84,7 @@ agentsEnv.addResource(
 
 ### Create the Agent
 
-Below is the example code for the `ParallelChatAgent`. Two system prompts — `PARALLEL_SYSTEM_PROMPT` for the parallel aspect judgments and `AGGREGATE_SYSTEM_PROMPT` for the aggregation call — are packaged into `ChatRequestEvent`s by `_build_aspect_request` / `buildAspectRequest` and `_build_summarize_request` / `buildSummarizeRequest`. The agent defines a chat model and four actions: `request_aspect_judgments` stores the review `id` and `text` in sensory memory and emits a single `SentimentInputEvent`; `handle_taste_input` and `handle_service_input` each listen on `SentimentInputEvent` and independently dispatch one `ChatRequestEvent`, recording a `{request_id → aspect}` entry using path-based memory access (`aspect_map.<request_id>`); and `handle_response` looks up the dispatched aspect, stores the result under `sentiments.<aspect>`, and triggers aggregation once all aspects are collected. For more details, please refer to the [Workflow Agent]({{< ref "docs/development/workflow_agent" >}}) documentation.
+Below is the example code for the `ParallelChatAgent`. Two system prompts — `PARALLEL_SYSTEM_PROMPT` for the parallel aspect judgments and `AGGREGATE_SYSTEM_PROMPT` for the aggregation call — are packaged into `ChatRequestEvent`s by `_build_aspect_request` / `buildAspectRequest` and `_build_summarize_request` / `buildSummarizeRequest`. The agent defines a chat model and four actions: `request_aspect_judgments` stores the review `id` and `text` in sensory memory and emits a single generic `Event` of type `SENTIMENT_INPUT_EVENT_TYPE`; `handle_taste_input` and `handle_service_input` each listen on that event type and independently dispatch one `ChatRequestEvent`, recording a `{request_id → aspect}` entry using path-based memory access (`aspect_map.<request_id>`); and `handle_response` looks up the dispatched aspect, stores the result under `sentiments.<aspect>`, and triggers aggregation once all aspects are collected.
 
 {{< tabs "Create the Agent" >}}
 
@@ -92,6 +92,7 @@ Below is the example code for the `ParallelChatAgent`. Two system prompts — `P
 ```python
 ASPECTS: tuple = ("taste", "service")
 N_ASPECTS = len(ASPECTS)
+SENTIMENT_INPUT_EVENT_TYPE = "SentimentInputEvent"
 
 PARALLEL_SYSTEM_PROMPT = (
     "You are a sentiment analysis assistant. Return JSON: "
@@ -104,19 +105,6 @@ AGGREGATE_SYSTEM_PROMPT = (
     '{"summary":"taste:<positive/negative/not_mentioned>, '
     'service:<positive/negative/not_mentioned>"} — return only this JSON.'
 )
-
-
-class SentimentInputEvent(Event):
-    """Intermediate event that broadcasts the review input to all aspect handlers."""
-
-    EVENT_TYPE: ClassVar[str] = "SentimentInputEvent"
-
-    def __init__(self, input_id: int, text: str) -> None:
-        """Initialize with the review id and text."""
-        super().__init__(
-            type=SentimentInputEvent.EVENT_TYPE,
-            attributes={"input_id": input_id, "text": text},
-        )
 
 
 def _build_aspect_request(text: str, aspect: str) -> ChatRequestEvent:
@@ -188,9 +176,14 @@ class ParallelChatAgent(Agent):
         # Primitive types (int, str) cross the Pemja JVM boundary without serialization.
         ctx.sensory_memory.set("id", payload["id"])
         ctx.sensory_memory.set("text", payload["text"])
-        ctx.send_event(SentimentInputEvent(input_id=payload["id"], text=payload["text"]))
+        ctx.send_event(
+            Event(
+                type=SENTIMENT_INPUT_EVENT_TYPE,
+                attributes={"input_id": payload["id"], "text": payload["text"]},
+            )
+        )
 
-    @action(SentimentInputEvent.EVENT_TYPE)
+    @action(SENTIMENT_INPUT_EVENT_TYPE)
     @staticmethod
     def handle_taste_input(event: Event, ctx: RunnerContext) -> None:
         """Handle taste aspect: build and send ChatRequestEvent for taste judgment."""
@@ -198,7 +191,7 @@ class ParallelChatAgent(Agent):
         ctx.sensory_memory.set(f"aspect_map.{req.id}", "taste")
         ctx.send_event(req)
 
-    @action(SentimentInputEvent.EVENT_TYPE)
+    @action(SENTIMENT_INPUT_EVENT_TYPE)
     @staticmethod
     def handle_service_input(event: Event, ctx: RunnerContext) -> None:
         """Handle service aspect: build and send ChatRequestEvent for service."""
@@ -237,6 +230,8 @@ public class ParallelChatAgent extends Agent {
 
     private static final String[] ASPECTS = {"taste", "service"};
 
+    private static final String SENTIMENT_INPUT_EVENT_TYPE = "SentimentInputEvent";
+
     private static final String PARALLEL_SYSTEM_PROMPT =
             "You are a sentiment analysis assistant. Return JSON: "
                     + "{\"aspect\":\"<dimension>\", \"result\":\"<positive|negative|not_mentioned>\"}"
@@ -246,18 +241,6 @@ public class ParallelChatAgent extends Agent {
                     + "dimensions, compose a brief one-line evaluation. Return JSON: "
                     + "{\"summary\":\"taste:<positive/negative/not_mentioned>, "
                     + "service:<positive/negative/not_mentioned>\"} — return only this JSON.";
-
-    public static class SentimentInputEvent extends Event {
-        public static final String EVENT_TYPE = "SentimentInputEvent";
-        public final int inputId;
-        public final String text;
-
-        public SentimentInputEvent(int inputId, String text) {
-            super(EVENT_TYPE);
-            this.inputId = inputId;
-            this.text = text;
-        }
-    }
 
     @ChatModelSetup
     public static ResourceDescriptor sentimentModel() {
@@ -301,23 +284,24 @@ public class ParallelChatAgent extends Agent {
                 (CustomTypesAndResources.SentimentRequest) InputEvent.fromEvent(event).getInput();
         ctx.getSensoryMemory().set("id", request.getId());
         ctx.getSensoryMemory().set("text", request.getText());
-        ctx.sendEvent(new SentimentInputEvent(request.getId(), request.getText()));
+        ctx.sendEvent(
+                new Event(
+                        SENTIMENT_INPUT_EVENT_TYPE,
+                        Map.of("input_id", request.getId(), "text", request.getText())));
     }
 
     /** Handle taste aspect: build and send ChatRequestEvent for taste judgment. */
-    @Action(listenEventTypes = {SentimentInputEvent.EVENT_TYPE})
+    @Action(listenEventTypes = {SENTIMENT_INPUT_EVENT_TYPE})
     public static void handleTasteInput(Event event, RunnerContext ctx) throws Exception {
-        SentimentInputEvent in = (SentimentInputEvent) event;
-        ChatRequestEvent req = buildAspectRequest(in.text, "taste");
+        ChatRequestEvent req = buildAspectRequest((String) event.getAttr("text"), "taste");
         ctx.getSensoryMemory().set("aspect_map." + req.getId(), "taste");
         ctx.sendEvent(req);
     }
 
     /** Handle service aspect: build and send ChatRequestEvent for service judgment. */
-    @Action(listenEventTypes = {SentimentInputEvent.EVENT_TYPE})
+    @Action(listenEventTypes = {SENTIMENT_INPUT_EVENT_TYPE})
     public static void handleServiceInput(Event event, RunnerContext ctx) throws Exception {
-        SentimentInputEvent in = (SentimentInputEvent) event;
-        ChatRequestEvent req = buildAspectRequest(in.text, "service");
+        ChatRequestEvent req = buildAspectRequest((String) event.getAttr("text"), "service");
         ctx.getSensoryMemory().set("aspect_map." + req.getId(), "service");
         ctx.sendEvent(req);
     }

--- a/docs/content/docs/get-started/quickstart/parallel_llm.md
+++ b/docs/content/docs/get-started/quickstart/parallel_llm.md
@@ -1,0 +1,347 @@
+---
+title: 'Parallel LLM Calls'
+weight: 3
+type: docs
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+## Overview
+
+Flink Agents supports parallel LLM invocations via multi-action fan-out. By emitting multiple `ChatRequestEvent` events from a single action, the framework's built-in chat action executes the corresponding LLM calls concurrently — no external orchestration is required.
+
+This quickstart introduces an example that demonstrates how to build a parallel LLM workflow with Flink Agents:
+
+The **Parallel Sentiment Analysis** agent processes a restaurant review and judges sentiment along three dimensions (taste / service / price) in parallel, then aggregates the results into a one-line summary with a final LLM call. The end-to-end wall clock time is roughly "slowest single branch + aggregation call", rather than the sum of all four calls.
+
+{{< hint info >}}
+**JDK version note (Java only):** On JDK 21+, the framework uses the Continuation API to execute concurrent chat actions in parallel. On JDK < 21, the framework silently falls back to sequential execution — the result is identical, but the LLM calls run one after another. Python uses native coroutines and always executes in parallel regardless of the JDK version.
+{{< /hint >}}
+
+## Code Walkthrough
+
+### Prepare Agents Execution Environment
+
+Create the agents execution environment, and register the available chat model connection to the environment.
+
+{{< tabs "Prepare Agents Execution Environment" >}}
+
+{{< tab "Python" >}}
+```python
+# Set up the Flink streaming environment and the Agents execution environment.
+stream_env = StreamExecutionEnvironment.get_execution_environment()
+stream_env.set_parallelism(1)
+t_env = StreamTableEnvironment.create(stream_execution_environment=stream_env)
+agents_env = AgentsExecutionEnvironment.get_execution_environment(
+    env=stream_env, t_env=t_env
+)
+
+# Add Ollama chat model connection to be used by the ParallelChatAgent.
+agents_env.add_resource(
+    "ollama_server",
+    ResourceType.CHAT_MODEL_CONNECTION,
+    ResourceDescriptor(
+        clazz=ResourceName.ChatModel.OLLAMA_CONNECTION,
+        request_timeout=240.0,
+    ),
+)
+```
+{{< /tab >}}
+
+{{< tab "Java" >}}
+```Java
+// Set up the Flink streaming environment and the Agents execution environment.
+StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+env.setParallelism(1);
+AgentsExecutionEnvironment agentsEnv =
+        AgentsExecutionEnvironment.getExecutionEnvironment(env);
+
+// Add Ollama chat model connection to be used by the ParallelChatAgent.
+agentsEnv.addResource(
+        "ollamaChatModelConnection",
+        ResourceType.CHAT_MODEL_CONNECTION,
+        ResourceDescriptor.Builder.newBuilder(ResourceName.ChatModel.OLLAMA_CONNECTION)
+                .addInitialArgument("endpoint", "http://localhost:11434")
+                .addInitialArgument("requestTimeout", 240)
+                .build());
+```
+{{< /tab >}}
+
+{{< /tabs >}}
+
+### Create the Agent
+
+Below is the example code for the `ParallelChatAgent`. The agent defines a chat model for sentiment analysis and two actions: `request_aspect_judgments` fans out one `ChatRequestEvent` per dimension, and `handle_response` collects the results, triggers the aggregation call, and emits the final output. For more details, please refer to the [Workflow Agent]({{< ref "docs/development/workflow_agent" >}}) documentation.
+
+{{< tabs "Create the Agent" >}}
+
+{{< tab "Python" >}}
+```python
+class ParallelChatAgent(Agent):
+    """An agent that demonstrates parallel LLM invocations via fan-out of
+    multiple ChatRequestEvent events.
+
+    This agent receives a restaurant review and uses an LLM to judge sentiment
+    along multiple dimensions in parallel, then aggregates the results into a
+    one-line summary with a final LLM call. It handles prompt construction,
+    parallel chat dispatch, response accumulation, and output assembly.
+    """
+
+    @chat_model_setup
+    @staticmethod
+    def sentiment_model() -> ResourceDescriptor:
+        """ChatModel for sentiment analysis."""
+        return ResourceDescriptor(
+            clazz=ResourceName.ChatModel.OLLAMA_SETUP,
+            connection="ollama_server",
+            model=OLLAMA_MODEL,
+            extract_reasoning=True,
+        )
+
+    @action(InputEvent.EVENT_TYPE)
+    @staticmethod
+    def request_aspect_judgments(event: Event, ctx: RunnerContext) -> None:
+        """Process input event and send chat requests for each aspect."""
+        row = _init_row(event)
+        _save_row(ctx, row)
+        for aspect in ASPECTS:
+            ctx.send_event(_build_aspect_request(row["text"], aspect))
+
+    @action(ChatResponseEvent.EVENT_TYPE)
+    @staticmethod
+    def handle_response(event: Event, ctx: RunnerContext) -> None:
+        """Process chat response event and send output event."""
+        parsed = _parse_response(event)
+        row = _load_row(ctx)
+        if _is_final(parsed):
+            ctx.send_event(_build_output_event(row, parsed))
+            return
+        row["sentiments"][parsed.aspect] = parsed.result
+        _save_row(ctx, row)
+        if _all_aspects_received(row):
+            ctx.send_event(_build_summarize_request(row))
+```
+{{< /tab >}}
+
+{{< tab "Java" >}}
+```Java
+/**
+ * An agent that demonstrates parallel LLM invocations via fan-out of multiple
+ * ChatRequestEvent events.
+ */
+public class ParallelChatAgent extends Agent {
+
+    @ChatModelSetup
+    public static ResourceDescriptor sentimentModel() {
+        return ResourceDescriptor.Builder.newBuilder(ResourceName.ChatModel.OLLAMA_SETUP)
+                .addInitialArgument("connection", "ollamaChatModelConnection")
+                .addInitialArgument("model", OLLAMA_MODEL)
+                .addInitialArgument("extract_reasoning", true)
+                .build();
+    }
+
+    @Action(listenEventTypes = {InputEvent.EVENT_TYPE})
+    public static void requestAspectJudgments(Event event, RunnerContext ctx)
+            throws Exception {
+        Map<String, Object> row = initRow(event);
+        saveRow(ctx, row);
+        for (String aspect : ASPECTS) {
+            ctx.sendEvent(buildAspectRequest((String) row.get("text"), aspect));
+        }
+    }
+
+    @Action(listenEventTypes = {ChatResponseEvent.EVENT_TYPE})
+    public static void handleResponse(Event event, RunnerContext ctx) throws Exception {
+        Object parsed = parseResponse(event);
+        Map<String, Object> row = loadRow(ctx);
+
+        if (parsed instanceof SummaryResponse) {
+            SummaryResponse summary = (SummaryResponse) parsed;
+            ctx.sendEvent(buildOutputEvent(row, summary));
+            return;
+        }
+
+        AspectResponse aspect = (AspectResponse) parsed;
+        Map<String, String> sentiments = (Map<String, String>) row.get("sentiments");
+        sentiments.put(aspect.aspect, aspect.result);
+        saveRow(ctx, row);
+        if (allAspectsReceived(row)) {
+            ctx.sendEvent(buildSummarizeRequest(row));
+        }
+    }
+}
+```
+{{< /tab >}}
+
+{{< /tabs >}}
+
+### Integrate the Agent with Flink
+
+Create the input data, use the `ParallelChatAgent` to analyze the review with parallel LLM calls, and print the results.
+
+{{< tabs "Integrate the Agent with Flink" >}}
+
+{{< tab "Python" >}}
+```python
+# Create input table with a single restaurant review.
+input_table = t_env.from_elements(
+    elements=[(1, INPUT_TEXT)],
+    schema=DataTypes.ROW(
+        [
+            DataTypes.FIELD("id", DataTypes.INT()),
+            DataTypes.FIELD("text", DataTypes.STRING()),
+        ]
+    ),
+)
+
+# Use the ParallelChatAgent to analyze the review with parallel LLM calls.
+output_table = (
+    agents_env.from_table(input=input_table, key_selector=ParallelChatKeySelector())
+    .apply(ParallelChatAgent())
+    .to_table(schema=output_schema, output_type=output_type)
+)
+
+# Execute the Flink pipeline.
+output_table.execute_insert("sink").wait()
+```
+{{< /tab >}}
+
+{{< tab "Java" >}}
+```Java
+// Create input stream with a single restaurant review.
+DataStream<SentimentRequest> inputStream =
+        env.fromElements(new SentimentRequest(1, ParallelChatAgent.INPUT_TEXT));
+
+// Use the ParallelChatAgent to analyze the review with parallel LLM calls.
+DataStream<Object> outputStream =
+        agentsEnv
+                .fromDataStream(inputStream, new SentimentKeySelector())
+                .apply(new ParallelChatAgent())
+                .toDataStream();
+
+// Print the analysis results to stdout.
+outputStream.print();
+
+// Execute the Flink pipeline.
+agentsEnv.execute();
+```
+{{< /tab >}}
+
+{{< /tabs >}}
+
+## Run the Example
+
+### Prerequisites
+
+* Unix-like environment (we use Linux, Mac OS X, Cygwin, WSL)
+* Git
+* Java 11+ (Java 21+ recommended for parallel execution on the Java side)
+* Python 3.10, 3.11 or 3.12
+
+### Preparation
+
+#### Prepare Flink and Flink Agents
+
+Follow the [installation]({{< ref "docs/get-started/installation" >}}) instructions to setup Flink and the Flink Agents.
+
+#### Clone the Flink Agents Repository (if not done already)
+
+```bash
+git clone https://github.com/apache/flink-agents.git
+cd flink-agents
+```
+{{< hint info >}}
+For python examples, you can skip this step and submit the python file in installed flink-agents wheel.
+{{< /hint >}}
+
+#### Deploy a Standalone Flink Cluster
+
+You can deploy a standalone Flink cluster in your local environment with the following command.
+
+{{< tabs "Deploy a Standalone Flink Cluster" >}}
+
+{{< tab "Python" >}}
+```bash
+export PYTHONPATH=$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
+$FLINK_HOME/bin/start-cluster.sh
+```
+{{< /tab >}}
+
+{{< tab "Java" >}}
+1. Build Flink Agents from source to generate example jar. See [installation]({{< ref "docs/get-started/installation" >}}) for more details.
+2. Start the Flink cluster
+    ```bash
+    $FLINK_HOME/bin/start-cluster.sh
+    ```
+
+{{< hint info >}}
+To run example on JDK 21+, append jvm option `--add-exports=java.base/jdk.internal.vm=ALL-UNNAMED` to [env.java.opts.all](https://nightlies.apache.org/flink/flink-docs-stable/docs/deployment/config/#env-java-opts-all) in `$FLINK_HOME/conf/config.yaml` before start the flink cluster.
+{{< /hint >}}
+{{< /tab >}}
+
+{{< /tabs >}}
+You can refer to the [local cluster](https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/try-flink/local_installation/#starting-and-stopping-a-local-cluster) instructions for more detailed step.
+
+{{< hint info >}}
+If you can't navigate to the web UI at [localhost:8081](localhost:8081), you can find the reason in `$FLINK_HOME/log`. If the reason is port conflict, you can change the port in `$FLINK_HOME/conf/config.yaml`.
+{{< /hint >}}
+
+#### Prepare Ollama
+
+Download and install Ollama from the official [website](https://ollama.com/download).
+
+{{< hint info >}}
+Ollama server **0.9.0** or higher is required.
+{{< /hint >}}
+
+Then pull the qwen3:1.7b model, which is required by the parallel LLM example
+
+```bash
+ollama pull qwen3:1.7b
+```
+
+### Submit Flink Agents Job to Standalone Flink Cluster
+
+#### Submit to Flink Cluster
+
+{{< tabs "Submit to Flink Cluster" >}}
+
+{{< tab "Python" >}}
+```bash
+export PYTHONPATH=$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
+
+# Run parallel chat request example
+$FLINK_HOME/bin/flink run -py ./flink-agents/python/flink_agents/examples/quickstart/parallel_chat_request_example.py
+# or submit the example python file in installed flink-agents wheel
+$FLINK_HOME/bin/flink run -py  $PYTHONPATH/flink_agents/examples/quickstart/parallel_chat_request_example.py
+```
+{{< /tab >}}
+
+{{< tab "Java" >}}
+```bash
+$FLINK_HOME/bin/flink run -c org.apache.flink.agents.examples.ParallelChatRequestExample ./flink-agents/examples/target/flink-agents-examples-$VERSION.jar
+```
+{{< /tab >}}
+
+{{< /tabs >}}
+
+Now you should see a Flink job submitted to the Flink Cluster in Flink web UI [localhost:8081](
+localhost:8081)
+
+After a few minutes, you can check for the output in the TaskManager output log.

--- a/docs/content/docs/get-started/quickstart/parallel_llm.md
+++ b/docs/content/docs/get-started/quickstart/parallel_llm.md
@@ -1,6 +1,6 @@
 ---
 title: 'Parallel LLM Calls'
-weight: 3
+weight: 4
 type: docs
 ---
 <!--
@@ -84,12 +84,59 @@ agentsEnv.addResource(
 
 ### Create the Agent
 
-Below is the example code for the `ParallelChatAgent`. The agent defines a chat model for sentiment analysis and two actions: `request_aspect_judgments` fans out one `ChatRequestEvent` per dimension, and `handle_response` collects the results, triggers the aggregation call, and emits the final output. For more details, please refer to the [Workflow Agent]({{< ref "docs/development/workflow_agent" >}}) documentation.
+Below is the example code for the `ParallelChatAgent`. Two system prompts — `PARALLEL_SYSTEM_PROMPT` for the parallel aspect judgments and `AGGREGATE_SYSTEM_PROMPT` for the aggregation call — are packaged into `ChatRequestEvent`s by `_build_aspect_request` / `buildAspectRequest` and `_build_summarize_request` / `buildSummarizeRequest`. The agent defines a chat model and two actions: `request_aspect_judgments` pre-builds all requests and records a `{request_id → aspect}` map for reliable correlation, and `handle_response` looks up the dispatched aspect by `request_id`, accumulates the results, and emits the final output. For more details, please refer to the [Workflow Agent]({{< ref "docs/development/workflow_agent" >}}) documentation.
 
 {{< tabs "Create the Agent" >}}
 
 {{< tab "Python" >}}
 ```python
+PARALLEL_SYSTEM_PROMPT = (
+    "You are a sentiment analysis assistant. Return JSON: "
+    '{"aspect":"<dimension>", "result":"<positive|negative|not_mentioned>"}'
+    " — no explanation, no extra fields."
+)
+AGGREGATE_SYSTEM_PROMPT = (
+    "You are a summary assistant. Based on the sentiment judgments for three "
+    "dimensions, compose a brief one-line evaluation. Return JSON: "
+    '{"summary":"taste:<positive/negative/not_mentioned>, '
+    "service:<positive/negative/not_mentioned>, "
+    'price:<positive/negative/not_mentioned>"} — return only this JSON.'
+)
+
+
+def _build_aspect_request(text: str, aspect: str) -> ChatRequestEvent:
+    """Build a ChatRequestEvent for a single aspect dimension."""
+    return ChatRequestEvent(
+        model="sentiment_model",
+        messages=[
+            ChatMessage(role=MessageRole.SYSTEM, content=PARALLEL_SYSTEM_PROMPT),
+            ChatMessage(
+                role=MessageRole.USER,
+                content=f'Judge the "{aspect}" dimension: {text}',
+            ),
+        ],
+        output_schema=OutputSchema(output_schema=AspectResponse),
+    )
+
+
+def _build_summarize_request(row: Dict[str, Any]) -> ChatRequestEvent:
+    """Build a ChatRequestEvent for the aggregation phase."""
+    sentiments = row["sentiments"]
+    body = (
+        f"Original: {row['text']}\n"
+        + "Judgments: "
+        + " ".join(f"{a}:{sentiments[a]}" for a in ASPECTS)
+    )
+    return ChatRequestEvent(
+        model="sentiment_model",
+        messages=[
+            ChatMessage(role=MessageRole.SYSTEM, content=AGGREGATE_SYSTEM_PROMPT),
+            ChatMessage(role=MessageRole.USER, content=body),
+        ],
+        output_schema=OutputSchema(output_schema=SummaryResponse),
+    )
+
+
 class ParallelChatAgent(Agent):
     """An agent that demonstrates parallel LLM invocations via fan-out of
     multiple ChatRequestEvent events.
@@ -116,33 +163,53 @@ class ParallelChatAgent(Agent):
     def request_aspect_judgments(event: Event, ctx: RunnerContext) -> None:
         """Process input event and send chat requests for each aspect."""
         row = _init_row(event)
-        _save_row(ctx, row)
-        for aspect in ASPECTS:
-            ctx.send_event(_build_aspect_request(row["text"], aspect))
+        requests = [_build_aspect_request(row["text"], aspect) for aspect in ASPECTS]
+        row["aspect_map"] = {
+            str(req.id): aspect for req, aspect in zip(requests, ASPECTS, strict=True)
+        }
+        # Sensory memory requires JSON serialization across the Pemja JVM boundary.
+        ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
+        for req in requests:
+            ctx.send_event(req)
 
     @action(ChatResponseEvent.EVENT_TYPE)
     @staticmethod
     def handle_response(event: Event, ctx: RunnerContext) -> None:
         """Process chat response event and send output event."""
-        parsed = _parse_response(event)
-        row = _load_row(ctx)
-        if _is_final(parsed):
+        response_event = ChatResponseEvent.from_event(event)
+        parsed = response_event.response.extra_args[STRUCTURED_OUTPUT]
+        row = json.loads(ctx.sensory_memory.get("res"))
+        if isinstance(parsed, SummaryResponse):
             ctx.send_event(_build_output_event(row, parsed))
             return
-        row["sentiments"][parsed.aspect] = parsed.result
-        _save_row(ctx, row)
+        aspect = row["aspect_map"][str(response_event.request_id)]
+        row["sentiments"][aspect] = parsed.result
+        # Sensory memory requires JSON serialization across the Pemja JVM boundary.
+        ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
         if _all_aspects_received(row):
             ctx.send_event(_build_summarize_request(row))
 ```
+
+The complete source including `_init_row`, `_build_output_event`, `_all_aspects_received`, and other supporting functions can be found in [`parallel_chat_agent.py`](https://github.com/apache/flink-agents/blob/main/python/flink_agents/examples/quickstart/agents/parallel_chat_agent.py).
 {{< /tab >}}
 
 {{< tab "Java" >}}
 ```Java
-/**
- * An agent that demonstrates parallel LLM invocations via fan-out of multiple
- * ChatRequestEvent events.
- */
 public class ParallelChatAgent extends Agent {
+
+    private static final String[] ASPECTS = {"taste", "service", "price"};
+    private static final int N_ASPECTS = ASPECTS.length;
+
+    private static final String PARALLEL_SYSTEM_PROMPT =
+            "You are a sentiment analysis assistant. Return JSON: "
+                    + "{\"aspect\":\"<dimension>\", \"result\":\"<positive|negative|not_mentioned>\"}"
+                    + " — no explanation, no extra fields.";
+    private static final String AGGREGATE_SYSTEM_PROMPT =
+            "You are a summary assistant. Based on the sentiment judgments for three "
+                    + "dimensions, compose a brief one-line evaluation. Return JSON: "
+                    + "{\"summary\":\"taste:<positive/negative/not_mentioned>, "
+                    + "service:<positive/negative/not_mentioned>, "
+                    + "price:<positive/negative/not_mentioned>\"} — return only this JSON.";
 
     @ChatModelSetup
     public static ResourceDescriptor sentimentModel() {
@@ -153,37 +220,82 @@ public class ParallelChatAgent extends Agent {
                 .build();
     }
 
-    @Action(listenEventTypes = {InputEvent.EVENT_TYPE})
-    public static void requestAspectJudgments(Event event, RunnerContext ctx)
-            throws Exception {
-        Map<String, Object> row = initRow(event);
-        saveRow(ctx, row);
+    private static ChatRequestEvent buildAspectRequest(String text, String aspect) {
+        List<ChatMessage> messages =
+                List.of(
+                        new ChatMessage(MessageRole.SYSTEM, PARALLEL_SYSTEM_PROMPT),
+                        new ChatMessage(
+                                MessageRole.USER,
+                                "Judge the \"" + aspect + "\" dimension: " + text));
+        return new ChatRequestEvent(
+                "sentimentModel", messages, CustomTypesAndResources.AspectResponse.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ChatRequestEvent buildSummarizeRequest(Map<String, Object> row) {
+        Map<String, String> sentiments = (Map<String, String>) row.get("sentiments");
+        StringJoiner sj = new StringJoiner(" ");
         for (String aspect : ASPECTS) {
-            ctx.sendEvent(buildAspectRequest((String) row.get("text"), aspect));
+            sj.add(aspect + ":" + sentiments.get(aspect));
+        }
+        String body = "Original: " + row.get("text") + "\nJudgments: " + sj;
+        List<ChatMessage> messages =
+                List.of(
+                        new ChatMessage(MessageRole.SYSTEM, AGGREGATE_SYSTEM_PROMPT),
+                        new ChatMessage(MessageRole.USER, body));
+        return new ChatRequestEvent(
+                "sentimentModel", messages, CustomTypesAndResources.SummaryResponse.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Action(listenEventTypes = {InputEvent.EVENT_TYPE})
+    public static void requestAspectJudgments(Event event, RunnerContext ctx) throws Exception {
+        Map<String, Object> row = initRow(event);
+        List<ChatRequestEvent> requests = new ArrayList<>();
+        Map<String, String> aspectMap = (Map<String, String>) row.get("aspect_map");
+        for (String aspect : ASPECTS) {
+            ChatRequestEvent req = buildAspectRequest((String) row.get("text"), aspect);
+            aspectMap.put(req.getId().toString(), aspect);
+            requests.add(req);
+        }
+        // Sensory memory stores the Map directly in Java; no JSON serialization required.
+        ctx.getSensoryMemory().set("res", row);
+        for (ChatRequestEvent req : requests) {
+            ctx.sendEvent(req);
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Action(listenEventTypes = {ChatResponseEvent.EVENT_TYPE})
     public static void handleResponse(Event event, RunnerContext ctx) throws Exception {
-        Object parsed = parseResponse(event);
-        Map<String, Object> row = loadRow(ctx);
+        ChatResponseEvent chatResponse = ChatResponseEvent.fromEvent(event);
+        Object parsed = chatResponse.getResponse().getExtraArgs().get(STRUCTURED_OUTPUT);
+        Map<String, Object> row =
+                (Map<String, Object>) ctx.getSensoryMemory().get("res").getValue();
 
-        if (parsed instanceof SummaryResponse) {
-            SummaryResponse summary = (SummaryResponse) parsed;
+        if (parsed instanceof CustomTypesAndResources.SummaryResponse) {
+            CustomTypesAndResources.SummaryResponse summary =
+                    (CustomTypesAndResources.SummaryResponse) parsed;
             ctx.sendEvent(buildOutputEvent(row, summary));
             return;
         }
 
-        AspectResponse aspect = (AspectResponse) parsed;
+        CustomTypesAndResources.AspectResponse aspectResponse =
+                (CustomTypesAndResources.AspectResponse) parsed;
         Map<String, String> sentiments = (Map<String, String>) row.get("sentiments");
-        sentiments.put(aspect.aspect, aspect.result);
-        saveRow(ctx, row);
+        Map<String, String> aspectMap = (Map<String, String>) row.get("aspect_map");
+        String dispatchedAspect = aspectMap.get(chatResponse.getRequestId().toString());
+        sentiments.put(dispatchedAspect, aspectResponse.result);
+        // Sensory memory stores the Map directly in Java; no JSON serialization required.
+        ctx.getSensoryMemory().set("res", row);
         if (allAspectsReceived(row)) {
             ctx.sendEvent(buildSummarizeRequest(row));
         }
     }
 }
 ```
+
+Other private helpers (`initRow`, `buildOutputEvent`, `allAspectsReceived`) are omitted above; the full source is at [`ParallelChatAgent.java`](https://github.com/apache/flink-agents/blob/main/examples/src/main/java/org/apache/flink/agents/examples/agents/ParallelChatAgent.java).
 {{< /tab >}}
 
 {{< /tabs >}}
@@ -192,7 +304,7 @@ public class ParallelChatAgent extends Agent {
 **Constraints when using multi-action fan-out:**
 - **Fan-out action must exit immediately after sending events.** The action that emits multiple `ChatRequestEvent` events (e.g. `request_aspect_judgments`) should return right after calling `ctx.send_event(...)`. Do not `await`, block, or perform further business logic in the same action — the framework needs control back to schedule the parallel chat actions.
 - **Response handlers on the same key execute sequentially.** Multiple `ChatResponseEvent` triggers for the same key are processed one at a time, not concurrently. This means the read-modify-write pattern on sensory memory (e.g. `load_row → update → save_row`) is safe and will not suffer from concurrent overwrites.
-  {{< /hint >}}
+{{< /hint >}}
 
 ### Integrate the Agent with Flink
 

--- a/docs/content/docs/get-started/quickstart/parallel_llm.md
+++ b/docs/content/docs/get-started/quickstart/parallel_llm.md
@@ -24,11 +24,11 @@ under the License.
 
 ## Overview
 
-Flink Agents supports parallel LLM invocations via multi-action fan-out. By emitting multiple `ChatRequestEvent` events from a single action, the framework's built-in chat action executes the corresponding LLM calls concurrently — no external orchestration is required.
+Flink Agents supports parallel LLM invocations via a broadcast event model. By emitting a single intermediate event from one action and registering multiple independent action handlers that each listen on that event type, the framework's built-in chat action executes the corresponding LLM calls concurrently — no external orchestration is required.
 
 This quickstart introduces an example that demonstrates how to build a parallel LLM workflow with Flink Agents:
 
-The **Parallel Sentiment Analysis** agent processes a restaurant review and judges sentiment along three dimensions (taste / service / price) in parallel, then aggregates the results into a one-line summary with a final LLM call. The end-to-end wall clock time is roughly "slowest single branch + aggregation call", rather than the sum of all four calls.
+The **Parallel Sentiment Analysis** agent processes a restaurant review and judges sentiment along two dimensions (taste / service) in parallel, then aggregates the results into a one-line summary with a final LLM call. The end-to-end wall clock time is roughly "slowest single branch + aggregation call", rather than the sum of all three calls.
 
 {{< hint info >}}
 **JDK version note (Java only):** On JDK 21+, the framework uses the Continuation API to execute concurrent chat actions in parallel. On JDK < 21, the framework silently falls back to sequential execution — the result is identical, but the LLM calls run one after another. Python uses native coroutines and always executes in parallel regardless of the JDK version.
@@ -84,13 +84,13 @@ agentsEnv.addResource(
 
 ### Create the Agent
 
-Below is the example code for the `ParallelChatAgent`. Two system prompts — `PARALLEL_SYSTEM_PROMPT` for the parallel aspect judgments and `AGGREGATE_SYSTEM_PROMPT` for the aggregation call — are packaged into `ChatRequestEvent`s by `_build_aspect_request` / `buildAspectRequest` and `_build_summarize_request` / `buildSummarizeRequest`. The agent defines a chat model and two actions: `request_aspect_judgments` pre-builds all requests and records a `{request_id → aspect}` map for reliable correlation, and `handle_response` looks up the dispatched aspect by `request_id`, accumulates the results, and emits the final output. For more details, please refer to the [Workflow Agent]({{< ref "docs/development/workflow_agent" >}}) documentation.
+Below is the example code for the `ParallelChatAgent`. Two system prompts — `PARALLEL_SYSTEM_PROMPT` for the parallel aspect judgments and `AGGREGATE_SYSTEM_PROMPT` for the aggregation call — are packaged into `ChatRequestEvent`s by `_build_aspect_request` / `buildAspectRequest` and `_build_summarize_request` / `buildSummarizeRequest`. The agent defines a chat model and four actions: `request_aspect_judgments` initializes the row state and emits a single `SentimentInputEvent`; `handle_taste_input` and `handle_service_input` each listen on `SentimentInputEvent` and independently dispatch one `ChatRequestEvent`, recording a `{request_id → aspect}` entry in the shared `aspect_map`; and `handle_response` looks up the dispatched aspect by `request_id`, accumulates the results, and emits the final output. For more details, please refer to the [Workflow Agent]({{< ref "docs/development/workflow_agent" >}}) documentation.
 
 {{< tabs "Create the Agent" >}}
 
 {{< tab "Python" >}}
 ```python
-ASPECTS: Tuple[str, ...] = ("taste", "service", "price")
+ASPECTS: Tuple[str, ...] = ("taste", "service")
 N_ASPECTS = len(ASPECTS)
 
 PARALLEL_SYSTEM_PROMPT = (
@@ -99,12 +99,21 @@ PARALLEL_SYSTEM_PROMPT = (
     " — no explanation, no extra fields."
 )
 AGGREGATE_SYSTEM_PROMPT = (
-    "You are a summary assistant. Based on the sentiment judgments for three "
+    "You are a summary assistant. Based on the sentiment judgments for two "
     "dimensions, compose a brief one-line evaluation. Return JSON: "
     '{"summary":"taste:<positive/negative/not_mentioned>, '
-    "service:<positive/negative/not_mentioned>, "
-    'price:<positive/negative/not_mentioned>"} — return only this JSON.'
+    'service:<positive/negative/not_mentioned>"} — return only this JSON.'
 )
+
+
+class SentimentInputEvent(Event):
+    EVENT_TYPE: ClassVar[str] = "SentimentInputEvent"
+
+    def __init__(self, input_id: int, text: str) -> None:
+        super().__init__(
+            type=SentimentInputEvent.EVENT_TYPE,
+            attributes={"input_id": input_id, "text": text},
+        )
 
 
 def _build_aspect_request(text: str, aspect: str) -> ChatRequestEvent:
@@ -148,6 +157,14 @@ class ParallelChatAgent(Agent):
     along multiple dimensions in parallel, then aggregates the results into a
     one-line summary with a final LLM call. It handles prompt construction,
     parallel chat dispatch, response accumulation, and output assembly.
+
+    Event flow:
+      1. InputEvent → request_aspect_judgments → emits SentimentInputEvent
+      2. SentimentInputEvent triggers handlers in parallel:
+           - handle_taste_input   → ChatRequestEvent (taste LLM call)
+           - handle_service_input → ChatRequestEvent (service LLM call)
+      3. Each ChatResponseEvent → handle_response (accumulates aspect results)
+      4. Once all aspects received → aggregation LLM call → OutputEvent
     """
 
     @chat_model_setup
@@ -164,33 +181,39 @@ class ParallelChatAgent(Agent):
     @action(InputEvent.EVENT_TYPE)
     @staticmethod
     def request_aspect_judgments(event: Event, ctx: RunnerContext) -> None:
-        """Process input event and send chat requests for each aspect."""
+        """Process input event and dispatch a SentimentInputEvent for each aspect handler."""
         row = _init_row(event)
-        requests = [_build_aspect_request(row["text"], aspect) for aspect in ASPECTS]
-        row["aspect_map"] = {
-            str(req.id): aspect for req, aspect in zip(requests, ASPECTS, strict=True)
-        }
         # Sensory memory requires JSON serialization across the Pemja JVM boundary.
         ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
-        for req in requests:
-            ctx.send_event(req)
+        ctx.send_event(SentimentInputEvent(input_id=row["id"], text=row["text"]))
+
+    @action(SentimentInputEvent.EVENT_TYPE)
+    @staticmethod
+    def handle_taste_input(event: Event, ctx: RunnerContext) -> None:
+        """Handle taste aspect: build and send ChatRequestEvent for taste judgment."""
+        row = json.loads(ctx.sensory_memory.get("res"))
+        req = _build_aspect_request(event.get_attr("text"), "taste")
+        row["aspect_map"][str(req.id)] = "taste"
+        # Sensory memory requires JSON serialization across the Pemja JVM boundary.
+        ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
+        ctx.send_event(req)
+
+    @action(SentimentInputEvent.EVENT_TYPE)
+    @staticmethod
+    def handle_service_input(event: Event, ctx: RunnerContext) -> None:
+        """Handle service aspect: build and send ChatRequestEvent for service judgment."""
+        row = json.loads(ctx.sensory_memory.get("res"))
+        req = _build_aspect_request(event.get_attr("text"), "service")
+        row["aspect_map"][str(req.id)] = "service"
+        # Sensory memory requires JSON serialization across the Pemja JVM boundary.
+        ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
+        ctx.send_event(req)
 
     @action(ChatResponseEvent.EVENT_TYPE)
     @staticmethod
     def handle_response(event: Event, ctx: RunnerContext) -> None:
         """Process chat response event and send output event."""
-        response_event = ChatResponseEvent.from_event(event)
-        parsed = response_event.response.extra_args[STRUCTURED_OUTPUT]
-        row = json.loads(ctx.sensory_memory.get("res"))
-        if isinstance(parsed, SummaryResponse):
-            ctx.send_event(_build_output_event(row, parsed))
-            return
-        aspect = row["aspect_map"][str(response_event.request_id)]
-        row["sentiments"][aspect] = parsed.result
-        # Sensory memory requires JSON serialization across the Pemja JVM boundary.
-        ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
-        if _all_aspects_received(row):
-            ctx.send_event(_build_summarize_request(row))
+        ...
 ```
 
 The complete source including `_init_row`, `_build_output_event`, `_all_aspects_received`, and other supporting functions can be found in [`parallel_chat_agent.py`](https://github.com/apache/flink-agents/blob/main/python/flink_agents/examples/quickstart/agents/parallel_chat_agent.py).
@@ -198,9 +221,24 @@ The complete source including `_init_row`, `_build_output_event`, `_all_aspects_
 
 {{< tab "Java" >}}
 ```Java
+/**
+ * An agent that demonstrates parallel LLM invocations via a broadcast event model.
+ *
+ * <p>Event flow:
+ * <ol>
+ *   <li>InputEvent → requestAspectJudgments → emits SentimentInputEvent
+ *   <li>SentimentInputEvent triggers handlers in parallel:
+ *       <ul>
+ *         <li>handleTasteInput   → ChatRequestEvent (taste LLM call)
+ *         <li>handleServiceInput → ChatRequestEvent (service LLM call)
+ *       </ul>
+ *   <li>Each ChatResponseEvent → handleResponse (accumulates aspect results)
+ *   <li>Once all aspects received → aggregation LLM call → OutputEvent
+ * </ol>
+ */
 public class ParallelChatAgent extends Agent {
 
-    private static final String[] ASPECTS = {"taste", "service", "price"};
+    private static final String[] ASPECTS = {"taste", "service"};
     private static final int N_ASPECTS = ASPECTS.length;
 
     private static final String PARALLEL_SYSTEM_PROMPT =
@@ -208,11 +246,22 @@ public class ParallelChatAgent extends Agent {
                     + "{\"aspect\":\"<dimension>\", \"result\":\"<positive|negative|not_mentioned>\"}"
                     + " — no explanation, no extra fields.";
     private static final String AGGREGATE_SYSTEM_PROMPT =
-            "You are a summary assistant. Based on the sentiment judgments for three "
+            "You are a summary assistant. Based on the sentiment judgments for two "
                     + "dimensions, compose a brief one-line evaluation. Return JSON: "
                     + "{\"summary\":\"taste:<positive/negative/not_mentioned>, "
-                    + "service:<positive/negative/not_mentioned>, "
-                    + "price:<positive/negative/not_mentioned>\"} — return only this JSON.";
+                    + "service:<positive/negative/not_mentioned>\"} — return only this JSON.";
+
+    public static class SentimentInputEvent extends Event {
+        public static final String EVENT_TYPE = "SentimentInputEvent";
+        public final int inputId;
+        public final String text;
+
+        public SentimentInputEvent(int inputId, String text) {
+            super(EVENT_TYPE);
+            this.inputId = inputId;
+            this.text = text;
+        }
+    }
 
     @ChatModelSetup
     public static ResourceDescriptor sentimentModel() {
@@ -250,50 +299,47 @@ public class ParallelChatAgent extends Agent {
                 "sentimentModel", messages, CustomTypesAndResources.SummaryResponse.class);
     }
 
-    @SuppressWarnings("unchecked")
+    /** Process input event and dispatch a SentimentInputEvent for each aspect handler. */
     @Action(listenEventTypes = {InputEvent.EVENT_TYPE})
     public static void requestAspectJudgments(Event event, RunnerContext ctx) throws Exception {
         Map<String, Object> row = initRow(event);
-        List<ChatRequestEvent> requests = new ArrayList<>();
-        Map<String, String> aspectMap = (Map<String, String>) row.get("aspect_map");
-        for (String aspect : ASPECTS) {
-            ChatRequestEvent req = buildAspectRequest((String) row.get("text"), aspect);
-            aspectMap.put(req.getId().toString(), aspect);
-            requests.add(req);
-        }
         // Sensory memory stores the Map directly in Java; no JSON serialization required.
         ctx.getSensoryMemory().set("res", row);
-        for (ChatRequestEvent req : requests) {
-            ctx.sendEvent(req);
-        }
+        ctx.sendEvent(new SentimentInputEvent((int) row.get("id"), (String) row.get("text")));
+    }
+
+    /** Handle taste aspect: build and send ChatRequestEvent for taste judgment. */
+    @SuppressWarnings("unchecked")
+    @Action(listenEventTypes = {SentimentInputEvent.EVENT_TYPE})
+    public static void handleTasteInput(Event event, RunnerContext ctx) throws Exception {
+        SentimentInputEvent in = (SentimentInputEvent) event;
+        Map<String, Object> row =
+                (Map<String, Object>) ctx.getSensoryMemory().get("res").getValue();
+        ChatRequestEvent req = buildAspectRequest(in.text, "taste");
+        ((Map<String, String>) row.get("aspect_map")).put(req.getId().toString(), "taste");
+        // Sensory memory stores the Map directly in Java; no JSON serialization required.
+        ctx.getSensoryMemory().set("res", row);
+        ctx.sendEvent(req);
+    }
+
+    /** Handle service aspect: build and send ChatRequestEvent for service judgment. */
+    @SuppressWarnings("unchecked")
+    @Action(listenEventTypes = {SentimentInputEvent.EVENT_TYPE})
+    public static void handleServiceInput(Event event, RunnerContext ctx) throws Exception {
+        SentimentInputEvent in = (SentimentInputEvent) event;
+        Map<String, Object> row =
+                (Map<String, Object>) ctx.getSensoryMemory().get("res").getValue();
+        ChatRequestEvent req = buildAspectRequest(in.text, "service");
+        ((Map<String, String>) row.get("aspect_map")).put(req.getId().toString(), "service");
+        // Sensory memory stores the Map directly in Java; no JSON serialization required.
+        ctx.getSensoryMemory().set("res", row);
+        ctx.sendEvent(req);
     }
 
     @SuppressWarnings("unchecked")
     @Action(listenEventTypes = {ChatResponseEvent.EVENT_TYPE})
     public static void handleResponse(Event event, RunnerContext ctx) throws Exception {
-        ChatResponseEvent chatResponse = ChatResponseEvent.fromEvent(event);
-        Object parsed = chatResponse.getResponse().getExtraArgs().get(STRUCTURED_OUTPUT);
-        Map<String, Object> row =
-                (Map<String, Object>) ctx.getSensoryMemory().get("res").getValue();
-
-        if (parsed instanceof CustomTypesAndResources.SummaryResponse) {
-            CustomTypesAndResources.SummaryResponse summary =
-                    (CustomTypesAndResources.SummaryResponse) parsed;
-            ctx.sendEvent(buildOutputEvent(row, summary));
-            return;
-        }
-
-        CustomTypesAndResources.AspectResponse aspectResponse =
-                (CustomTypesAndResources.AspectResponse) parsed;
-        Map<String, String> sentiments = (Map<String, String>) row.get("sentiments");
-        Map<String, String> aspectMap = (Map<String, String>) row.get("aspect_map");
-        String dispatchedAspect = aspectMap.get(chatResponse.getRequestId().toString());
-        sentiments.put(dispatchedAspect, aspectResponse.result);
-        // Sensory memory stores the Map directly in Java; no JSON serialization required.
-        ctx.getSensoryMemory().set("res", row);
-        if (allAspectsReceived(row)) {
-            ctx.sendEvent(buildSummarizeRequest(row));
-        }
+        ...
     }
 }
 ```
@@ -304,9 +350,10 @@ Other private helpers (`initRow`, `buildOutputEvent`, `allAspectsReceived`) are 
 {{< /tabs >}}
 
 {{< hint warning >}}
-**Constraints when using multi-action fan-out:**
-- **Fan-out action must exit immediately after sending events.** The action that emits multiple `ChatRequestEvent` events (e.g. `request_aspect_judgments`) should return right after calling `ctx.send_event(...)`. Do not `await`, block, or perform further business logic in the same action — the framework needs control back to schedule the parallel chat actions.
-- **Response handlers on the same key execute sequentially.** Multiple `ChatResponseEvent` triggers for the same key are processed one at a time, not concurrently. This means the read-modify-write pattern on sensory memory (e.g. `load_row → update → save_row`) is safe and will not suffer from concurrent overwrites.
+**Constraints when using parallel actions:**
+- **Dispatch action must exit immediately after sending events.** The action that emits `SentimentInputEvent` (i.e. `request_aspect_judgments`) should return right after calling `ctx.send_event(...)`. Do not `await`, block, or perform further business logic in the same action — the framework needs control back to schedule the parallel chat actions.
+- **Action handlers on the same key execute sequentially.** Multiple action invocations triggered by the same key are processed one at a time, not concurrently. This means `handle_taste_input` and `handle_service_input` are called in sequence, making the read-modify-write pattern on sensory memory (e.g. `load_row → update → save_row`) safe and free from concurrent overwrites. The actual LLM calls dispatched by these handlers still execute in parallel.
+- **Response handlers on the same key execute sequentially.** Multiple `ChatResponseEvent` triggers for the same key are processed one at a time, not concurrently. This means the read-modify-write pattern on sensory memory in `handle_response` is safe and will not suffer from concurrent overwrites.
 {{< /hint >}}
 
 ### Integrate the Agent with Flink

--- a/examples/src/main/java/org/apache/flink/agents/examples/ParallelChatRequestExample.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/ParallelChatRequestExample.java
@@ -21,7 +21,6 @@ import org.apache.flink.agents.api.AgentsExecutionEnvironment;
 import org.apache.flink.agents.api.resource.ResourceDescriptor;
 import org.apache.flink.agents.api.resource.ResourceName;
 import org.apache.flink.agents.api.resource.ResourceType;
-import org.apache.flink.agents.examples.agents.CustomTypesAndResources;
 import org.apache.flink.agents.examples.agents.CustomTypesAndResources.SentimentKeySelector;
 import org.apache.flink.agents.examples.agents.CustomTypesAndResources.SentimentRequest;
 import org.apache.flink.agents.examples.agents.ParallelChatAgent;

--- a/examples/src/main/java/org/apache/flink/agents/examples/ParallelChatRequestExample.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/ParallelChatRequestExample.java
@@ -21,9 +21,10 @@ import org.apache.flink.agents.api.AgentsExecutionEnvironment;
 import org.apache.flink.agents.api.resource.ResourceDescriptor;
 import org.apache.flink.agents.api.resource.ResourceName;
 import org.apache.flink.agents.api.resource.ResourceType;
+import org.apache.flink.agents.examples.agents.CustomTypesAndResources;
+import org.apache.flink.agents.examples.agents.CustomTypesAndResources.SentimentKeySelector;
+import org.apache.flink.agents.examples.agents.CustomTypesAndResources.SentimentRequest;
 import org.apache.flink.agents.examples.agents.ParallelChatAgent;
-import org.apache.flink.agents.examples.agents.ParallelChatAgent.SentimentKeySelector;
-import org.apache.flink.agents.examples.agents.ParallelChatAgent.SentimentRequest;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
@@ -39,10 +40,6 @@ public class ParallelChatRequestExample {
 
     /** Runs the example pipeline. */
     public static void main(String[] args) throws Exception {
-        System.out.println("=== Parallel ChatRequest Example ===");
-        System.out.println("Model: " + ParallelChatAgent.OLLAMA_MODEL);
-        System.out.println("Input: " + ParallelChatAgent.INPUT_TEXT);
-
         // Set up the Flink streaming environment and the Agents execution environment.
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);
@@ -73,11 +70,6 @@ public class ParallelChatRequestExample {
         outputStream.print();
 
         // Execute the Flink pipeline.
-        long wallStart = System.currentTimeMillis();
         agentsEnv.execute();
-        long wallElapsed = System.currentTimeMillis() - wallStart;
-
-        System.out.println("End-to-end wall time: " + wallElapsed + "ms");
-        System.out.println("=== Done ===");
     }
 }

--- a/examples/src/main/java/org/apache/flink/agents/examples/ParallelChatRequestExample.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/ParallelChatRequestExample.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.examples;
+
+import org.apache.flink.agents.api.AgentsExecutionEnvironment;
+import org.apache.flink.agents.api.resource.ResourceDescriptor;
+import org.apache.flink.agents.api.resource.ResourceName;
+import org.apache.flink.agents.api.resource.ResourceType;
+import org.apache.flink.agents.examples.agents.ParallelChatAgent;
+import org.apache.flink.agents.examples.agents.ParallelChatAgent.SentimentKeySelector;
+import org.apache.flink.agents.examples.agents.ParallelChatAgent.SentimentRequest;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+/**
+ * Java example demonstrating parallel LLM invocations via multi-action fan-out.
+ *
+ * <p>This example demonstrates how to use the Flink Agents to analyze a restaurant review by
+ * fanning out multiple parallel LLM calls — one per sentiment dimension — and aggregating the
+ * results with a final LLM call. This serves as a minimal, end-to-end example of integrating
+ * parallel LLM-powered agents with Flink streaming jobs.
+ */
+public class ParallelChatRequestExample {
+
+    /** Runs the example pipeline. */
+    public static void main(String[] args) throws Exception {
+        System.out.println("=== Parallel ChatRequest Example ===");
+        System.out.println("Model: " + ParallelChatAgent.OLLAMA_MODEL);
+        System.out.println("Input: " + ParallelChatAgent.INPUT_TEXT);
+
+        // Set up the Flink streaming environment and the Agents execution environment.
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        AgentsExecutionEnvironment agentsEnv =
+                AgentsExecutionEnvironment.getExecutionEnvironment(env);
+
+        // Add Ollama chat model connection to be used by the ParallelChatAgent.
+        agentsEnv.addResource(
+                "ollamaChatModelConnection",
+                ResourceType.CHAT_MODEL_CONNECTION,
+                ResourceDescriptor.Builder.newBuilder(ResourceName.ChatModel.OLLAMA_CONNECTION)
+                        .addInitialArgument("endpoint", "http://localhost:11434")
+                        .addInitialArgument("requestTimeout", 240)
+                        .build());
+
+        // Create input stream with a single restaurant review.
+        DataStream<SentimentRequest> inputStream =
+                env.fromElements(new SentimentRequest(1, ParallelChatAgent.INPUT_TEXT));
+
+        // Use the ParallelChatAgent to analyze the review with parallel LLM calls.
+        DataStream<Object> outputStream =
+                agentsEnv
+                        .fromDataStream(inputStream, new SentimentKeySelector())
+                        .apply(new ParallelChatAgent())
+                        .toDataStream();
+
+        // Print the analysis results to stdout.
+        outputStream.print();
+
+        // Execute the Flink pipeline.
+        long wallStart = System.currentTimeMillis();
+        agentsEnv.execute();
+        long wallElapsed = System.currentTimeMillis() - wallStart;
+
+        System.out.println("End-to-end wall time: " + wallElapsed + "ms");
+        System.out.println("=== Done ===");
+    }
+}

--- a/examples/src/main/java/org/apache/flink/agents/examples/agents/CustomTypesAndResources.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/agents/CustomTypesAndResources.java
@@ -26,7 +26,9 @@ import org.apache.flink.agents.api.chat.messages.MessageRole;
 import org.apache.flink.agents.api.prompt.Prompt;
 import org.apache.flink.agents.api.resource.ResourceDescriptor;
 import org.apache.flink.agents.api.resource.ResourceName;
+import org.apache.flink.api.java.functions.KeySelector;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 
@@ -221,6 +223,66 @@ public class CustomTypesAndResources {
             return String.format(
                     "ProductReviewSummary{id='%s', scoreHist=%s, unsatisfiedReasons=%s}",
                     id, scoreHist, unsatisfiedReasons);
+        }
+    }
+
+    /** Single input record carrying an id and text for parallel sentiment analysis. */
+    public static class SentimentRequest implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private final int id;
+        private final String text;
+
+        public SentimentRequest(int id, String text) {
+            this.id = id;
+            this.text = text;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("SentimentRequest{id=%d, text='%s'}", id, text);
+        }
+    }
+
+    /** Key selector that extracts the id field from a {@link SentimentRequest}. */
+    public static class SentimentKeySelector implements KeySelector<SentimentRequest, Integer> {
+        @Override
+        public Integer getKey(SentimentRequest request) {
+            return request.getId();
+        }
+    }
+
+    /** LLM response for a single aspect judgment. */
+    public static class AspectResponse implements Serializable {
+        private static final long serialVersionUID = 1L;
+        public String aspect;
+        public String result;
+
+        public AspectResponse() {}
+
+        @Override
+        public String toString() {
+            return String.format("AspectResponse{aspect='%s', result='%s'}", aspect, result);
+        }
+    }
+
+    /** LLM response for the aggregation phase. */
+    public static class SummaryResponse implements Serializable {
+        private static final long serialVersionUID = 1L;
+        public String summary;
+
+        public SummaryResponse() {}
+
+        @Override
+        public String toString() {
+            return String.format("SummaryResponse{summary='%s'}", summary);
         }
     }
 

--- a/examples/src/main/java/org/apache/flink/agents/examples/agents/ParallelChatAgent.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/agents/ParallelChatAgent.java
@@ -86,7 +86,8 @@ public class ParallelChatAgent extends Agent {
 
     private static Map<String, Object> initRow(Event event) {
         InputEvent inputEvent = InputEvent.fromEvent(event);
-        CustomTypesAndResources.SentimentRequest request = (CustomTypesAndResources.SentimentRequest) inputEvent.getInput();
+        CustomTypesAndResources.SentimentRequest request =
+                (CustomTypesAndResources.SentimentRequest) inputEvent.getInput();
         Map<String, Object> row = new HashMap<>();
         row.put("id", request.getId());
         row.put("text", request.getText());
@@ -110,7 +111,8 @@ public class ParallelChatAgent extends Agent {
                         new ChatMessage(
                                 MessageRole.USER,
                                 "Judge the \"" + aspect + "\" dimension: " + text));
-        return new ChatRequestEvent("sentimentModel", messages, CustomTypesAndResources.AspectResponse.class);
+        return new ChatRequestEvent(
+                "sentimentModel", messages, CustomTypesAndResources.AspectResponse.class);
     }
 
     @SuppressWarnings("unchecked")
@@ -125,10 +127,12 @@ public class ParallelChatAgent extends Agent {
                 List.of(
                         new ChatMessage(MessageRole.SYSTEM, AGGREGATE_SYSTEM_PROMPT),
                         new ChatMessage(MessageRole.USER, body));
-        return new ChatRequestEvent("sentimentModel", messages, CustomTypesAndResources.SummaryResponse.class);
+        return new ChatRequestEvent(
+                "sentimentModel", messages, CustomTypesAndResources.SummaryResponse.class);
     }
 
-    private static OutputEvent buildOutputEvent(Map<String, Object> row, CustomTypesAndResources.SummaryResponse parsed) {
+    private static OutputEvent buildOutputEvent(
+            Map<String, Object> row, CustomTypesAndResources.SummaryResponse parsed) {
         Map<String, Object> output = new HashMap<>();
         output.put("id", row.get("id"));
         output.put("text", row.get("text"));
@@ -166,12 +170,14 @@ public class ParallelChatAgent extends Agent {
         Map<String, Object> row = loadRow(ctx);
 
         if (parsed instanceof CustomTypesAndResources.SummaryResponse) {
-            CustomTypesAndResources.SummaryResponse summary = (CustomTypesAndResources.SummaryResponse) parsed;
+            CustomTypesAndResources.SummaryResponse summary =
+                    (CustomTypesAndResources.SummaryResponse) parsed;
             ctx.sendEvent(buildOutputEvent(row, summary));
             return;
         }
 
-        CustomTypesAndResources.AspectResponse aspect = (CustomTypesAndResources.AspectResponse) parsed;
+        CustomTypesAndResources.AspectResponse aspect =
+                (CustomTypesAndResources.AspectResponse) parsed;
         Map<String, String> sentiments = (Map<String, String>) row.get("sentiments");
         sentiments.put(aspect.aspect, aspect.result);
         saveRow(ctx, row);

--- a/examples/src/main/java/org/apache/flink/agents/examples/agents/ParallelChatAgent.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/agents/ParallelChatAgent.java
@@ -31,7 +31,6 @@ import org.apache.flink.agents.api.event.ChatResponseEvent;
 import org.apache.flink.agents.api.resource.ResourceDescriptor;
 import org.apache.flink.agents.api.resource.ResourceName;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,9 +43,21 @@ import static org.apache.flink.agents.api.agents.Agent.STRUCTURED_OUTPUT;
  * ChatRequestEvent} events.
  *
  * <p>This agent receives a restaurant review and uses an LLM to judge sentiment along multiple
- * dimensions (taste / service / price) in parallel, then aggregates the results into a one-line
+ * dimensions (taste / service) in parallel, then aggregates the results into a one-line
  * summary with a final LLM call. It handles prompt construction, parallel chat dispatch, response
  * accumulation, and output assembly.
+ *
+ * <p>Event flow:
+ * <ol>
+ *   <li>InputEvent → requestAspectJudgments → emits SentimentInputEvent
+ *   <li>SentimentInputEvent triggers handlers in parallel:
+ *       <ul>
+ *         <li>handleTasteInput   → ChatRequestEvent (taste LLM call)
+ *         <li>handleServiceInput → ChatRequestEvent (service LLM call)
+ *       </ul>
+ *   <li>Each ChatResponseEvent → handleResponse (accumulates aspect results)
+ *   <li>Once all aspects received → aggregation LLM call → OutputEvent
+ * </ol>
  *
  * <p><b>JDK version note:</b> On JDK 21+, the framework uses the Continuation API to execute
  * concurrent chat actions in parallel, so the wall clock time is roughly "slowest single branch +
@@ -62,7 +73,7 @@ public class ParallelChatAgent extends Agent {
     /** Input text for the demo. */
     public static final String INPUT_TEXT = "The food here is great, but the service is too slow";
 
-    private static final String[] ASPECTS = {"taste", "service", "price"};
+    private static final String[] ASPECTS = {"taste", "service"};
     private static final int N_ASPECTS = ASPECTS.length;
 
     private static final String PARALLEL_SYSTEM_PROMPT =
@@ -70,11 +81,23 @@ public class ParallelChatAgent extends Agent {
                     + "{\"aspect\":\"<dimension>\", \"result\":\"<positive|negative|not_mentioned>\"}"
                     + " — no explanation, no extra fields.";
     private static final String AGGREGATE_SYSTEM_PROMPT =
-            "You are a summary assistant. Based on the sentiment judgments for three "
+            "You are a summary assistant. Based on the sentiment judgments for two "
                     + "dimensions, compose a brief one-line evaluation. Return JSON: "
                     + "{\"summary\":\"taste:<positive/negative/not_mentioned>, "
-                    + "service:<positive/negative/not_mentioned>, "
-                    + "price:<positive/negative/not_mentioned>\"} — return only this JSON.";
+                    + "service:<positive/negative/not_mentioned>\"} — return only this JSON.";
+
+    /** Intermediate event that broadcasts the review input to all aspect handlers. */
+    public static class SentimentInputEvent extends Event {
+        public static final String EVENT_TYPE = "SentimentInputEvent";
+        public final int inputId;
+        public final String text;
+
+        public SentimentInputEvent(int inputId, String text) {
+            super(EVENT_TYPE);
+            this.inputId = inputId;
+            this.text = text;
+        }
+    }
 
     @ChatModelSetup
     public static ResourceDescriptor sentimentModel() {
@@ -139,23 +162,41 @@ public class ParallelChatAgent extends Agent {
         return sentiments.size() == N_ASPECTS;
     }
 
-    /** Process input event and fan-out chat requests for each aspect. */
-    @SuppressWarnings("unchecked")
+    /** Process input event and dispatch a SentimentInputEvent for each aspect handler. */
     @Action(listenEventTypes = {InputEvent.EVENT_TYPE})
     public static void requestAspectJudgments(Event event, RunnerContext ctx) throws Exception {
         Map<String, Object> row = initRow(event);
-        List<ChatRequestEvent> requests = new ArrayList<>();
-        Map<String, String> aspectMap = (Map<String, String>) row.get("aspect_map");
-        for (String aspect : ASPECTS) {
-            ChatRequestEvent req = buildAspectRequest((String) row.get("text"), aspect);
-            aspectMap.put(req.getId().toString(), aspect);
-            requests.add(req);
-        }
         // Sensory memory stores the Map directly in Java; no JSON serialization required.
         ctx.getSensoryMemory().set("res", row);
-        for (ChatRequestEvent req : requests) {
-            ctx.sendEvent(req);
-        }
+        ctx.sendEvent(new SentimentInputEvent((int) row.get("id"), (String) row.get("text")));
+    }
+
+    /** Handle taste aspect: build and send ChatRequestEvent for taste judgment. */
+    @SuppressWarnings("unchecked")
+    @Action(listenEventTypes = {SentimentInputEvent.EVENT_TYPE})
+    public static void handleTasteInput(Event event, RunnerContext ctx) throws Exception {
+        SentimentInputEvent in = (SentimentInputEvent) event;
+        Map<String, Object> row =
+                (Map<String, Object>) ctx.getSensoryMemory().get("res").getValue();
+        ChatRequestEvent req = buildAspectRequest(in.text, "taste");
+        ((Map<String, String>) row.get("aspect_map")).put(req.getId().toString(), "taste");
+        // Sensory memory stores the Map directly in Java; no JSON serialization required.
+        ctx.getSensoryMemory().set("res", row);
+        ctx.sendEvent(req);
+    }
+
+    /** Handle service aspect: build and send ChatRequestEvent for service judgment. */
+    @SuppressWarnings("unchecked")
+    @Action(listenEventTypes = {SentimentInputEvent.EVENT_TYPE})
+    public static void handleServiceInput(Event event, RunnerContext ctx) throws Exception {
+        SentimentInputEvent in = (SentimentInputEvent) event;
+        Map<String, Object> row =
+                (Map<String, Object>) ctx.getSensoryMemory().get("res").getValue();
+        ChatRequestEvent req = buildAspectRequest(in.text, "service");
+        ((Map<String, String>) row.get("aspect_map")).put(req.getId().toString(), "service");
+        // Sensory memory stores the Map directly in Java; no JSON serialization required.
+        ctx.getSensoryMemory().set("res", row);
+        ctx.sendEvent(req);
     }
 
     /** Process chat response event. */

--- a/examples/src/main/java/org/apache/flink/agents/examples/agents/ParallelChatAgent.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/agents/ParallelChatAgent.java
@@ -31,6 +31,7 @@ import org.apache.flink.agents.api.event.ChatResponseEvent;
 import org.apache.flink.agents.api.resource.ResourceDescriptor;
 import org.apache.flink.agents.api.resource.ResourceName;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -92,16 +93,8 @@ public class ParallelChatAgent extends Agent {
         row.put("id", request.getId());
         row.put("text", request.getText());
         row.put("sentiments", new HashMap<String, String>());
+        row.put("aspect_map", new HashMap<String, String>());
         return row;
-    }
-
-    private static void saveRow(RunnerContext ctx, Map<String, Object> row) throws Exception {
-        ctx.getSensoryMemory().set("res", row);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Map<String, Object> loadRow(RunnerContext ctx) throws Exception {
-        return (Map<String, Object>) ctx.getSensoryMemory().get("res").getValue();
     }
 
     private static ChatRequestEvent buildAspectRequest(String text, String aspect) {
@@ -140,12 +133,6 @@ public class ParallelChatAgent extends Agent {
         return new OutputEvent(output);
     }
 
-    private static Object parseResponse(Event event) {
-        ChatResponseEvent chatResponse = ChatResponseEvent.fromEvent(event);
-        ChatMessage response = chatResponse.getResponse();
-        return response.getExtraArgs().get(STRUCTURED_OUTPUT);
-    }
-
     @SuppressWarnings("unchecked")
     private static boolean allAspectsReceived(Map<String, Object> row) {
         Map<String, String> sentiments = (Map<String, String>) row.get("sentiments");
@@ -153,12 +140,21 @@ public class ParallelChatAgent extends Agent {
     }
 
     /** Process input event and fan-out chat requests for each aspect. */
+    @SuppressWarnings("unchecked")
     @Action(listenEventTypes = {InputEvent.EVENT_TYPE})
     public static void requestAspectJudgments(Event event, RunnerContext ctx) throws Exception {
         Map<String, Object> row = initRow(event);
-        saveRow(ctx, row);
+        List<ChatRequestEvent> requests = new ArrayList<>();
+        Map<String, String> aspectMap = (Map<String, String>) row.get("aspect_map");
         for (String aspect : ASPECTS) {
-            ctx.sendEvent(buildAspectRequest((String) row.get("text"), aspect));
+            ChatRequestEvent req = buildAspectRequest((String) row.get("text"), aspect);
+            aspectMap.put(req.getId().toString(), aspect);
+            requests.add(req);
+        }
+        // Sensory memory stores the Map directly in Java; no JSON serialization required.
+        ctx.getSensoryMemory().set("res", row);
+        for (ChatRequestEvent req : requests) {
+            ctx.sendEvent(req);
         }
     }
 
@@ -166,8 +162,10 @@ public class ParallelChatAgent extends Agent {
     @SuppressWarnings("unchecked")
     @Action(listenEventTypes = {ChatResponseEvent.EVENT_TYPE})
     public static void handleResponse(Event event, RunnerContext ctx) throws Exception {
-        Object parsed = parseResponse(event);
-        Map<String, Object> row = loadRow(ctx);
+        ChatResponseEvent chatResponse = ChatResponseEvent.fromEvent(event);
+        Object parsed = chatResponse.getResponse().getExtraArgs().get(STRUCTURED_OUTPUT);
+        Map<String, Object> row =
+                (Map<String, Object>) ctx.getSensoryMemory().get("res").getValue();
 
         if (parsed instanceof CustomTypesAndResources.SummaryResponse) {
             CustomTypesAndResources.SummaryResponse summary =
@@ -176,11 +174,14 @@ public class ParallelChatAgent extends Agent {
             return;
         }
 
-        CustomTypesAndResources.AspectResponse aspect =
+        CustomTypesAndResources.AspectResponse aspectResponse =
                 (CustomTypesAndResources.AspectResponse) parsed;
         Map<String, String> sentiments = (Map<String, String>) row.get("sentiments");
-        sentiments.put(aspect.aspect, aspect.result);
-        saveRow(ctx, row);
+        Map<String, String> aspectMap = (Map<String, String>) row.get("aspect_map");
+        String dispatchedAspect = aspectMap.get(chatResponse.getRequestId().toString());
+        sentiments.put(dispatchedAspect, aspectResponse.result);
+        // Sensory memory stores the Map directly in Java; no JSON serialization required.
+        ctx.getSensoryMemory().set("res", row);
         if (allAspectsReceived(row)) {
             ctx.sendEvent(buildSummarizeRequest(row));
         }

--- a/examples/src/main/java/org/apache/flink/agents/examples/agents/ParallelChatAgent.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/agents/ParallelChatAgent.java
@@ -43,16 +43,17 @@ import static org.apache.flink.agents.api.agents.Agent.STRUCTURED_OUTPUT;
  * ChatRequestEvent} events.
  *
  * <p>This agent receives a restaurant review and uses an LLM to judge sentiment along multiple
- * dimensions (taste / service) in parallel, then aggregates the results into a one-line
- * summary with a final LLM call. It handles prompt construction, parallel chat dispatch, response
+ * dimensions (taste / service) in parallel, then aggregates the results into a one-line summary
+ * with a final LLM call. It handles prompt construction, parallel chat dispatch, response
  * accumulation, and output assembly.
  *
  * <p>Event flow:
+ *
  * <ol>
  *   <li>InputEvent → requestAspectJudgments → emits SentimentInputEvent
  *   <li>SentimentInputEvent triggers handlers in parallel:
  *       <ul>
- *         <li>handleTasteInput   → ChatRequestEvent (taste LLM call)
+ *         <li>handleTasteInput → ChatRequestEvent (taste LLM call)
  *         <li>handleServiceInput → ChatRequestEvent (service LLM call)
  *       </ul>
  *   <li>Each ChatResponseEvent → handleResponse (accumulates aspect results)
@@ -74,7 +75,6 @@ public class ParallelChatAgent extends Agent {
     public static final String INPUT_TEXT = "The food here is great, but the service is too slow";
 
     private static final String[] ASPECTS = {"taste", "service"};
-    private static final int N_ASPECTS = ASPECTS.length;
 
     private static final String PARALLEL_SYSTEM_PROMPT =
             "You are a sentiment analysis assistant. Return JSON: "
@@ -108,18 +108,6 @@ public class ParallelChatAgent extends Agent {
                 .build();
     }
 
-    private static Map<String, Object> initRow(Event event) {
-        InputEvent inputEvent = InputEvent.fromEvent(event);
-        CustomTypesAndResources.SentimentRequest request =
-                (CustomTypesAndResources.SentimentRequest) inputEvent.getInput();
-        Map<String, Object> row = new HashMap<>();
-        row.put("id", request.getId());
-        row.put("text", request.getText());
-        row.put("sentiments", new HashMap<String, String>());
-        row.put("aspect_map", new HashMap<String, String>());
-        return row;
-    }
-
     private static ChatRequestEvent buildAspectRequest(String text, String aspect) {
         List<ChatMessage> messages =
                 List.of(
@@ -131,14 +119,13 @@ public class ParallelChatAgent extends Agent {
                 "sentimentModel", messages, CustomTypesAndResources.AspectResponse.class);
     }
 
-    @SuppressWarnings("unchecked")
-    private static ChatRequestEvent buildSummarizeRequest(Map<String, Object> row) {
-        Map<String, String> sentiments = (Map<String, String>) row.get("sentiments");
+    private static ChatRequestEvent buildSummarizeRequest(
+            String text, Map<String, String> sentiments) {
         StringJoiner sj = new StringJoiner(" ");
         for (String aspect : ASPECTS) {
             sj.add(aspect + ":" + sentiments.get(aspect));
         }
-        String body = "Original: " + row.get("text") + "\nJudgments: " + sj;
+        String body = "Original: " + text + "\nJudgments: " + sj;
         List<ChatMessage> messages =
                 List.of(
                         new ChatMessage(MessageRole.SYSTEM, AGGREGATE_SYSTEM_PROMPT),
@@ -148,83 +135,81 @@ public class ParallelChatAgent extends Agent {
     }
 
     private static OutputEvent buildOutputEvent(
-            Map<String, Object> row, CustomTypesAndResources.SummaryResponse parsed) {
+            int id, String text, CustomTypesAndResources.SummaryResponse parsed) {
         Map<String, Object> output = new HashMap<>();
-        output.put("id", row.get("id"));
-        output.put("text", row.get("text"));
+        output.put("id", id);
+        output.put("text", text);
         output.put("summary", parsed.summary);
         return new OutputEvent(output);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static boolean allAspectsReceived(Map<String, Object> row) {
-        Map<String, String> sentiments = (Map<String, String>) row.get("sentiments");
-        return sentiments.size() == N_ASPECTS;
     }
 
     /** Process input event and dispatch a SentimentInputEvent for each aspect handler. */
     @Action(listenEventTypes = {InputEvent.EVENT_TYPE})
     public static void requestAspectJudgments(Event event, RunnerContext ctx) throws Exception {
-        Map<String, Object> row = initRow(event);
-        // Sensory memory stores the Map directly in Java; no JSON serialization required.
-        ctx.getSensoryMemory().set("res", row);
-        ctx.sendEvent(new SentimentInputEvent((int) row.get("id"), (String) row.get("text")));
+        InputEvent inputEvent = InputEvent.fromEvent(event);
+        CustomTypesAndResources.SentimentRequest request =
+                (CustomTypesAndResources.SentimentRequest) inputEvent.getInput();
+        ctx.getSensoryMemory().set("id", request.getId());
+        ctx.getSensoryMemory().set("text", request.getText());
+        ctx.sendEvent(new SentimentInputEvent(request.getId(), request.getText()));
     }
 
     /** Handle taste aspect: build and send ChatRequestEvent for taste judgment. */
-    @SuppressWarnings("unchecked")
     @Action(listenEventTypes = {SentimentInputEvent.EVENT_TYPE})
     public static void handleTasteInput(Event event, RunnerContext ctx) throws Exception {
         SentimentInputEvent in = (SentimentInputEvent) event;
-        Map<String, Object> row =
-                (Map<String, Object>) ctx.getSensoryMemory().get("res").getValue();
         ChatRequestEvent req = buildAspectRequest(in.text, "taste");
-        ((Map<String, String>) row.get("aspect_map")).put(req.getId().toString(), "taste");
-        // Sensory memory stores the Map directly in Java; no JSON serialization required.
-        ctx.getSensoryMemory().set("res", row);
+        ctx.getSensoryMemory().set("aspect_map." + req.getId(), "taste");
         ctx.sendEvent(req);
     }
 
     /** Handle service aspect: build and send ChatRequestEvent for service judgment. */
-    @SuppressWarnings("unchecked")
     @Action(listenEventTypes = {SentimentInputEvent.EVENT_TYPE})
     public static void handleServiceInput(Event event, RunnerContext ctx) throws Exception {
         SentimentInputEvent in = (SentimentInputEvent) event;
-        Map<String, Object> row =
-                (Map<String, Object>) ctx.getSensoryMemory().get("res").getValue();
         ChatRequestEvent req = buildAspectRequest(in.text, "service");
-        ((Map<String, String>) row.get("aspect_map")).put(req.getId().toString(), "service");
-        // Sensory memory stores the Map directly in Java; no JSON serialization required.
-        ctx.getSensoryMemory().set("res", row);
+        ctx.getSensoryMemory().set("aspect_map." + req.getId(), "service");
         ctx.sendEvent(req);
     }
 
     /** Process chat response event. */
-    @SuppressWarnings("unchecked")
     @Action(listenEventTypes = {ChatResponseEvent.EVENT_TYPE})
     public static void handleResponse(Event event, RunnerContext ctx) throws Exception {
         ChatResponseEvent chatResponse = ChatResponseEvent.fromEvent(event);
         Object parsed = chatResponse.getResponse().getExtraArgs().get(STRUCTURED_OUTPUT);
-        Map<String, Object> row =
-                (Map<String, Object>) ctx.getSensoryMemory().get("res").getValue();
 
         if (parsed instanceof CustomTypesAndResources.SummaryResponse) {
             CustomTypesAndResources.SummaryResponse summary =
                     (CustomTypesAndResources.SummaryResponse) parsed;
-            ctx.sendEvent(buildOutputEvent(row, summary));
+            int id = (int) ctx.getSensoryMemory().get("id").getValue();
+            String text = (String) ctx.getSensoryMemory().get("text").getValue();
+            ctx.sendEvent(buildOutputEvent(id, text, summary));
             return;
         }
 
         CustomTypesAndResources.AspectResponse aspectResponse =
                 (CustomTypesAndResources.AspectResponse) parsed;
-        Map<String, String> sentiments = (Map<String, String>) row.get("sentiments");
-        Map<String, String> aspectMap = (Map<String, String>) row.get("aspect_map");
-        String dispatchedAspect = aspectMap.get(chatResponse.getRequestId().toString());
-        sentiments.put(dispatchedAspect, aspectResponse.result);
-        // Sensory memory stores the Map directly in Java; no JSON serialization required.
-        ctx.getSensoryMemory().set("res", row);
-        if (allAspectsReceived(row)) {
-            ctx.sendEvent(buildSummarizeRequest(row));
+        String aspect =
+                (String)
+                        ctx.getSensoryMemory()
+                                .get("aspect_map." + chatResponse.getRequestId())
+                                .getValue();
+        ctx.getSensoryMemory().set("sentiments." + aspect, aspectResponse.result);
+        boolean allReceived = true;
+        for (String a : ASPECTS) {
+            if (!ctx.getSensoryMemory().isExist("sentiments." + a)) {
+                allReceived = false;
+                break;
+            }
+        }
+        if (allReceived) {
+            String text = (String) ctx.getSensoryMemory().get("text").getValue();
+            Map<String, String> sentiments = new HashMap<>();
+            for (String a : ASPECTS) {
+                sentiments.put(
+                        a, (String) ctx.getSensoryMemory().get("sentiments." + a).getValue());
+            }
+            ctx.sendEvent(buildSummarizeRequest(text, sentiments));
         }
     }
 }

--- a/examples/src/main/java/org/apache/flink/agents/examples/agents/ParallelChatAgent.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/agents/ParallelChatAgent.java
@@ -30,10 +30,7 @@ import org.apache.flink.agents.api.event.ChatRequestEvent;
 import org.apache.flink.agents.api.event.ChatResponseEvent;
 import org.apache.flink.agents.api.resource.ResourceDescriptor;
 import org.apache.flink.agents.api.resource.ResourceName;
-import org.apache.flink.api.java.functions.KeySelector;
-import org.apache.flink.types.Row;
 
-import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,58 +75,6 @@ public class ParallelChatAgent extends Agent {
                     + "service:<positive/negative/not_mentioned>, "
                     + "price:<positive/negative/not_mentioned>\"} — return only this JSON.";
 
-    /** LLM response for a single aspect judgment. */
-    public static class AspectResponse implements Serializable {
-        private static final long serialVersionUID = 1L;
-        public String aspect;
-        public String result;
-
-        public AspectResponse() {}
-
-        @Override
-        public String toString() {
-            return String.format("AspectResponse{aspect='%s', result='%s'}", aspect, result);
-        }
-    }
-
-    /** LLM response for the aggregation phase. */
-    public static class SummaryResponse implements Serializable {
-        private static final long serialVersionUID = 1L;
-        public String summary;
-
-        public SummaryResponse() {}
-
-        @Override
-        public String toString() {
-            return String.format("SummaryResponse{summary='%s'}", summary);
-        }
-    }
-
-    /** Single input record carrying an id and text. */
-    public static class SentimentRequest implements Serializable {
-        private static final long serialVersionUID = 1L;
-        public final int id;
-        public final String text;
-
-        public SentimentRequest(int id, String text) {
-            this.id = id;
-            this.text = text;
-        }
-
-        @Override
-        public String toString() {
-            return String.format("SentimentRequest{id=%d, text='%s'}", id, text);
-        }
-    }
-
-    /** Key selector that extracts the id field from a {@link SentimentRequest}. */
-    public static class SentimentKeySelector implements KeySelector<SentimentRequest, Integer> {
-        @Override
-        public Integer getKey(SentimentRequest request) {
-            return request.id;
-        }
-    }
-
     @ChatModelSetup
     public static ResourceDescriptor sentimentModel() {
         return ResourceDescriptor.Builder.newBuilder(ResourceName.ChatModel.OLLAMA_SETUP)
@@ -141,10 +86,10 @@ public class ParallelChatAgent extends Agent {
 
     private static Map<String, Object> initRow(Event event) {
         InputEvent inputEvent = InputEvent.fromEvent(event);
-        SentimentRequest request = (SentimentRequest) inputEvent.getInput();
+        CustomTypesAndResources.SentimentRequest request = (CustomTypesAndResources.SentimentRequest) inputEvent.getInput();
         Map<String, Object> row = new HashMap<>();
-        row.put("id", request.id);
-        row.put("text", request.text);
+        row.put("id", request.getId());
+        row.put("text", request.getText());
         row.put("sentiments", new HashMap<String, String>());
         return row;
     }
@@ -165,7 +110,7 @@ public class ParallelChatAgent extends Agent {
                         new ChatMessage(
                                 MessageRole.USER,
                                 "Judge the \"" + aspect + "\" dimension: " + text));
-        return new ChatRequestEvent("sentimentModel", messages, AspectResponse.class);
+        return new ChatRequestEvent("sentimentModel", messages, CustomTypesAndResources.AspectResponse.class);
     }
 
     @SuppressWarnings("unchecked")
@@ -180,14 +125,14 @@ public class ParallelChatAgent extends Agent {
                 List.of(
                         new ChatMessage(MessageRole.SYSTEM, AGGREGATE_SYSTEM_PROMPT),
                         new ChatMessage(MessageRole.USER, body));
-        return new ChatRequestEvent("sentimentModel", messages, SummaryResponse.class);
+        return new ChatRequestEvent("sentimentModel", messages, CustomTypesAndResources.SummaryResponse.class);
     }
 
-    private static OutputEvent buildOutputEvent(Map<String, Object> row, SummaryResponse parsed) {
-        Row output = Row.withNames();
-        output.setField("id", row.get("id"));
-        output.setField("text", row.get("text"));
-        output.setField("summary", parsed.summary);
+    private static OutputEvent buildOutputEvent(Map<String, Object> row, CustomTypesAndResources.SummaryResponse parsed) {
+        Map<String, Object> output = new HashMap<>();
+        output.put("id", row.get("id"));
+        output.put("text", row.get("text"));
+        output.put("summary", parsed.summary);
         return new OutputEvent(output);
     }
 
@@ -220,27 +165,13 @@ public class ParallelChatAgent extends Agent {
         Object parsed = parseResponse(event);
         Map<String, Object> row = loadRow(ctx);
 
-        if (parsed instanceof SummaryResponse) {
-            SummaryResponse summary = (SummaryResponse) parsed;
-            System.out.println(
-                    "FINAL summary="
-                            + summary.summary
-                            + " (t="
-                            + System.nanoTime() / 1_000_000_000.0
-                            + ")");
+        if (parsed instanceof CustomTypesAndResources.SummaryResponse) {
+            CustomTypesAndResources.SummaryResponse summary = (CustomTypesAndResources.SummaryResponse) parsed;
             ctx.sendEvent(buildOutputEvent(row, summary));
             return;
         }
 
-        AspectResponse aspect = (AspectResponse) parsed;
-        System.out.println(
-                "ASPECT "
-                        + aspect.aspect
-                        + "="
-                        + aspect.result
-                        + " (t="
-                        + System.nanoTime() / 1_000_000_000.0
-                        + ")");
+        CustomTypesAndResources.AspectResponse aspect = (CustomTypesAndResources.AspectResponse) parsed;
         Map<String, String> sentiments = (Map<String, String>) row.get("sentiments");
         sentiments.put(aspect.aspect, aspect.result);
         saveRow(ctx, row);

--- a/examples/src/main/java/org/apache/flink/agents/examples/agents/ParallelChatAgent.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/agents/ParallelChatAgent.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.examples.agents;
+
+import org.apache.flink.agents.api.Event;
+import org.apache.flink.agents.api.InputEvent;
+import org.apache.flink.agents.api.OutputEvent;
+import org.apache.flink.agents.api.agents.Agent;
+import org.apache.flink.agents.api.annotation.Action;
+import org.apache.flink.agents.api.annotation.ChatModelSetup;
+import org.apache.flink.agents.api.chat.messages.ChatMessage;
+import org.apache.flink.agents.api.chat.messages.MessageRole;
+import org.apache.flink.agents.api.context.RunnerContext;
+import org.apache.flink.agents.api.event.ChatRequestEvent;
+import org.apache.flink.agents.api.event.ChatResponseEvent;
+import org.apache.flink.agents.api.resource.ResourceDescriptor;
+import org.apache.flink.agents.api.resource.ResourceName;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.types.Row;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
+
+import static org.apache.flink.agents.api.agents.Agent.STRUCTURED_OUTPUT;
+
+/**
+ * An agent that demonstrates parallel LLM invocations via fan-out of multiple {@link
+ * ChatRequestEvent} events.
+ *
+ * <p>This agent receives a restaurant review and uses an LLM to judge sentiment along multiple
+ * dimensions (taste / service / price) in parallel, then aggregates the results into a one-line
+ * summary with a final LLM call. It handles prompt construction, parallel chat dispatch, response
+ * accumulation, and output assembly.
+ *
+ * <p><b>JDK version note:</b> On JDK 21+, the framework uses the Continuation API to execute
+ * concurrent chat actions in parallel, so the wall clock time is roughly "slowest single branch +
+ * aggregation call". On JDK &lt; 21, the framework silently falls back to sequential execution —
+ * the result is identical, but the LLM calls run one after another.
+ */
+public class ParallelChatAgent extends Agent {
+
+    /** Ollama model name, configurable via environment variable. */
+    public static final String OLLAMA_MODEL =
+            System.getenv().getOrDefault("PARALLEL_CHAT_OLLAMA_MODEL", "qwen3:1.7b");
+
+    /** Input text for the demo. */
+    public static final String INPUT_TEXT = "The food here is great, but the service is too slow";
+
+    private static final String[] ASPECTS = {"taste", "service", "price"};
+    private static final int N_ASPECTS = ASPECTS.length;
+
+    private static final String PARALLEL_SYSTEM_PROMPT =
+            "You are a sentiment analysis assistant. Return JSON: "
+                    + "{\"aspect\":\"<dimension>\", \"result\":\"<positive|negative|not_mentioned>\"}"
+                    + " — no explanation, no extra fields.";
+    private static final String AGGREGATE_SYSTEM_PROMPT =
+            "You are a summary assistant. Based on the sentiment judgments for three "
+                    + "dimensions, compose a brief one-line evaluation. Return JSON: "
+                    + "{\"summary\":\"taste:<positive/negative/not_mentioned>, "
+                    + "service:<positive/negative/not_mentioned>, "
+                    + "price:<positive/negative/not_mentioned>\"} — return only this JSON.";
+
+    /** LLM response for a single aspect judgment. */
+    public static class AspectResponse implements Serializable {
+        private static final long serialVersionUID = 1L;
+        public String aspect;
+        public String result;
+
+        public AspectResponse() {}
+
+        @Override
+        public String toString() {
+            return String.format("AspectResponse{aspect='%s', result='%s'}", aspect, result);
+        }
+    }
+
+    /** LLM response for the aggregation phase. */
+    public static class SummaryResponse implements Serializable {
+        private static final long serialVersionUID = 1L;
+        public String summary;
+
+        public SummaryResponse() {}
+
+        @Override
+        public String toString() {
+            return String.format("SummaryResponse{summary='%s'}", summary);
+        }
+    }
+
+    /** Single input record carrying an id and text. */
+    public static class SentimentRequest implements Serializable {
+        private static final long serialVersionUID = 1L;
+        public final int id;
+        public final String text;
+
+        public SentimentRequest(int id, String text) {
+            this.id = id;
+            this.text = text;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("SentimentRequest{id=%d, text='%s'}", id, text);
+        }
+    }
+
+    /** Key selector that extracts the id field from a {@link SentimentRequest}. */
+    public static class SentimentKeySelector implements KeySelector<SentimentRequest, Integer> {
+        @Override
+        public Integer getKey(SentimentRequest request) {
+            return request.id;
+        }
+    }
+
+    @ChatModelSetup
+    public static ResourceDescriptor sentimentModel() {
+        return ResourceDescriptor.Builder.newBuilder(ResourceName.ChatModel.OLLAMA_SETUP)
+                .addInitialArgument("connection", "ollamaChatModelConnection")
+                .addInitialArgument("model", OLLAMA_MODEL)
+                .addInitialArgument("extract_reasoning", true)
+                .build();
+    }
+
+    private static Map<String, Object> initRow(Event event) {
+        InputEvent inputEvent = InputEvent.fromEvent(event);
+        SentimentRequest request = (SentimentRequest) inputEvent.getInput();
+        Map<String, Object> row = new HashMap<>();
+        row.put("id", request.id);
+        row.put("text", request.text);
+        row.put("sentiments", new HashMap<String, String>());
+        return row;
+    }
+
+    private static void saveRow(RunnerContext ctx, Map<String, Object> row) throws Exception {
+        ctx.getSensoryMemory().set("res", row);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> loadRow(RunnerContext ctx) throws Exception {
+        return (Map<String, Object>) ctx.getSensoryMemory().get("res").getValue();
+    }
+
+    private static ChatRequestEvent buildAspectRequest(String text, String aspect) {
+        List<ChatMessage> messages =
+                List.of(
+                        new ChatMessage(MessageRole.SYSTEM, PARALLEL_SYSTEM_PROMPT),
+                        new ChatMessage(
+                                MessageRole.USER,
+                                "Judge the \"" + aspect + "\" dimension: " + text));
+        return new ChatRequestEvent("sentimentModel", messages, AspectResponse.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ChatRequestEvent buildSummarizeRequest(Map<String, Object> row) {
+        Map<String, String> sentiments = (Map<String, String>) row.get("sentiments");
+        StringJoiner sj = new StringJoiner(" ");
+        for (String aspect : ASPECTS) {
+            sj.add(aspect + ":" + sentiments.get(aspect));
+        }
+        String body = "Original: " + row.get("text") + "\nJudgments: " + sj;
+        List<ChatMessage> messages =
+                List.of(
+                        new ChatMessage(MessageRole.SYSTEM, AGGREGATE_SYSTEM_PROMPT),
+                        new ChatMessage(MessageRole.USER, body));
+        return new ChatRequestEvent("sentimentModel", messages, SummaryResponse.class);
+    }
+
+    private static OutputEvent buildOutputEvent(Map<String, Object> row, SummaryResponse parsed) {
+        Row output = Row.withNames();
+        output.setField("id", row.get("id"));
+        output.setField("text", row.get("text"));
+        output.setField("summary", parsed.summary);
+        return new OutputEvent(output);
+    }
+
+    private static Object parseResponse(Event event) {
+        ChatResponseEvent chatResponse = ChatResponseEvent.fromEvent(event);
+        ChatMessage response = chatResponse.getResponse();
+        return response.getExtraArgs().get(STRUCTURED_OUTPUT);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean allAspectsReceived(Map<String, Object> row) {
+        Map<String, String> sentiments = (Map<String, String>) row.get("sentiments");
+        return sentiments.size() == N_ASPECTS;
+    }
+
+    /** Process input event and fan-out chat requests for each aspect. */
+    @Action(listenEventTypes = {InputEvent.EVENT_TYPE})
+    public static void requestAspectJudgments(Event event, RunnerContext ctx) throws Exception {
+        Map<String, Object> row = initRow(event);
+        saveRow(ctx, row);
+        for (String aspect : ASPECTS) {
+            ctx.sendEvent(buildAspectRequest((String) row.get("text"), aspect));
+        }
+    }
+
+    /** Process chat response event. */
+    @SuppressWarnings("unchecked")
+    @Action(listenEventTypes = {ChatResponseEvent.EVENT_TYPE})
+    public static void handleResponse(Event event, RunnerContext ctx) throws Exception {
+        Object parsed = parseResponse(event);
+        Map<String, Object> row = loadRow(ctx);
+
+        if (parsed instanceof SummaryResponse) {
+            SummaryResponse summary = (SummaryResponse) parsed;
+            System.out.println(
+                    "FINAL summary="
+                            + summary.summary
+                            + " (t="
+                            + System.nanoTime() / 1_000_000_000.0
+                            + ")");
+            ctx.sendEvent(buildOutputEvent(row, summary));
+            return;
+        }
+
+        AspectResponse aspect = (AspectResponse) parsed;
+        System.out.println(
+                "ASPECT "
+                        + aspect.aspect
+                        + "="
+                        + aspect.result
+                        + " (t="
+                        + System.nanoTime() / 1_000_000_000.0
+                        + ")");
+        Map<String, String> sentiments = (Map<String, String>) row.get("sentiments");
+        sentiments.put(aspect.aspect, aspect.result);
+        saveRow(ctx, row);
+        if (allAspectsReceived(row)) {
+            ctx.sendEvent(buildSummarizeRequest(row));
+        }
+    }
+}

--- a/examples/src/main/java/org/apache/flink/agents/examples/agents/ParallelChatAgent.java
+++ b/examples/src/main/java/org/apache/flink/agents/examples/agents/ParallelChatAgent.java
@@ -76,6 +76,8 @@ public class ParallelChatAgent extends Agent {
 
     private static final String[] ASPECTS = {"taste", "service"};
 
+    private static final String SENTIMENT_INPUT_EVENT_TYPE = "SentimentInputEvent";
+
     private static final String PARALLEL_SYSTEM_PROMPT =
             "You are a sentiment analysis assistant. Return JSON: "
                     + "{\"aspect\":\"<dimension>\", \"result\":\"<positive|negative|not_mentioned>\"}"
@@ -85,19 +87,6 @@ public class ParallelChatAgent extends Agent {
                     + "dimensions, compose a brief one-line evaluation. Return JSON: "
                     + "{\"summary\":\"taste:<positive/negative/not_mentioned>, "
                     + "service:<positive/negative/not_mentioned>\"} — return only this JSON.";
-
-    /** Intermediate event that broadcasts the review input to all aspect handlers. */
-    public static class SentimentInputEvent extends Event {
-        public static final String EVENT_TYPE = "SentimentInputEvent";
-        public final int inputId;
-        public final String text;
-
-        public SentimentInputEvent(int inputId, String text) {
-            super(EVENT_TYPE);
-            this.inputId = inputId;
-            this.text = text;
-        }
-    }
 
     @ChatModelSetup
     public static ResourceDescriptor sentimentModel() {
@@ -151,23 +140,24 @@ public class ParallelChatAgent extends Agent {
                 (CustomTypesAndResources.SentimentRequest) inputEvent.getInput();
         ctx.getSensoryMemory().set("id", request.getId());
         ctx.getSensoryMemory().set("text", request.getText());
-        ctx.sendEvent(new SentimentInputEvent(request.getId(), request.getText()));
+        ctx.sendEvent(
+                new Event(
+                        SENTIMENT_INPUT_EVENT_TYPE,
+                        Map.of("input_id", request.getId(), "text", request.getText())));
     }
 
     /** Handle taste aspect: build and send ChatRequestEvent for taste judgment. */
-    @Action(listenEventTypes = {SentimentInputEvent.EVENT_TYPE})
+    @Action(listenEventTypes = {SENTIMENT_INPUT_EVENT_TYPE})
     public static void handleTasteInput(Event event, RunnerContext ctx) throws Exception {
-        SentimentInputEvent in = (SentimentInputEvent) event;
-        ChatRequestEvent req = buildAspectRequest(in.text, "taste");
+        ChatRequestEvent req = buildAspectRequest((String) event.getAttr("text"), "taste");
         ctx.getSensoryMemory().set("aspect_map." + req.getId(), "taste");
         ctx.sendEvent(req);
     }
 
     /** Handle service aspect: build and send ChatRequestEvent for service judgment. */
-    @Action(listenEventTypes = {SentimentInputEvent.EVENT_TYPE})
+    @Action(listenEventTypes = {SENTIMENT_INPUT_EVENT_TYPE})
     public static void handleServiceInput(Event event, RunnerContext ctx) throws Exception {
-        SentimentInputEvent in = (SentimentInputEvent) event;
-        ChatRequestEvent req = buildAspectRequest(in.text, "service");
+        ChatRequestEvent req = buildAspectRequest((String) event.getAttr("text"), "service");
         ctx.getSensoryMemory().set("aspect_map." + req.getId(), "service");
         ctx.sendEvent(req);
     }

--- a/python/flink_agents/examples/quickstart/agents/custom_types_and_resources.py
+++ b/python/flink_agents/examples/quickstart/agents/custom_types_and_resources.py
@@ -210,7 +210,6 @@ class SummaryResponse(BaseModel):
     summary: str
 
 
-
 # ollama chat model connection descriptor
 ollama_server_descriptor = ResourceDescriptor(
     clazz=ResourceName.ChatModel.OLLAMA_CONNECTION, request_timeout=120

--- a/python/flink_agents/examples/quickstart/agents/custom_types_and_resources.py
+++ b/python/flink_agents/examples/quickstart/agents/custom_types_and_resources.py
@@ -196,6 +196,21 @@ class ProductReviewAnalysisRes(BaseModel):
     reasons: list[str]
 
 
+# Custom types for parallel chat agent.
+class AspectResponse(BaseModel):
+    """LLM response for a single aspect judgment."""
+
+    aspect: str
+    result: str
+
+
+class SummaryResponse(BaseModel):
+    """LLM response for the aggregation phase."""
+
+    summary: str
+
+
+
 # ollama chat model connection descriptor
 ollama_server_descriptor = ResourceDescriptor(
     clazz=ResourceName.ChatModel.OLLAMA_CONNECTION, request_timeout=120

--- a/python/flink_agents/examples/quickstart/agents/parallel_chat_agent.py
+++ b/python/flink_agents/examples/quickstart/agents/parallel_chat_agent.py
@@ -1,0 +1,196 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+import json
+import os
+import time
+from typing import Any, Dict, Tuple
+
+from pydantic import BaseModel
+from pyflink.common import Row
+from pyflink.datastream import KeySelector
+
+from flink_agents.api.agents.agent import STRUCTURED_OUTPUT, Agent
+from flink_agents.api.agents.types import OutputSchema
+from flink_agents.api.chat_message import ChatMessage, MessageRole
+from flink_agents.api.decorators import action, chat_model_setup
+from flink_agents.api.events.chat_event import ChatRequestEvent, ChatResponseEvent
+from flink_agents.api.events.event import Event, InputEvent, OutputEvent
+from flink_agents.api.resource import ResourceDescriptor, ResourceName
+from flink_agents.api.runner_context import RunnerContext
+
+OLLAMA_MODEL = os.environ.get("PARALLEL_CHAT_OLLAMA_MODEL", "qwen3:1.7b")
+
+INPUT_TEXT = "The food here is great, but the service is too slow"
+ASPECTS: Tuple[str, ...] = ("taste", "service", "price")
+N_ASPECTS = len(ASPECTS)
+
+PARALLEL_SYSTEM_PROMPT = (
+    "You are a sentiment analysis assistant. Return JSON: "
+    '{"aspect":"<dimension>", "result":"<positive|negative|not_mentioned>"}'
+    " — no explanation, no extra fields."
+)
+AGGREGATE_SYSTEM_PROMPT = (
+    "You are a summary assistant. Based on the sentiment judgments for three "
+    "dimensions, compose a brief one-line evaluation. Return JSON: "
+    '{"summary":"taste: service: price:"} — return only this JSON.'
+)
+
+
+class AspectResponse(BaseModel):
+    """LLM response for a single aspect judgment."""
+
+    aspect: str
+    result: str
+
+
+class SummaryResponse(BaseModel):
+    """LLM response for the aggregation phase."""
+
+    summary: str
+
+
+class ParallelChatKeySelector(KeySelector):
+    """Key selector that extracts the id field from the input row."""
+
+    def get_key(self, value: Row) -> int:
+        """Extract key from row."""
+        return value[0]
+
+
+def _init_row(event: Event) -> Dict[str, Any]:
+    """Build a row skeleton from the InputEvent."""
+    payload = InputEvent.from_event(event).input
+    return {"id": payload["id"], "text": payload["text"], "sentiments": {}}
+
+
+def _save_row(ctx: RunnerContext, row: Dict[str, Any]) -> None:
+    """Write the row to sensory memory."""
+    ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
+
+
+def _load_row(ctx: RunnerContext) -> Dict[str, Any]:
+    """Read the row from sensory memory."""
+    return json.loads(ctx.sensory_memory.get("res"))
+
+
+def _build_aspect_request(text: str, aspect: str) -> ChatRequestEvent:
+    """Build a ChatRequestEvent for a single aspect dimension."""
+    return ChatRequestEvent(
+        model="sentiment_model",
+        messages=[
+            ChatMessage(role=MessageRole.SYSTEM, content=PARALLEL_SYSTEM_PROMPT),
+            ChatMessage(
+                role=MessageRole.USER,
+                content=f'Judge the "{aspect}" dimension: {text}',
+            ),
+        ],
+        output_schema=OutputSchema(output_schema=AspectResponse),
+    )
+
+
+def _build_summarize_request(row: Dict[str, Any]) -> ChatRequestEvent:
+    """Build a ChatRequestEvent for the aggregation phase."""
+    sentiments = row["sentiments"]
+    body = (
+        f"Original: {row['text']}\n"
+        + "Judgments: "
+        + " ".join(f"{a}:{sentiments[a]}" for a in ASPECTS)
+    )
+    return ChatRequestEvent(
+        model="sentiment_model",
+        messages=[
+            ChatMessage(role=MessageRole.SYSTEM, content=AGGREGATE_SYSTEM_PROMPT),
+            ChatMessage(role=MessageRole.USER, content=body),
+        ],
+        output_schema=OutputSchema(output_schema=SummaryResponse),
+    )
+
+
+def _build_output_event(row: Dict[str, Any], parsed: SummaryResponse) -> OutputEvent:
+    """Pack row fields and summary into the final OutputEvent."""
+    return OutputEvent(
+        output=Row(id=row["id"], text=row["text"], summary=parsed.summary)
+    )
+
+
+def _parse_response(event: Event) -> AspectResponse | SummaryResponse:
+    """Parse a ChatResponseEvent into a structured response object."""
+    response = ChatResponseEvent.from_event(event).response
+    raw = response.extra_args[STRUCTURED_OUTPUT]
+    if isinstance(raw, BaseModel):
+        return raw
+    if "summary" in raw:
+        return SummaryResponse.model_validate(raw)
+    return AspectResponse.model_validate(raw)
+
+
+def _is_final(parsed: AspectResponse | SummaryResponse) -> bool:
+    """Return True if the parsed response is from the aggregation phase."""
+    return isinstance(parsed, SummaryResponse)
+
+
+def _all_aspects_received(row: Dict[str, Any]) -> bool:
+    """Return True if all aspect judgments have been collected."""
+    return len(row["sentiments"]) == N_ASPECTS
+
+
+class ParallelChatAgent(Agent):
+    """An agent that demonstrates parallel LLM invocations via fan-out of
+    multiple ChatRequestEvent events.
+
+    This agent receives a restaurant review and uses an LLM to judge sentiment
+    along multiple dimensions in parallel, then aggregates the results into a
+    one-line summary with a final LLM call. It handles prompt construction,
+    parallel chat dispatch, response accumulation, and output assembly.
+    """
+
+    @chat_model_setup
+    @staticmethod
+    def sentiment_model() -> ResourceDescriptor:
+        """ChatModel for sentiment analysis."""
+        return ResourceDescriptor(
+            clazz=ResourceName.ChatModel.OLLAMA_SETUP,
+            connection="ollama_server",
+            model=OLLAMA_MODEL,
+            extract_reasoning=True,
+        )
+
+    @action(InputEvent.EVENT_TYPE)
+    @staticmethod
+    def request_aspect_judgments(event: Event, ctx: RunnerContext) -> None:
+        """Process input event and send chat requests for each aspect."""
+        row = _init_row(event)
+        _save_row(ctx, row)
+        for aspect in ASPECTS:
+            ctx.send_event(_build_aspect_request(row["text"], aspect))
+
+    @action(ChatResponseEvent.EVENT_TYPE)
+    @staticmethod
+    def handle_response(event: Event, ctx: RunnerContext) -> None:
+        """Process chat response event and send output event."""
+        parsed = _parse_response(event)
+        row = _load_row(ctx)
+        if _is_final(parsed):
+            print(f"FINAL summary={parsed.summary} (t={time.monotonic():.3f})")
+            ctx.send_event(_build_output_event(row, parsed))
+            return
+        print(f"ASPECT {parsed.aspect}={parsed.result} (t={time.monotonic():.3f})")
+        row["sentiments"][parsed.aspect] = parsed.result
+        _save_row(ctx, row)
+        if _all_aspects_received(row):
+            ctx.send_event(_build_summarize_request(row))

--- a/python/flink_agents/examples/quickstart/agents/parallel_chat_agent.py
+++ b/python/flink_agents/examples/quickstart/agents/parallel_chat_agent.py
@@ -17,12 +17,9 @@
 #################################################################################
 import json
 import os
-import time
 from typing import Any, Dict, Tuple
 
 from pydantic import BaseModel
-from pyflink.common import Row
-from pyflink.datastream import KeySelector
 
 from flink_agents.api.agents.agent import STRUCTURED_OUTPUT, Agent
 from flink_agents.api.agents.types import OutputSchema
@@ -32,6 +29,10 @@ from flink_agents.api.events.chat_event import ChatRequestEvent, ChatResponseEve
 from flink_agents.api.events.event import Event, InputEvent, OutputEvent
 from flink_agents.api.resource import ResourceDescriptor, ResourceName
 from flink_agents.api.runner_context import RunnerContext
+from flink_agents.examples.quickstart.agents.custom_types_and_resources import (
+    AspectResponse,
+    SummaryResponse,
+)
 
 OLLAMA_MODEL = os.environ.get("PARALLEL_CHAT_OLLAMA_MODEL", "qwen3:1.7b")
 
@@ -49,27 +50,6 @@ AGGREGATE_SYSTEM_PROMPT = (
     "dimensions, compose a brief one-line evaluation. Return JSON: "
     '{"summary":"taste: service: price:"} — return only this JSON.'
 )
-
-
-class AspectResponse(BaseModel):
-    """LLM response for a single aspect judgment."""
-
-    aspect: str
-    result: str
-
-
-class SummaryResponse(BaseModel):
-    """LLM response for the aggregation phase."""
-
-    summary: str
-
-
-class ParallelChatKeySelector(KeySelector):
-    """Key selector that extracts the id field from the input row."""
-
-    def get_key(self, value: Row) -> int:
-        """Extract key from row."""
-        return value[0]
 
 
 def _init_row(event: Event) -> Dict[str, Any]:
@@ -124,7 +104,7 @@ def _build_summarize_request(row: Dict[str, Any]) -> ChatRequestEvent:
 def _build_output_event(row: Dict[str, Any], parsed: SummaryResponse) -> OutputEvent:
     """Pack row fields and summary into the final OutputEvent."""
     return OutputEvent(
-        output=Row(id=row["id"], text=row["text"], summary=parsed.summary)
+        output={"id": row["id"], "text": row["text"], "summary": parsed.summary}
     )
 
 
@@ -186,10 +166,8 @@ class ParallelChatAgent(Agent):
         parsed = _parse_response(event)
         row = _load_row(ctx)
         if _is_final(parsed):
-            print(f"FINAL summary={parsed.summary} (t={time.monotonic():.3f})")
             ctx.send_event(_build_output_event(row, parsed))
             return
-        print(f"ASPECT {parsed.aspect}={parsed.result} (t={time.monotonic():.3f})")
         row["sentiments"][parsed.aspect] = parsed.result
         _save_row(ctx, row)
         if _all_aspects_received(row):

--- a/python/flink_agents/examples/quickstart/agents/parallel_chat_agent.py
+++ b/python/flink_agents/examples/quickstart/agents/parallel_chat_agent.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 #################################################################################
 import os
-from typing import ClassVar, Dict
+from typing import Dict
 
 from flink_agents.api.agents.agent import STRUCTURED_OUTPUT, Agent
 from flink_agents.api.agents.types import OutputSchema
@@ -34,6 +34,7 @@ from flink_agents.examples.quickstart.agents.custom_types_and_resources import (
 OLLAMA_MODEL = os.environ.get("PARALLEL_CHAT_OLLAMA_MODEL", "qwen3:1.7b")
 
 INPUT_TEXT = "The food here is great, but the service is too slow"
+SENTIMENT_INPUT_EVENT_TYPE = "SentimentInputEvent"
 ASPECTS: tuple = ("taste", "service")
 N_ASPECTS = len(ASPECTS)
 
@@ -48,19 +49,6 @@ AGGREGATE_SYSTEM_PROMPT = (
     '{"summary":"taste:<positive/negative/not_mentioned>, '
     'service:<positive/negative/not_mentioned>"} — return only this JSON.'
 )
-
-
-class SentimentInputEvent(Event):
-    """Intermediate event that broadcasts the review input to all aspect handlers."""
-
-    EVENT_TYPE: ClassVar[str] = "SentimentInputEvent"
-
-    def __init__(self, input_id: int, text: str) -> None:
-        """Initialize with the review id and text."""
-        super().__init__(
-            type=SentimentInputEvent.EVENT_TYPE,
-            attributes={"input_id": input_id, "text": text},
-        )
 
 
 def _build_aspect_request(text: str, aspect: str) -> ChatRequestEvent:
@@ -137,9 +125,14 @@ class ParallelChatAgent(Agent):
         # Primitive types (int, str) cross the Pemja JVM boundary without serialization.
         ctx.sensory_memory.set("id", payload["id"])
         ctx.sensory_memory.set("text", payload["text"])
-        ctx.send_event(SentimentInputEvent(input_id=payload["id"], text=payload["text"]))
+        ctx.send_event(
+            Event(
+                type=SENTIMENT_INPUT_EVENT_TYPE,
+                attributes={"input_id": payload["id"], "text": payload["text"]},
+            )
+        )
 
-    @action(SentimentInputEvent.EVENT_TYPE)
+    @action(SENTIMENT_INPUT_EVENT_TYPE)
     @staticmethod
     def handle_taste_input(event: Event, ctx: RunnerContext) -> None:
         """Handle taste aspect: build and send ChatRequestEvent for taste judgment."""
@@ -147,7 +140,7 @@ class ParallelChatAgent(Agent):
         ctx.sensory_memory.set(f"aspect_map.{req.id}", "taste")
         ctx.send_event(req)
 
-    @action(SentimentInputEvent.EVENT_TYPE)
+    @action(SENTIMENT_INPUT_EVENT_TYPE)
     @staticmethod
     def handle_service_input(event: Event, ctx: RunnerContext) -> None:
         """Handle service aspect: build and send ChatRequestEvent for service."""

--- a/python/flink_agents/examples/quickstart/agents/parallel_chat_agent.py
+++ b/python/flink_agents/examples/quickstart/agents/parallel_chat_agent.py
@@ -15,9 +15,8 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 #################################################################################
-import json
 import os
-from typing import Any, ClassVar, Dict, Tuple
+from typing import ClassVar, Dict
 
 from flink_agents.api.agents.agent import STRUCTURED_OUTPUT, Agent
 from flink_agents.api.agents.types import OutputSchema
@@ -35,7 +34,7 @@ from flink_agents.examples.quickstart.agents.custom_types_and_resources import (
 OLLAMA_MODEL = os.environ.get("PARALLEL_CHAT_OLLAMA_MODEL", "qwen3:1.7b")
 
 INPUT_TEXT = "The food here is great, but the service is too slow"
-ASPECTS: Tuple[str, ...] = ("taste", "service")
+ASPECTS: tuple = ("taste", "service")
 N_ASPECTS = len(ASPECTS)
 
 PARALLEL_SYSTEM_PROMPT = (
@@ -52,24 +51,16 @@ AGGREGATE_SYSTEM_PROMPT = (
 
 
 class SentimentInputEvent(Event):
+    """Intermediate event that broadcasts the review input to all aspect handlers."""
+
     EVENT_TYPE: ClassVar[str] = "SentimentInputEvent"
 
     def __init__(self, input_id: int, text: str) -> None:
+        """Initialize with the review id and text."""
         super().__init__(
             type=SentimentInputEvent.EVENT_TYPE,
             attributes={"input_id": input_id, "text": text},
         )
-
-
-def _init_row(event: Event) -> Dict[str, Any]:
-    """Build a row skeleton from the InputEvent."""
-    payload = InputEvent.from_event(event).input
-    return {
-        "id": payload["id"],
-        "text": payload["text"],
-        "sentiments": {},
-        "aspect_map": {},
-    }
 
 
 def _build_aspect_request(text: str, aspect: str) -> ChatRequestEvent:
@@ -87,11 +78,10 @@ def _build_aspect_request(text: str, aspect: str) -> ChatRequestEvent:
     )
 
 
-def _build_summarize_request(row: Dict[str, Any]) -> ChatRequestEvent:
+def _build_summarize_request(text: str, sentiments: Dict[str, str]) -> ChatRequestEvent:
     """Build a ChatRequestEvent for the aggregation phase."""
-    sentiments = row["sentiments"]
     body = (
-        f"Original: {row['text']}\n"
+        f"Original: {text}\n"
         + "Judgments: "
         + " ".join(f"{a}:{sentiments[a]}" for a in ASPECTS)
     )
@@ -105,14 +95,9 @@ def _build_summarize_request(row: Dict[str, Any]) -> ChatRequestEvent:
     )
 
 
-def _build_output_event(row: Dict[str, Any], parsed: SummaryResponse) -> OutputEvent:
+def _build_output_event(row_id: int, text: str, parsed: SummaryResponse) -> OutputEvent:
     """Build the final OutputEvent from the aggregated row."""
-    return OutputEvent(output={"id": row["id"], "text": row["text"], "summary": parsed.summary})
-
-
-def _all_aspects_received(row: Dict[str, Any]) -> bool:
-    """Return True when all aspect judgments have been collected."""
-    return len(row["sentiments"]) == N_ASPECTS
+    return OutputEvent(output={"id": row_id, "text": text, "summary": parsed.summary})
 
 
 class ParallelChatAgent(Agent):
@@ -147,32 +132,27 @@ class ParallelChatAgent(Agent):
     @action(InputEvent.EVENT_TYPE)
     @staticmethod
     def request_aspect_judgments(event: Event, ctx: RunnerContext) -> None:
-        """Process input event and dispatch a SentimentInputEvent for each aspect handler."""
-        row = _init_row(event)
-        # Sensory memory requires JSON serialization across the Pemja JVM boundary.
-        ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
-        ctx.send_event(SentimentInputEvent(input_id=row["id"], text=row["text"]))
+        """Process input event and dispatch SentimentInputEvent to aspect handlers."""
+        payload = InputEvent.from_event(event).input
+        # Primitive types (int, str) cross the Pemja JVM boundary without serialization.
+        ctx.sensory_memory.set("id", payload["id"])
+        ctx.sensory_memory.set("text", payload["text"])
+        ctx.send_event(SentimentInputEvent(input_id=payload["id"], text=payload["text"]))
 
     @action(SentimentInputEvent.EVENT_TYPE)
     @staticmethod
     def handle_taste_input(event: Event, ctx: RunnerContext) -> None:
         """Handle taste aspect: build and send ChatRequestEvent for taste judgment."""
-        row = json.loads(ctx.sensory_memory.get("res"))
         req = _build_aspect_request(event.get_attr("text"), "taste")
-        row["aspect_map"][str(req.id)] = "taste"
-        # Sensory memory requires JSON serialization across the Pemja JVM boundary.
-        ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
+        ctx.sensory_memory.set(f"aspect_map.{req.id}", "taste")
         ctx.send_event(req)
 
     @action(SentimentInputEvent.EVENT_TYPE)
     @staticmethod
     def handle_service_input(event: Event, ctx: RunnerContext) -> None:
-        """Handle service aspect: build and send ChatRequestEvent for service judgment."""
-        row = json.loads(ctx.sensory_memory.get("res"))
+        """Handle service aspect: build and send ChatRequestEvent for service."""
         req = _build_aspect_request(event.get_attr("text"), "service")
-        row["aspect_map"][str(req.id)] = "service"
-        # Sensory memory requires JSON serialization across the Pemja JVM boundary.
-        ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
+        ctx.sensory_memory.set(f"aspect_map.{req.id}", "service")
         ctx.send_event(req)
 
     @action(ChatResponseEvent.EVENT_TYPE)
@@ -181,15 +161,20 @@ class ParallelChatAgent(Agent):
         """Process chat response event and send output event."""
         response_event = ChatResponseEvent.from_event(event)
         parsed = response_event.response.extra_args[STRUCTURED_OUTPUT]
-        row = json.loads(ctx.sensory_memory.get("res"))
         if isinstance(parsed, dict):
             parsed = SummaryResponse(**parsed) if "summary" in parsed else AspectResponse(**parsed)
         if isinstance(parsed, SummaryResponse):
-            ctx.send_event(_build_output_event(row, parsed))
+            ctx.send_event(
+                _build_output_event(
+                    ctx.sensory_memory.get("id"),
+                    ctx.sensory_memory.get("text"),
+                    parsed,
+                )
+            )
             return
-        aspect = row["aspect_map"][str(response_event.request_id)]
-        row["sentiments"][aspect] = parsed.result
-        # Sensory memory requires JSON serialization across the Pemja JVM boundary.
-        ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
-        if _all_aspects_received(row):
-            ctx.send_event(_build_summarize_request(row))
+        aspect = ctx.sensory_memory.get(f"aspect_map.{response_event.request_id}")
+        ctx.sensory_memory.set(f"sentiments.{aspect}", parsed.result)
+        if all(ctx.sensory_memory.is_exist(f"sentiments.{a}") for a in ASPECTS):
+            text = ctx.sensory_memory.get("text")
+            sentiments = {a: ctx.sensory_memory.get(f"sentiments.{a}") for a in ASPECTS}
+            ctx.send_event(_build_summarize_request(text, sentiments))

--- a/python/flink_agents/examples/quickstart/agents/parallel_chat_agent.py
+++ b/python/flink_agents/examples/quickstart/agents/parallel_chat_agent.py
@@ -19,8 +19,6 @@ import json
 import os
 from typing import Any, Dict, Tuple
 
-from pydantic import BaseModel
-
 from flink_agents.api.agents.agent import STRUCTURED_OUTPUT, Agent
 from flink_agents.api.agents.types import OutputSchema
 from flink_agents.api.chat_message import ChatMessage, MessageRole
@@ -48,24 +46,21 @@ PARALLEL_SYSTEM_PROMPT = (
 AGGREGATE_SYSTEM_PROMPT = (
     "You are a summary assistant. Based on the sentiment judgments for three "
     "dimensions, compose a brief one-line evaluation. Return JSON: "
-    '{"summary":"taste: service: price:"} — return only this JSON.'
+    '{"summary":"taste:<positive/negative/not_mentioned>, '
+    "service:<positive/negative/not_mentioned>, "
+    'price:<positive/negative/not_mentioned>"} — return only this JSON.'
 )
 
 
 def _init_row(event: Event) -> Dict[str, Any]:
     """Build a row skeleton from the InputEvent."""
     payload = InputEvent.from_event(event).input
-    return {"id": payload["id"], "text": payload["text"], "sentiments": {}}
-
-
-def _save_row(ctx: RunnerContext, row: Dict[str, Any]) -> None:
-    """Write the row to sensory memory."""
-    ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
-
-
-def _load_row(ctx: RunnerContext) -> Dict[str, Any]:
-    """Read the row from sensory memory."""
-    return json.loads(ctx.sensory_memory.get("res"))
+    return {
+        "id": payload["id"],
+        "text": payload["text"],
+        "sentiments": {},
+        "aspect_map": {},
+    }
 
 
 def _build_aspect_request(text: str, aspect: str) -> ChatRequestEvent:
@@ -102,30 +97,12 @@ def _build_summarize_request(row: Dict[str, Any]) -> ChatRequestEvent:
 
 
 def _build_output_event(row: Dict[str, Any], parsed: SummaryResponse) -> OutputEvent:
-    """Pack row fields and summary into the final OutputEvent."""
-    return OutputEvent(
-        output={"id": row["id"], "text": row["text"], "summary": parsed.summary}
-    )
-
-
-def _parse_response(event: Event) -> AspectResponse | SummaryResponse:
-    """Parse a ChatResponseEvent into a structured response object."""
-    response = ChatResponseEvent.from_event(event).response
-    raw = response.extra_args[STRUCTURED_OUTPUT]
-    if isinstance(raw, BaseModel):
-        return raw
-    if "summary" in raw:
-        return SummaryResponse.model_validate(raw)
-    return AspectResponse.model_validate(raw)
-
-
-def _is_final(parsed: AspectResponse | SummaryResponse) -> bool:
-    """Return True if the parsed response is from the aggregation phase."""
-    return isinstance(parsed, SummaryResponse)
+    """Build the final OutputEvent from the aggregated row."""
+    return OutputEvent(output={"id": row["id"], "text": row["text"], "summary": parsed.summary})
 
 
 def _all_aspects_received(row: Dict[str, Any]) -> bool:
-    """Return True if all aspect judgments have been collected."""
+    """Return True when all aspect judgments have been collected."""
     return len(row["sentiments"]) == N_ASPECTS
 
 
@@ -155,20 +132,31 @@ class ParallelChatAgent(Agent):
     def request_aspect_judgments(event: Event, ctx: RunnerContext) -> None:
         """Process input event and send chat requests for each aspect."""
         row = _init_row(event)
-        _save_row(ctx, row)
-        for aspect in ASPECTS:
-            ctx.send_event(_build_aspect_request(row["text"], aspect))
+        requests = [_build_aspect_request(row["text"], aspect) for aspect in ASPECTS]
+        row["aspect_map"] = {
+            str(req.id): aspect for req, aspect in zip(requests, ASPECTS, strict=True)
+        }
+        # Sensory memory requires JSON serialization across the Pemja JVM boundary.
+        ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
+        for req in requests:
+            ctx.send_event(req)
 
     @action(ChatResponseEvent.EVENT_TYPE)
     @staticmethod
     def handle_response(event: Event, ctx: RunnerContext) -> None:
         """Process chat response event and send output event."""
-        parsed = _parse_response(event)
-        row = _load_row(ctx)
-        if _is_final(parsed):
+        response_event = ChatResponseEvent.from_event(event)
+        parsed = response_event.response.extra_args[STRUCTURED_OUTPUT]
+        row = json.loads(ctx.sensory_memory.get("res"))
+        # Pemja JVM boundary serializes pydantic instances to dicts; restore the type.
+        if isinstance(parsed, dict):
+            parsed = SummaryResponse(**parsed) if "summary" in parsed else AspectResponse(**parsed)
+        if isinstance(parsed, SummaryResponse):
             ctx.send_event(_build_output_event(row, parsed))
             return
-        row["sentiments"][parsed.aspect] = parsed.result
-        _save_row(ctx, row)
+        aspect = row["aspect_map"][str(response_event.request_id)]
+        row["sentiments"][aspect] = parsed.result
+        # Sensory memory requires JSON serialization across the Pemja JVM boundary.
+        ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
         if _all_aspects_received(row):
             ctx.send_event(_build_summarize_request(row))

--- a/python/flink_agents/examples/quickstart/agents/parallel_chat_agent.py
+++ b/python/flink_agents/examples/quickstart/agents/parallel_chat_agent.py
@@ -148,7 +148,6 @@ class ParallelChatAgent(Agent):
         response_event = ChatResponseEvent.from_event(event)
         parsed = response_event.response.extra_args[STRUCTURED_OUTPUT]
         row = json.loads(ctx.sensory_memory.get("res"))
-        # Pemja JVM boundary serializes pydantic instances to dicts; restore the type.
         if isinstance(parsed, dict):
             parsed = SummaryResponse(**parsed) if "summary" in parsed else AspectResponse(**parsed)
         if isinstance(parsed, SummaryResponse):

--- a/python/flink_agents/examples/quickstart/agents/parallel_chat_agent.py
+++ b/python/flink_agents/examples/quickstart/agents/parallel_chat_agent.py
@@ -17,7 +17,7 @@
 #################################################################################
 import json
 import os
-from typing import Any, Dict, Tuple
+from typing import Any, ClassVar, Dict, Tuple
 
 from flink_agents.api.agents.agent import STRUCTURED_OUTPUT, Agent
 from flink_agents.api.agents.types import OutputSchema
@@ -35,7 +35,7 @@ from flink_agents.examples.quickstart.agents.custom_types_and_resources import (
 OLLAMA_MODEL = os.environ.get("PARALLEL_CHAT_OLLAMA_MODEL", "qwen3:1.7b")
 
 INPUT_TEXT = "The food here is great, but the service is too slow"
-ASPECTS: Tuple[str, ...] = ("taste", "service", "price")
+ASPECTS: Tuple[str, ...] = ("taste", "service")
 N_ASPECTS = len(ASPECTS)
 
 PARALLEL_SYSTEM_PROMPT = (
@@ -44,12 +44,21 @@ PARALLEL_SYSTEM_PROMPT = (
     " — no explanation, no extra fields."
 )
 AGGREGATE_SYSTEM_PROMPT = (
-    "You are a summary assistant. Based on the sentiment judgments for three "
+    "You are a summary assistant. Based on the sentiment judgments for two "
     "dimensions, compose a brief one-line evaluation. Return JSON: "
     '{"summary":"taste:<positive/negative/not_mentioned>, '
-    "service:<positive/negative/not_mentioned>, "
-    'price:<positive/negative/not_mentioned>"} — return only this JSON.'
+    'service:<positive/negative/not_mentioned>"} — return only this JSON.'
 )
+
+
+class SentimentInputEvent(Event):
+    EVENT_TYPE: ClassVar[str] = "SentimentInputEvent"
+
+    def __init__(self, input_id: int, text: str) -> None:
+        super().__init__(
+            type=SentimentInputEvent.EVENT_TYPE,
+            attributes={"input_id": input_id, "text": text},
+        )
 
 
 def _init_row(event: Event) -> Dict[str, Any]:
@@ -114,6 +123,14 @@ class ParallelChatAgent(Agent):
     along multiple dimensions in parallel, then aggregates the results into a
     one-line summary with a final LLM call. It handles prompt construction,
     parallel chat dispatch, response accumulation, and output assembly.
+
+    Event flow:
+      1. InputEvent → request_aspect_judgments → emits SentimentInputEvent
+      2. SentimentInputEvent triggers handlers in parallel:
+           - handle_taste_input   → ChatRequestEvent (taste LLM call)
+           - handle_service_input → ChatRequestEvent (service LLM call)
+      3. Each ChatResponseEvent → handle_response (accumulates aspect results)
+      4. Once all aspects received → aggregation LLM call → OutputEvent
     """
 
     @chat_model_setup
@@ -130,16 +147,33 @@ class ParallelChatAgent(Agent):
     @action(InputEvent.EVENT_TYPE)
     @staticmethod
     def request_aspect_judgments(event: Event, ctx: RunnerContext) -> None:
-        """Process input event and send chat requests for each aspect."""
+        """Process input event and dispatch a SentimentInputEvent for each aspect handler."""
         row = _init_row(event)
-        requests = [_build_aspect_request(row["text"], aspect) for aspect in ASPECTS]
-        row["aspect_map"] = {
-            str(req.id): aspect for req, aspect in zip(requests, ASPECTS, strict=True)
-        }
         # Sensory memory requires JSON serialization across the Pemja JVM boundary.
         ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
-        for req in requests:
-            ctx.send_event(req)
+        ctx.send_event(SentimentInputEvent(input_id=row["id"], text=row["text"]))
+
+    @action(SentimentInputEvent.EVENT_TYPE)
+    @staticmethod
+    def handle_taste_input(event: Event, ctx: RunnerContext) -> None:
+        """Handle taste aspect: build and send ChatRequestEvent for taste judgment."""
+        row = json.loads(ctx.sensory_memory.get("res"))
+        req = _build_aspect_request(event.get_attr("text"), "taste")
+        row["aspect_map"][str(req.id)] = "taste"
+        # Sensory memory requires JSON serialization across the Pemja JVM boundary.
+        ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
+        ctx.send_event(req)
+
+    @action(SentimentInputEvent.EVENT_TYPE)
+    @staticmethod
+    def handle_service_input(event: Event, ctx: RunnerContext) -> None:
+        """Handle service aspect: build and send ChatRequestEvent for service judgment."""
+        row = json.loads(ctx.sensory_memory.get("res"))
+        req = _build_aspect_request(event.get_attr("text"), "service")
+        row["aspect_map"][str(req.id)] = "service"
+        # Sensory memory requires JSON serialization across the Pemja JVM boundary.
+        ctx.sensory_memory.set("res", json.dumps(row, ensure_ascii=False))
+        ctx.send_event(req)
 
     @action(ChatResponseEvent.EVENT_TYPE)
     @staticmethod

--- a/python/flink_agents/examples/quickstart/parallel_chat_request_example.py
+++ b/python/flink_agents/examples/quickstart/parallel_chat_request_example.py
@@ -15,24 +15,13 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 #################################################################################
-import json
-import os
-import sysconfig
-import time
-from pathlib import Path
-
-from pyflink.common.typeinfo import BasicTypeInfo, ExternalTypeInfo, RowTypeInfo
 from pyflink.datastream import StreamExecutionEnvironment
-from pyflink.table import DataTypes, Schema, StreamTableEnvironment, TableDescriptor
 
 from flink_agents.api.execution_environment import AgentsExecutionEnvironment
 from flink_agents.api.resource import ResourceDescriptor, ResourceName, ResourceType
 from flink_agents.examples.quickstart.agents.parallel_chat_agent import (
     INPUT_TEXT,
-    N_ASPECTS,
-    OLLAMA_MODEL,
     ParallelChatAgent,
-    ParallelChatKeySelector,
 )
 
 
@@ -46,12 +35,9 @@ def main() -> None:
     with Flink streaming jobs.
     """
     # Set up the Flink streaming environment and the Agents execution environment.
-    stream_env = StreamExecutionEnvironment.get_execution_environment()
-    stream_env.set_parallelism(1)
-    t_env = StreamTableEnvironment.create(stream_execution_environment=stream_env)
-    agents_env = AgentsExecutionEnvironment.get_execution_environment(
-        env=stream_env, t_env=t_env
-    )
+    env = StreamExecutionEnvironment.get_execution_environment()
+    env.set_parallelism(1)
+    agents_env = AgentsExecutionEnvironment.get_execution_environment(env)
 
     # Add Ollama chat model connection to be used by the ParallelChatAgent.
     agents_env.add_resource(
@@ -63,73 +49,25 @@ def main() -> None:
         ),
     )
 
-    # Create input table with a single restaurant review.
-    input_table = t_env.from_elements(
-        elements=[(1, INPUT_TEXT)],
-        schema=DataTypes.ROW(
-            [
-                DataTypes.FIELD("id", DataTypes.INT()),
-                DataTypes.FIELD("text", DataTypes.STRING()),
-            ]
-        ),
-    )
-
-    # Define output schema and type info.
-    output_type_info = RowTypeInfo(
-        [
-            BasicTypeInfo.INT_TYPE_INFO(),
-            BasicTypeInfo.STRING_TYPE_INFO(),
-            BasicTypeInfo.STRING_TYPE_INFO(),
-        ],
-        ["id", "text", "summary"],
-    )
-    output_type = ExternalTypeInfo(output_type_info)
-    output_schema = (
-        Schema.new_builder()
-        .column("id", DataTypes.INT())
-        .column("text", DataTypes.STRING())
-        .column("summary", DataTypes.STRING())
-        .build()
-    )
-
-    # Register a filesystem sink for collecting results.
-    result_dir = Path("/tmp/parallel_chat_results")
-    result_dir.mkdir(parents=True, exist_ok=True)
-
-    t_env.create_temporary_table(
-        "sink",
-        TableDescriptor.for_connector("filesystem")
-        .option("path", str(result_dir.absolute()))
-        .format("json")
-        .schema(output_schema)
-        .build(),
+    # Create input stream with a single restaurant review.
+    input_stream = env.from_collection(
+        collection=[{"id": 1, "text": INPUT_TEXT}],
     )
 
     # Use the ParallelChatAgent to analyze the review with parallel LLM calls.
-    output_table = (
-        agents_env.from_table(input=input_table, key_selector=ParallelChatKeySelector())
+    output_stream = (
+        agents_env.from_datastream(
+            input=input_stream, key_selector=lambda x: x["id"]
+        )
         .apply(ParallelChatAgent())
-        .to_table(schema=output_schema, output_type=output_type)
+        .to_datastream()
     )
 
-    # Execute the Flink pipeline.
-    wall_start = time.monotonic()
-    output_table.execute_insert("sink").wait()
-    wall_elapsed = time.monotonic() - wall_start
-
     # Print the analysis results to stdout.
-    rows = []
-    for file in result_dir.iterdir():
-        if file.is_file():
-            with file.open() as f:
-                for line in f:
-                    line = line.strip()
-                    if line:
-                        rows.append(json.loads(line))
+    output_stream.print()
 
-    print(f"OUTPUT rows: {rows}")
-    print(f"End-to-end wall time: {wall_elapsed:.2f}s")
-    print("=== Done ===")
+    # Execute the Flink pipeline.
+    agents_env.execute()
 
 
 if __name__ == "__main__":

--- a/python/flink_agents/examples/quickstart/parallel_chat_request_example.py
+++ b/python/flink_agents/examples/quickstart/parallel_chat_request_example.py
@@ -1,0 +1,136 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+import json
+import os
+import sysconfig
+import time
+from pathlib import Path
+
+from pyflink.common.typeinfo import BasicTypeInfo, ExternalTypeInfo, RowTypeInfo
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.table import DataTypes, Schema, StreamTableEnvironment, TableDescriptor
+
+from flink_agents.api.execution_environment import AgentsExecutionEnvironment
+from flink_agents.api.resource import ResourceDescriptor, ResourceName, ResourceType
+from flink_agents.examples.quickstart.agents.parallel_chat_agent import (
+    INPUT_TEXT,
+    N_ASPECTS,
+    OLLAMA_MODEL,
+    ParallelChatAgent,
+    ParallelChatKeySelector,
+)
+
+
+def main() -> None:
+    """Main function for the parallel chat request quickstart example.
+
+    This example demonstrates how to use Flink Agents to analyze a restaurant
+    review by fanning out multiple parallel LLM calls — one per sentiment
+    dimension — and aggregating the results with a final LLM call. This serves
+    as a minimal, end-to-end example of integrating parallel LLM-powered agents
+    with Flink streaming jobs.
+    """
+    # Set up the Flink streaming environment and the Agents execution environment.
+    stream_env = StreamExecutionEnvironment.get_execution_environment()
+    stream_env.set_parallelism(1)
+    t_env = StreamTableEnvironment.create(stream_execution_environment=stream_env)
+    agents_env = AgentsExecutionEnvironment.get_execution_environment(
+        env=stream_env, t_env=t_env
+    )
+
+    # Add Ollama chat model connection to be used by the ParallelChatAgent.
+    agents_env.add_resource(
+        "ollama_server",
+        ResourceType.CHAT_MODEL_CONNECTION,
+        ResourceDescriptor(
+            clazz=ResourceName.ChatModel.OLLAMA_CONNECTION,
+            request_timeout=240.0,
+        ),
+    )
+
+    # Create input table with a single restaurant review.
+    input_table = t_env.from_elements(
+        elements=[(1, INPUT_TEXT)],
+        schema=DataTypes.ROW(
+            [
+                DataTypes.FIELD("id", DataTypes.INT()),
+                DataTypes.FIELD("text", DataTypes.STRING()),
+            ]
+        ),
+    )
+
+    # Define output schema and type info.
+    output_type_info = RowTypeInfo(
+        [
+            BasicTypeInfo.INT_TYPE_INFO(),
+            BasicTypeInfo.STRING_TYPE_INFO(),
+            BasicTypeInfo.STRING_TYPE_INFO(),
+        ],
+        ["id", "text", "summary"],
+    )
+    output_type = ExternalTypeInfo(output_type_info)
+    output_schema = (
+        Schema.new_builder()
+        .column("id", DataTypes.INT())
+        .column("text", DataTypes.STRING())
+        .column("summary", DataTypes.STRING())
+        .build()
+    )
+
+    # Register a filesystem sink for collecting results.
+    result_dir = Path("/tmp/parallel_chat_results")
+    result_dir.mkdir(parents=True, exist_ok=True)
+
+    t_env.create_temporary_table(
+        "sink",
+        TableDescriptor.for_connector("filesystem")
+        .option("path", str(result_dir.absolute()))
+        .format("json")
+        .schema(output_schema)
+        .build(),
+    )
+
+    # Use the ParallelChatAgent to analyze the review with parallel LLM calls.
+    output_table = (
+        agents_env.from_table(input=input_table, key_selector=ParallelChatKeySelector())
+        .apply(ParallelChatAgent())
+        .to_table(schema=output_schema, output_type=output_type)
+    )
+
+    # Execute the Flink pipeline.
+    wall_start = time.monotonic()
+    output_table.execute_insert("sink").wait()
+    wall_elapsed = time.monotonic() - wall_start
+
+    # Print the analysis results to stdout.
+    rows = []
+    for file in result_dir.iterdir():
+        if file.is_file():
+            with file.open() as f:
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        rows.append(json.loads(line))
+
+    print(f"OUTPUT rows: {rows}")
+    print(f"End-to-end wall time: {wall_elapsed:.2f}s")
+    print("=== Done ===")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #822 

### Purpose of change

Flink Agents supports parallel LLM invocations via multi-action fan-out, but no existing quickstart or example demonstrates this capability. This PR adds a complete "Parallel Sentiment Analysis" example (Java + Python) and a quickstart doc page covering the end-to-end workflow.

**New files:**

- `docs/content/docs/get-started/quickstart/parallel_llm.md` — quickstart page with code walkthrough (both Python and Java tabs), deployment instructions, and constraints for multi-action fan-out
- `examples/.../ParallelChatRequestExample.java` — Java entry point
- `examples/.../agents/ParallelChatAgent.java` — Java agent that fans out three `ChatRequestEvent` events (one per sentiment dimension) in parallel, collects responses via sensory memory, and aggregates with a final LLM call
- `python/.../parallel_chat_request_example.py` — Python entry point
- `python/.../agents/parallel_chat_agent.py` — Python equivalent of the Java agent

**Modified files:**

- `examples/.../agents/CustomTypesAndResources.java` — add shared types (`SentimentRequest`, `SentimentKeySelector`, `AspectResponse`, `SummaryResponse`) following project convention
- `python/.../agents/custom_types_and_resources.py` — add shared types (`AspectResponse`, `SummaryResponse`)

### Tests

- Verified Java example runs successfully (JDK 21, parallel execution)
- Verified Python example runs successfully (conda + Python 3.11)
- Both produce correct output: `taste:positive, service:negative, price:not_mentioned`

### API

No public API changes.

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
