### PR TITLE
[docs] Refresh get-started overview for 0.3 features

### DIFF
--- a/docs/content/docs/get-started/overview.md
+++ b/docs/content/docs/get-started/overview.md
@@ -24,7 +24,7 @@ under the License.
 
 ## What is Flink Agents?
 
-**Apache Flink Agents** is a streaming **Agent OS** for enterprise, production-grade scenarios, built as a sub-project of the Apache Flink community. It brings AI agents into the Flink streaming pipeline - an agent becomes a first-class operator in your real-time datastream, making AI decisions in the flow of live events rather than in response to human prompts.
+**Apache Flink Agents** is a **streaming Agent OS** for enterprise, production-grade scenarios, built as a sub-project of the Apache Flink community. It brings AI agents into the Flink streaming pipeline - an agent becomes a first-class operator in your real-time datastream, making AI decisions in the flow of live events rather than in response to human prompts.
 
 Like any Agent OS, it manages the core building blocks of an agent - orchestration, context, memory, skills, and tool/MCP invocation. Built on Flink's battle-tested streaming engine, it additionally inherits **distributed, at-scale, fault-tolerant** processing and mature state management, so agents run **event-driven, distributed, and reliable** at production scale.
 

--- a/docs/content/docs/get-started/overview.md
+++ b/docs/content/docs/get-started/overview.md
@@ -24,18 +24,18 @@ under the License.
 
 ## What is Flink Agents?
 
-**Apache Flink Agents** is a brand-new sub-project from the Apache Flink community, providing an **open-source framework for building event-driven streaming agents**.
+**Apache Flink Agents** is a streaming **Agent OS** for enterprise, production-grade scenarios, built as a sub-project of the Apache Flink community. It brings AI agents into the Flink streaming pipeline - an agent becomes a first-class operator in your real-time datastream, making AI decisions in the flow of live events rather than in response to human prompts.
 
-Building on Flink's battle-tested streaming engine, Apache Flink Agents inherits **distributed, at-scale, fault-tolerant structured data processing and mature state management**, and adds first-class abstractions for Agentic AI building blocks and functionalities - **large language models (LLMs)**, **prompts**, **tools**, **memory**, **dynamic orchestration**, **observability**, and more.
+Like any Agent OS, it manages the core building blocks of an agent - orchestration, context, memory, skills, and tool/MCP invocation. Built on Flink's battle-tested streaming engine, it additionally inherits **distributed, at-scale, fault-tolerant** processing and mature state management, so agents run **event-driven, distributed, and reliable** at production scale.
 
 ## Features
 
 The key features of Apache Flink Agents include:
 - **Massive Scale and Millisecond Latency**: Processes massive-scale event streams in real time, leveraging Flink's distributed processing engine.
 - **Seamless Data and AI Integration**: Agents interact directly with Flink's DataStream and Table APIs for input and output, enabling a smooth integration of structured data processing and semantic AI capabilities within Flink.
-- **Exactly-Once Action Consistency**: Ensures exactly-once consistency for agent actions and their side effects by integrating Flink's checkpointing with an external write-ahead log.
-- **Familiar Agent Abstractions**: Leverages well-known AI agent concepts, making it easy for developers experienced with agent-based systems to quickly adopt and build on Apache Flink Agents without a steep learning curve.
-- **Multi-Language Supports**: Provides native APIs in both Python and Java, enabling seamless integration into diverse development environments and allowing teams to use their preferred programming language. For guidance on choosing Java or Python, see [Should I choose Java or Python?]({{< ref "docs/faq/faq#q3-should-i-choose-java-or-python" >}}).
+- **Reliable and Exactly-Once Execution**: Ensures exactly-once consistency for agent actions and their side effects by integrating Flink's checkpointing with an external write-ahead log, and supports durable execution - optionally with reconcilers to reconcile in-flight side effects upon failure recovery - so agents run reliably without human supervision.
+- **Familiar Agent Abstractions**: Leverages well-known AI agent concepts - skills, short/long-term memory, prompts, tools, and dynamic orchestration - making it easy for developers experienced with agent-based systems to quickly adopt and build on Apache Flink Agents without a steep learning curve.
+- **Multi-Language Supports**: Provides native APIs in Python, Java, and a declarative YAML API, enabling seamless integration into diverse development environments and allowing teams to use their preferred programming style. You can even mix languages, authoring actions, tools, and events in one and running them in an agent built in the other. For guidance on choosing Java or Python, see [Should I choose Java or Python?]({{< ref "docs/faq/faq#q3-should-i-choose-java-or-python" >}}).
 - **Rich Ecosystem**: Natively integrates mainstream LLMs, vector stores from diverse providers, and tools or prompts hosted on MCP servers into your agents, while enabling customizable extensions.
 - **Observability**: Adopts an event-centric orchestration approach, where all agent actions are connected and controlled by events, enabling observation and understanding of agent behavior through the event log.
 


### PR DESCRIPTION
### Purpose of change

Update the What-is and Features sections to match the 0.3 release: reposition as a streaming Agent OS, add skills/memory/MCP to the abstractions, list the YAML API alongside Python and Java, and cover durable execution.

### Tests

no

### API

no

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
