### PR TITLE
[python] Admit bytes in the Python memory value contract

### DIFF
--- a/docs/content/docs/development/memory/sensory_and_short_term_memory.md
+++ b/docs/content/docs/development/memory/sensory_and_short_term_memory.md
@@ -77,16 +77,16 @@ The key of the pairs stored in `MemoryObject` must be a string. The supported va
 
 **Python** is restricted to recursively *checkpoint-stable* values:
 
-- **Primitive Types**: `None`, `bool`, `int`, `float`, `str`
+- **Primitive Types**: `None`, `bool`, `int`, `float`, `str`, `bytes`
 - **Collections**: `list`, and `dict` with `str` keys (values are recursively validated)
 - **Memory Object**: A nested `MemoryObject` created via `new_object()`.
 
-Anything else — Pydantic models, `uuid.UUID`, `Enum`, custom classes, `tuple`, `set`, or a `dict` with non-`str` keys — is **rejected by `set()` with a `TypeError`**. `bytes` is not supported yet.
+Anything else — Pydantic models, `uuid.UUID`, `Enum`, custom classes, `tuple`, `set`, `bytearray`, or a `dict` with non-`str` keys — is **rejected by `set()` with a `TypeError`**. Exact `bytes` is supported (it converts to a native Java `byte[]`), but `bytearray` and `bytes` subclasses are not — Pemja wraps them as non-checkpoint-stable objects rather than materializing a `byte[]`.
 
 This is because Python values are converted across the Pemja boundary into Flink state, and only the types above materialize into native, checkpoint-stable JVM values; other objects would be stored as wrappers that fail on state restore. To store a richer object, materialize it to a primitive form first (e.g. `model.model_dump(mode="json")` for a Pydantic model, or `str(value)` for a UUID) and reconstruct it on read.
 
 {{< hint warning >}}
-Python memory values must be checkpoint-stable primitives, unlike the Java contract which also supports POJOs and Kryo-serializable objects. Python values materialize across the Pemja boundary before reaching Flink state, so models and other objects must be materialized first with `model_dump(mode="json")` (or `str(...)`) and reconstructed on read.
+Python memory values must be checkpoint-stable primitives, unlike the Java contract which also supports POJOs and Kryo-serializable objects. Python values materialize across the Pemja boundary before reaching Flink state, so models and other objects must be materialized first with `model_dump(mode="json")` (or `str(...)`) and reconstructed on read. Use exact `bytes` rather than `bytearray` for binary values, since only `bytes` materializes into a native `byte[]`.
 {{< /hint >}}
 
 ### Read & Write

--- a/python/flink_agents/api/memory_object.py
+++ b/python/flink_agents/api/memory_object.py
@@ -28,7 +28,9 @@ if TYPE_CHECKING:
 # Exact builtin types Pemja materializes into native, checkpoint-stable JVM values.
 # Exact-type (not isinstance): a str/int Enum or numpy scalar is a subclass that Pemja
 # PyObject-wraps despite passing isinstance — accepting it would defeat the validator.
-_CHECKPOINT_STABLE_SCALARS = (bool, int, float, str)
+# Exact `bytes` converts to a Java byte[]; bytearray and bytes-subclasses are PyObject-
+# wrapped, and the exact-type check excludes both for free.
+_CHECKPOINT_STABLE_SCALARS = (bool, int, float, str, bytes)
 
 
 def validate_memory_value(path: str, value: Any) -> None:
@@ -45,7 +47,7 @@ def validate_memory_value(path: str, value: Any) -> None:
         The memory path the value is being set at, used to build the error breadcrumb.
     value: Any
         The value to validate. Must be recursively composed of None, bool, int, float,
-        str, list, or dict with str keys.
+        str, bytes, list, or dict with str keys.
     """
     _validate(value, f"value at memory path {path!r}")
 
@@ -77,8 +79,9 @@ def _validate(value: Any, where: str) -> None:
     msg = (
         f"{where} has type {type(value).__name__!r}, which is not checkpoint-stable. "
         f"Python memory values must be recursively composed of None, bool, int, float, "
-        f"str, list, or dict with str keys, because they cross the Pemja boundary into "
-        f"Flink state and non-primitive objects cannot be safely checkpointed/restored. "
+        f"str, bytes, list, or dict with str keys, because they cross the Pemja boundary "
+        f"into Flink state and non-primitive objects cannot be safely "
+        f"checkpointed/restored. "
         f"Materialize it first, e.g. str(value) for a UUID, value.model_dump(mode='json')"
         f" for a Pydantic model, or list(value) for a tuple/set."
     )

--- a/python/flink_agents/runtime/tests/test_memory_value_validation.py
+++ b/python/flink_agents/runtime/tests/test_memory_value_validation.py
@@ -41,14 +41,19 @@ class _Plain:
     pass
 
 
+class _BytesSub(bytes):
+    pass
+
+
 def test_accepts_none_and_scalars() -> None:
-    for value in (None, True, False, 0, 1, -3, 3.14, "", "hello"):
+    for value in (None, True, False, 0, 1, -3, 3.14, "", "hello", b"", b"hello"):
         validate_memory_value("p", value)
 
 
 def test_accepts_nested_list_and_dict() -> None:
     validate_memory_value("p", [1, "a", [2, 3], {"k": [4, None]}])
     validate_memory_value("p", {"a": 1, "b": {"c": [True, "x"]}})
+    validate_memory_value("p", [b"x", {"k": b"y"}])
 
 
 def test_rejects_pydantic_model() -> None:
@@ -64,6 +69,14 @@ def test_rejects_uuid() -> None:
 def test_rejects_tuple_set_frozenset() -> None:
     for value in ((1, 2), {1, 2}, frozenset({1, 2})):
         with pytest.raises(TypeError, match=r"list\(value\)"):
+            validate_memory_value("p", value)
+
+
+def test_rejects_bytearray_and_bytes_subclass() -> None:
+    # Exact `bytes` is accepted, but bytearray and bytes-subclasses are PyObject-wrapped
+    # by Pemja; the exact-type check must reject them.
+    for value in (bytearray(b"x"), _BytesSub(b"x")):
+        with pytest.raises(TypeError, match="not checkpoint-stable"):
             validate_memory_value("p", value)
 
 


### PR DESCRIPTION
Linked issue: #845

### Purpose of change

Admits exact Python `bytes` into the `set()`-time memory value validator (`validate_memory_value`), which previously rejected it.

`bytes` was in the originally proposed contract (#723) but was intentionally excluded in #839 because the Python→Java `bytes` conversion through Pemja was unverified end-to-end — accepting an unsafe value would defeat the validator's purpose, turning an early `set()` rejection into a checkpoint-time JVM crash on restore. This change closes that gap.

Verification shows exact Python `bytes` materializes through Pemja into a native Java `byte[]`, which is checkpoint-stable:

- Pemja 0.5.5 C source (`src/main/c/pemja/core/pyutils.c`): the Python→Java dispatch `JcpPyObject_AsJObject` routes `PyBytes_CheckExact` to `JcpPyBytes_AsJObject`, whose body is `NewByteArray` + `SetByteArrayRegion` — a genuine JVM `byte[]` with no native back-pointer. `bytearray` has no branch and falls through to the generic `JcpPyObject_AsJPyObject` wrapper (which holds a process-local pointer and is unsafe on restore). The conversion is identical in 0.5.5 and 0.5.7.
- A local embedded-Pemja probe driving a real interpreter confirmed it at runtime: `b"hello"` materializes on the Java side as `byte[]` (`[B`), while `bytearray` materializes as `pemja.core.object.PyObject` and `str` as `java.lang.String`.

Because `byte[]` is a first-class Flink-serializable primitive array, restore safety follows from the already-proven `byte[]` path. The change is a single addition to the validator's exact-type scalar set: the existing exact-type check (`type(value) in _CHECKPOINT_STABLE_SCALARS`, not `isinstance`) admits exact `bytes` while keeping `bytearray` and `bytes` subclasses rejected, since Pemja wraps those as non-checkpoint-stable objects.

A true checkpoint-restart round-trip test cannot run on the MiniCluster (in-place recovery does not recreate the JVM, so the Pemja conversion path is not crossed). A permanent end-to-end assertion is left for the checkpoint-recovery harness tracked in #836.

### Tests

`python/flink_agents/runtime/tests/test_memory_value_validation.py`:

- Accept: exact `bytes` as a scalar (`b""`, `b"hello"`) and nested in `list`/`dict`.
- Reject: a new `test_rejects_bytearray_and_bytes_subclass` (using a real `bytes` subclass and `bytearray`) that pins the exact-type boundary — an `isinstance`-based regression would wrongly accept the subclass and fail this test.

Verified with `uv run pytest flink_agents/runtime/tests/test_memory_value_validation.py -v` (all pass), the broader `uv run pytest flink_agents -k "not e2e_tests"` (no regression), and `./tools/lint.sh -c` (0 violations).

### API

No new or changed public API signatures. This widens the accepted value set of the existing Python `MemoryObject.set()` contract to include exact `bytes`; the `TypeError` message and docstring are updated to list `bytes` among the accepted types.

### Documentation

- [ ] `doc-needed`
- [ ] `doc-not-needed`
- [x] `doc-included`
