### PR TITLE
[Feature] Support tool parameter injection

### DIFF
--- a/api/src/main/java/org/apache/flink/agents/api/annotation/ToolParam.java
+++ b/api/src/main/java/org/apache/flink/agents/api/annotation/ToolParam.java
@@ -20,6 +20,8 @@
 
 package org.apache.flink.agents.api.annotation;
 
+import org.apache.flink.agents.api.tools.ToolParameterSource;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -60,4 +62,30 @@ public @interface ToolParam {
      * @return a string representing the default value of the argument.
      */
     String defaultValue() default "";
+
+    /**
+     * Whether this argument is injected by the framework at tool execution time.
+     *
+     * <p>Injected arguments are hidden from the model-facing tool schema.
+     *
+     * @return true if the argument is injected by the framework
+     */
+    boolean injected() default false;
+
+    /**
+     * Source used to resolve an injected argument.
+     *
+     * <p>Defaults to sensory memory so omitted sources read from the current request context.
+     *
+     * <p>Ignored unless {@link #injected()} is true.
+     */
+    ToolParameterSource source() default ToolParameterSource.SENSORY_MEMORY;
+
+    /**
+     * Key or path used by {@link #source()} to resolve an injected argument. When empty, the tool
+     * parameter name is used.
+     *
+     * <p>Ignored unless {@link #injected()} is true.
+     */
+    String key() default "";
 }

--- a/api/src/main/java/org/apache/flink/agents/api/function/JavaFunctionUtils.java
+++ b/api/src/main/java/org/apache/flink/agents/api/function/JavaFunctionUtils.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.api.function;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+/** Utilities for resolving pure-data Java function descriptors. */
+public final class JavaFunctionUtils {
+
+    private JavaFunctionUtils() {}
+
+    public static Method resolveMethod(JavaFunction function)
+            throws ClassNotFoundException, NoSuchMethodException {
+        Class<?> clazz =
+                Class.forName(
+                        function.getQualName(),
+                        true,
+                        Thread.currentThread().getContextClassLoader());
+        return clazz.getMethod(
+                function.getMethodName(), resolveParameterTypes(function.getParameterTypes()));
+    }
+
+    public static Class<?>[] resolveParameterTypes(List<String> names)
+            throws ClassNotFoundException {
+        Class<?>[] out = new Class<?>[names.size()];
+        for (int i = 0; i < names.size(); i++) {
+            out[i] = resolveParameterType(names.get(i));
+        }
+        return out;
+    }
+
+    public static Class<?> resolveParameterType(String name) throws ClassNotFoundException {
+        switch (name) {
+            case "boolean":
+                return boolean.class;
+            case "byte":
+                return byte.class;
+            case "short":
+                return short.class;
+            case "int":
+                return int.class;
+            case "long":
+                return long.class;
+            case "float":
+                return float.class;
+            case "double":
+                return double.class;
+            case "char":
+                return char.class;
+            case "void":
+                return void.class;
+            default:
+                return Class.forName(name, true, Thread.currentThread().getContextClassLoader());
+        }
+    }
+}

--- a/api/src/main/java/org/apache/flink/agents/api/resource/python/PythonResourceAdapter.java
+++ b/api/src/main/java/org/apache/flink/agents/api/resource/python/PythonResourceAdapter.java
@@ -134,8 +134,9 @@ public interface PythonResourceAdapter {
      *
      * <p>The Java side asks the Python side to introspect a callable identified by {@code module} +
      * {@code qualName}, and returns a flat {@code Map<String, String>} with keys {@code "name"},
-     * {@code "description"}, and {@code "inputSchema"} (a JSON schema string compatible with {@code
-     * ToolMetadata.inputSchema}).
+     * {@code "description"}, {@code "inputSchema"} (a JSON schema string compatible with {@code
+     * ToolMetadata.inputSchema}), and optional {@code "injectedArgs"} (a JSON object string
+     * carrying callable-declared injected arguments).
      *
      * <p>The return shape is intentionally flat — pemja can SIGSEGV when returning arbitrary Python
      * objects to Java on non-main-interpreter threads.
@@ -143,9 +144,17 @@ public interface PythonResourceAdapter {
      * @param module the Python module containing the callable
      * @param qualName the qualified name of the callable inside the module (e.g. {@code "fn"} or
      *     {@code "MyClass.method"})
-     * @return flat map with keys "name", "description", "inputSchema"
+     * @return flat map with keys "name", "description", "inputSchema", and optional "injectedArgs"
      */
     Map<String, String> getPythonToolMetadata(String module, String qualName);
+
+    /**
+     * Look up Python function tool metadata while hiding framework-injected arguments from the
+     * model-facing schema. The returned flat map may also include callable-declared injected
+     * arguments under "injectedArgs" so the Java host can merge them before tool execution.
+     */
+    Map<String, String> getPythonToolMetadata(
+            String module, String qualName, List<String> injectedArgs);
 
     /**
      * Invoke a Python callable as a tool, passing keyword arguments. Used when a Java chat model's

--- a/api/src/main/java/org/apache/flink/agents/api/tools/FunctionTool.java
+++ b/api/src/main/java/org/apache/flink/agents/api/tools/FunctionTool.java
@@ -24,6 +24,8 @@ import org.apache.flink.agents.api.resource.ResourceType;
 import org.apache.flink.agents.api.resource.SerializableResource;
 
 import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -34,9 +36,15 @@ import java.util.Objects;
 public class FunctionTool extends SerializableResource {
 
     private final Function func;
+    private final Map<String, ToolParameterInjection> injectedArgs;
 
     public FunctionTool(Function func) {
+        this(func, Map.of());
+    }
+
+    public FunctionTool(Function func, Map<String, ToolParameterInjection> injectedArgs) {
         this.func = Objects.requireNonNull(func, "func");
+        this.injectedArgs = normalizeInjectedArgs(injectedArgs);
     }
 
     /** Convenience factory: derive a {@link JavaFunction} from a reflected method. */
@@ -46,6 +54,19 @@ public class FunctionTool extends SerializableResource {
 
     public Function getFunc() {
         return func;
+    }
+
+    public Map<String, ToolParameterInjection> getInjectedArgs() {
+        return injectedArgs;
+    }
+
+    private static Map<String, ToolParameterInjection> normalizeInjectedArgs(
+            Map<String, ToolParameterInjection> injectedArgs) {
+        Map<String, ToolParameterInjection> result = new LinkedHashMap<>();
+        if (injectedArgs != null) {
+            injectedArgs.forEach((name, spec) -> result.put(name, spec.withDefaultKey(name)));
+        }
+        return Map.copyOf(result);
     }
 
     @Override

--- a/api/src/main/java/org/apache/flink/agents/api/tools/ToolParameterInjection.java
+++ b/api/src/main/java/org/apache/flink/agents/api/tools/ToolParameterInjection.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.api.tools;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** Declarative source binding for a framework-injected tool parameter. */
+public final class ToolParameterInjection implements Serializable {
+    private final ToolParameterSource source;
+    private final String key;
+
+    @JsonCreator
+    public ToolParameterInjection(
+            @JsonProperty("source") ToolParameterSource source, @JsonProperty("key") String key) {
+        this.source = source == null ? ToolParameterSource.SENSORY_MEMORY : source;
+        this.key = key;
+    }
+
+    public static ToolParameterInjection fromConfig(String key) {
+        return new ToolParameterInjection(ToolParameterSource.CONFIG, key);
+    }
+
+    public static ToolParameterInjection fromSensoryMemory(String path) {
+        return new ToolParameterInjection(ToolParameterSource.SENSORY_MEMORY, path);
+    }
+
+    public static ToolParameterInjection fromShortTermMemory(String path) {
+        return new ToolParameterInjection(ToolParameterSource.SHORT_TERM_MEMORY, path);
+    }
+
+    public ToolParameterSource getSource() {
+        return source;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public ToolParameterInjection withDefaultKey(String defaultKey) {
+        if (key != null && !key.isEmpty()) {
+            return this;
+        }
+        return new ToolParameterInjection(source, defaultKey);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ToolParameterInjection)) {
+            return false;
+        }
+        ToolParameterInjection that = (ToolParameterInjection) o;
+        return source == that.source && Objects.equals(key, that.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(source, key);
+    }
+
+    @Override
+    public String toString() {
+        return "ToolParameterInjection{" + "source=" + source + ", key='" + key + '\'' + '}';
+    }
+}

--- a/api/src/main/java/org/apache/flink/agents/api/tools/ToolParameterInjectionValidator.java
+++ b/api/src/main/java/org/apache/flink/agents/api/tools/ToolParameterInjectionValidator.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.api.tools;
+
+import org.apache.flink.agents.api.annotation.ToolParam;
+import org.apache.flink.agents.api.function.Function;
+import org.apache.flink.agents.api.function.JavaFunction;
+import org.apache.flink.agents.api.function.JavaFunctionUtils;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/** Validation helpers for declarative tool parameter injection. */
+public final class ToolParameterInjectionValidator {
+
+    private ToolParameterInjectionValidator() {}
+
+    public static void validate(
+            Function function, Map<String, ToolParameterInjection> injectedArgs, String toolName) {
+        if (injectedArgs.isEmpty() || !(function instanceof JavaFunction)) {
+            return;
+        }
+        JavaFunction javaFunction = (JavaFunction) function;
+        String displayName = toolName == null ? javaFunction.getMethodName() : toolName;
+        try {
+            Method method = JavaFunctionUtils.resolveMethod(javaFunction);
+            Set<String> parameterNames = new HashSet<>();
+            boolean allParameterNamesReliable = true;
+            for (Parameter parameter : method.getParameters()) {
+                if (parameter.isAnnotationPresent(ToolParam.class)) {
+                    ToolParam toolParam = parameter.getAnnotation(ToolParam.class);
+                    if (!toolParam.name().isEmpty()) {
+                        parameterNames.add(toolParam.name());
+                        continue;
+                    }
+                }
+                if (parameter.isNamePresent()) {
+                    parameterNames.add(parameter.getName());
+                } else {
+                    allParameterNamesReliable = false;
+                }
+            }
+            if (!allParameterNamesReliable) {
+                return;
+            }
+            Set<String> unknown = new HashSet<>(injectedArgs.keySet());
+            unknown.removeAll(parameterNames);
+            if (!unknown.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "Tool '"
+                                + displayName
+                                + "': injected_args contain unknown parameter(s): "
+                                + unknown);
+            }
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            throw new IllegalArgumentException(
+                    "Tool '" + displayName + "': failed to validate injected_args.", e);
+        }
+    }
+}

--- a/api/src/main/java/org/apache/flink/agents/api/tools/ToolParameterSource.java
+++ b/api/src/main/java/org/apache/flink/agents/api/tools/ToolParameterSource.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.api.tools;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/** Source for a framework-injected tool parameter. */
+public enum ToolParameterSource {
+    CONFIG("config"),
+    SENSORY_MEMORY("sensory_memory"),
+    SHORT_TERM_MEMORY("short_term_memory");
+
+    private final String value;
+
+    ToolParameterSource(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static ToolParameterSource fromValue(String value) {
+        for (ToolParameterSource source : values()) {
+            if (source.value.equals(value) || source.name().equals(value)) {
+                return source;
+            }
+        }
+        throw new IllegalArgumentException("Unknown tool parameter source: " + value);
+    }
+}

--- a/api/src/main/java/org/apache/flink/agents/api/yaml/YamlLoader.java
+++ b/api/src/main/java/org/apache/flink/agents/api/yaml/YamlLoader.java
@@ -152,7 +152,7 @@ public final class YamlLoader {
         Function fn =
                 resolveFunction(
                         spec.getName(), spec.getFunction(), language, spec.getParameterTypes());
-        return new FunctionTool(fn);
+        return new FunctionTool(fn, spec.getInjectedArgs());
     }
 
     /** Build a {@link Prompt} from a parsed {@link PromptSpec}. */

--- a/api/src/main/java/org/apache/flink/agents/api/yaml/spec/ToolSpec.java
+++ b/api/src/main/java/org/apache/flink/agents/api/yaml/spec/ToolSpec.java
@@ -21,9 +21,14 @@ package org.apache.flink.agents.api.yaml.spec;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.agents.api.tools.ToolParameterInjection;
 import org.apache.flink.agents.api.yaml.Language;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /** Declarative function tool. */
 @JsonIgnoreProperties(ignoreUnknown = false)
@@ -32,17 +37,20 @@ public final class ToolSpec {
     private final String function;
     private final Language type;
     private final List<String> parameterTypes;
+    private final Map<String, ToolParameterInjection> injectedArgs;
 
     @JsonCreator
     public ToolSpec(
             @JsonProperty(value = "name", required = true) String name,
             @JsonProperty("function") String function,
             @JsonProperty("type") Language type,
-            @JsonProperty("parameter_types") List<String> parameterTypes) {
+            @JsonProperty("parameter_types") List<String> parameterTypes,
+            @JsonProperty("injected_args") JsonNode injectedArgs) {
         this.name = name;
         this.function = function;
         this.type = type;
         this.parameterTypes = parameterTypes;
+        this.injectedArgs = parseInjectedArgs(injectedArgs);
     }
 
     public String getName() {
@@ -59,5 +67,36 @@ public final class ToolSpec {
 
     public List<String> getParameterTypes() {
         return parameterTypes;
+    }
+
+    public Map<String, ToolParameterInjection> getInjectedArgs() {
+        return injectedArgs;
+    }
+
+    private static Map<String, ToolParameterInjection> parseInjectedArgs(JsonNode node) {
+        Map<String, ToolParameterInjection> result = new LinkedHashMap<>();
+        if (node == null || node.isNull()) {
+            return Map.of();
+        }
+        if (!node.isObject()) {
+            throw new IllegalArgumentException("'injected_args' must be an object.");
+        }
+        ObjectMapper mapper = new ObjectMapper();
+        node.fields()
+                .forEachRemaining(
+                        entry -> {
+                            try {
+                                result.put(
+                                        entry.getKey(),
+                                        mapper.treeToValue(
+                                                        entry.getValue(),
+                                                        ToolParameterInjection.class)
+                                                .withDefaultKey(entry.getKey()));
+                            } catch (Exception e) {
+                                throw new IllegalArgumentException(
+                                        "Failed to parse injected_args." + entry.getKey(), e);
+                            }
+                        });
+        return Map.copyOf(result);
     }
 }

--- a/api/src/test/java/org/apache/flink/agents/api/CrossLanguageEventSnapshotTest.java
+++ b/api/src/test/java/org/apache/flink/agents/api/CrossLanguageEventSnapshotTest.java
@@ -366,12 +366,9 @@ class CrossLanguageEventSnapshotTest {
         assertEquals(Boolean.TRUE, boolResp.getResult());
         assertTrue(boolResp.isSuccess());
 
-        // Remaining shape gap: Python's ToolResponseEvent model has no top-level success/error/
-        // timestamp maps (those live inside each ToolResponse on the Java side). Pin it so the
-        // divergence stays visible.
         Map<String, Object> attrs = typed.getAttributes();
-        assertFalse(attrs.containsKey("success"));
-        assertFalse(attrs.containsKey("error"));
+        assertEquals(Boolean.TRUE, typed.getSuccess().get(FIXED_TOOL_CALL_ID));
+        assertTrue(typed.getError().isEmpty());
         assertFalse(attrs.containsKey("timestamp"));
     }
 

--- a/api/src/test/java/org/apache/flink/agents/api/tools/FunctionToolTest.java
+++ b/api/src/test/java/org/apache/flink/agents/api/tools/FunctionToolTest.java
@@ -18,12 +18,15 @@
 
 package org.apache.flink.agents.api.tools;
 
+import org.apache.flink.agents.api.annotation.ToolParam;
 import org.apache.flink.agents.api.function.JavaFunction;
 import org.apache.flink.agents.api.function.PythonFunction;
 import org.apache.flink.agents.api.resource.ResourceType;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,6 +34,12 @@ class FunctionToolTest {
 
     public static int demo(int a) {
         return a;
+    }
+
+    public static String queryOrder(
+            @ToolParam(name = "order_id") String orderId,
+            @ToolParam(name = "tenant_id") String tenantId) {
+        return tenantId + ":" + orderId;
     }
 
     @Test
@@ -46,6 +55,46 @@ class FunctionToolTest {
         JavaFunction jf = new JavaFunction("X", "m", java.util.List.of("int"));
         FunctionTool tool = new FunctionTool(jf);
         assertThat(tool.getFunc()).isSameAs(jf);
+    }
+
+    @Test
+    void holdsInjectedArgs() {
+        PythonFunction pf = new PythonFunction("pkg.mod", "fn");
+        FunctionTool tool =
+                new FunctionTool(
+                        pf, Map.of("tenant_id", ToolParameterInjection.fromConfig("tenant_id")));
+        assertThat(tool.getInjectedArgs())
+                .containsExactlyEntriesOf(
+                        Map.of("tenant_id", ToolParameterInjection.fromConfig("tenant_id")));
+    }
+
+    @Test
+    void constructorDoesNotResolveJavaFunctionDescriptor() {
+        JavaFunction jf = new JavaFunction("missing.Clazz", "queryOrder", List.of("int"));
+
+        FunctionTool tool =
+                new FunctionTool(
+                        jf, Map.of("tenant_id", ToolParameterInjection.fromConfig("tenant_id")));
+
+        assertThat(tool.getFunc()).isSameAs(jf);
+        assertThat(tool.getInjectedArgs())
+                .containsExactlyEntriesOf(
+                        Map.of("tenant_id", ToolParameterInjection.fromConfig("tenant_id")));
+    }
+
+    @Test
+    void acceptsKnownInjectedArgNamesForManualJavaFunctionTool() throws Exception {
+        Method m =
+                FunctionToolTest.class.getDeclaredMethod("queryOrder", String.class, String.class);
+        JavaFunction jf = JavaFunction.fromMethod(m);
+
+        FunctionTool tool =
+                new FunctionTool(
+                        jf, Map.of("tenant_id", ToolParameterInjection.fromConfig("tenant_id")));
+
+        assertThat(tool.getInjectedArgs())
+                .containsExactlyEntriesOf(
+                        Map.of("tenant_id", ToolParameterInjection.fromConfig("tenant_id")));
     }
 
     @Test

--- a/api/src/test/java/org/apache/flink/agents/api/yaml/LoaderTargets.java
+++ b/api/src/test/java/org/apache/flink/agents/api/yaml/LoaderTargets.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.agents.api.yaml;
 
+import org.apache.flink.agents.api.annotation.ToolParam;
+
 /** Static targets referenced by YAML fixtures. */
 public final class LoaderTargets {
     private LoaderTargets() {}
@@ -28,6 +30,12 @@ public final class LoaderTargets {
 
     public static String notify(String id, String message) {
         return "notified " + id + ": " + message;
+    }
+
+    public static String queryOrder(
+            @ToolParam(name = "order_id") String orderId,
+            @ToolParam(name = "tenant_id") String tenantId) {
+        return tenantId + ":" + orderId;
     }
 
     public static final class Counter {

--- a/api/src/test/java/org/apache/flink/agents/api/yaml/YamlLoaderBuildersTest.java
+++ b/api/src/test/java/org/apache/flink/agents/api/yaml/YamlLoaderBuildersTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.agents.api.resource.ResourceType;
 import org.apache.flink.agents.api.skills.SkillSourceSpec;
 import org.apache.flink.agents.api.skills.Skills;
 import org.apache.flink.agents.api.tools.FunctionTool;
+import org.apache.flink.agents.api.tools.ToolParameterInjection;
 import org.apache.flink.agents.api.yaml.spec.DescriptorSpec;
 import org.apache.flink.agents.api.yaml.spec.PromptSpec;
 import org.apache.flink.agents.api.yaml.spec.SkillsSpec;
@@ -96,10 +97,22 @@ class YamlLoaderBuildersTest {
 
     @Test
     void buildToolPython() throws Exception {
-        ToolSpec spec = M.readValue("name: t\nfunction: pkg:fn\ntype: python\n", ToolSpec.class);
+        ToolSpec spec =
+                M.readValue(
+                        "name: t\n"
+                                + "function: pkg:fn\n"
+                                + "type: python\n"
+                                + "injected_args:\n"
+                                + "  tenant_id:\n"
+                                + "    source: config\n"
+                                + "    key: tenant_id\n",
+                        ToolSpec.class);
         FunctionTool tool = YamlLoader.buildTool(spec);
         assertThat(tool.getFunc()).isInstanceOf(PythonFunction.class);
         assertThat(((PythonFunction) tool.getFunc()).getQualName()).isEqualTo("fn");
+        assertThat(tool.getInjectedArgs())
+                .containsExactlyEntriesOf(
+                        Map.of("tenant_id", ToolParameterInjection.fromConfig("tenant_id")));
     }
 
     @Test
@@ -119,6 +132,44 @@ class YamlLoaderBuildersTest {
         FunctionTool tool = YamlLoader.buildTool(spec);
         assertThat(tool.getFunc()).isInstanceOf(JavaFunction.class);
         assertThat(((JavaFunction) tool.getFunc()).getParameterTypes()).containsExactly("int");
+    }
+
+    @Test
+    void buildToolJavaKeepsUnknownInjectedArgNamesForPlanValidation() throws Exception {
+        ToolSpec spec =
+                M.readValue(
+                        "name: t\n"
+                                + "function: org.apache.flink.agents.api.yaml.LoaderTargets:queryOrder\n"
+                                + "type: java\n"
+                                + "parameter_types: [java.lang.String, java.lang.String]\n"
+                                + "injected_args:\n"
+                                + "  tenent_id:\n"
+                                + "    source: config\n"
+                                + "    key: tenant_id\n",
+                        ToolSpec.class);
+        FunctionTool tool = YamlLoader.buildTool(spec);
+        assertThat(tool.getInjectedArgs())
+                .containsExactlyEntriesOf(
+                        Map.of("tenent_id", ToolParameterInjection.fromConfig("tenant_id")));
+    }
+
+    @Test
+    void buildToolJavaAcceptsKnownInjectedArgNames() throws Exception {
+        ToolSpec spec =
+                M.readValue(
+                        "name: t\n"
+                                + "function: org.apache.flink.agents.api.yaml.LoaderTargets:queryOrder\n"
+                                + "type: java\n"
+                                + "parameter_types: [java.lang.String, java.lang.String]\n"
+                                + "injected_args:\n"
+                                + "  tenant_id:\n"
+                                + "    source: config\n"
+                                + "    key: tenant_id\n",
+                        ToolSpec.class);
+        FunctionTool tool = YamlLoader.buildTool(spec);
+        assertThat(tool.getInjectedArgs())
+                .containsExactlyEntriesOf(
+                        Map.of("tenant_id", ToolParameterInjection.fromConfig("tenant_id")));
     }
 
     @Test

--- a/api/src/test/java/org/apache/flink/agents/api/yaml/spec/SchemaParityTest.java
+++ b/api/src/test/java/org/apache/flink/agents/api/yaml/spec/SchemaParityTest.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.agents.api.chat.messages.MessageRole;
+import org.apache.flink.agents.api.tools.ToolParameterInjection;
+import org.apache.flink.agents.api.tools.ToolParameterSource;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -76,6 +78,7 @@ class SchemaParityTest {
         m.put("SkillsSpec", SkillsSpec.class);
         m.put("PackageSkillSpec", PackageSkillSpec.class);
         m.put("ToolSpec", ToolSpec.class);
+        m.put("InjectedArg", ToolParameterInjection.class);
         SPEC_CLASSES = Map.copyOf(m);
     }
 
@@ -94,6 +97,10 @@ class SchemaParityTest {
                 assertMessageRoleEnum(def);
                 continue;
             }
+            if ("ToolParameterSource".equals(name)) {
+                assertToolParameterSourceEnum(def);
+                continue;
+            }
             Class<?> javaClass = SPEC_CLASSES.get(name);
             assertThat(javaClass).as("no Java spec for $defs/%s", name).isNotNull();
             assertDefMatchesClass(name, def, javaClass);
@@ -102,6 +109,7 @@ class SchemaParityTest {
         // Every Java spec in the map must have appeared in $defs.
         Set<String> expectedSchemaDefs = new HashSet<>(SPEC_CLASSES.keySet());
         expectedSchemaDefs.add("MessageRole");
+        expectedSchemaDefs.add("ToolParameterSource");
         assertThat(seen).as("$defs entries").isEqualTo(expectedSchemaDefs);
 
         // Top-level YAML document.
@@ -118,6 +126,18 @@ class SchemaParityTest {
                         .map(MessageRole::getValue)
                         .collect(Collectors.toSet());
         assertThat(schemaValues).as("MessageRole enum values").isEqualTo(javaValues);
+    }
+
+    private static void assertToolParameterSourceEnum(JsonNode def) {
+        Set<String> schemaValues = new HashSet<>();
+        for (JsonNode v : def.get("enum")) {
+            schemaValues.add(v.asText());
+        }
+        Set<String> javaValues =
+                Arrays.stream(ToolParameterSource.values())
+                        .map(ToolParameterSource::getValue)
+                        .collect(Collectors.toSet());
+        assertThat(schemaValues).as("ToolParameterSource enum values").isEqualTo(javaValues);
     }
 
     private static void assertDefMatchesClass(String defName, JsonNode def, Class<?> clz) {

--- a/api/src/test/java/org/apache/flink/agents/api/yaml/spec/ToolSpecTest.java
+++ b/api/src/test/java/org/apache/flink/agents/api/yaml/spec/ToolSpecTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.agents.api.yaml.spec;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.apache.flink.agents.api.tools.ToolParameterInjection;
 import org.apache.flink.agents.api.yaml.Language;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +37,7 @@ class ToolSpecTest {
         assertThat(spec.getFunction()).isEqualTo("pkg:fn");
         assertThat(spec.getType()).isNull();
         assertThat(spec.getParameterTypes()).isNull();
+        assertThat(spec.getInjectedArgs()).isEmpty();
     }
 
     @Test
@@ -48,6 +50,50 @@ class ToolSpecTest {
         ToolSpec spec = M.readValue(yaml, ToolSpec.class);
         assertThat(spec.getType()).isEqualTo(Language.JAVA);
         assertThat(spec.getParameterTypes()).containsExactly("int", "java.lang.String");
+    }
+
+    @Test
+    void rejectsListInjectedArgs() {
+        assertThatThrownBy(
+                        () ->
+                                M.readValue(
+                                        "name: t\nfunction: pkg:fn\ninjected_args: [tenant_id]\n",
+                                        ToolSpec.class))
+                .hasMessageContaining("'injected_args' must be an object.");
+    }
+
+    @Test
+    void toolWithDeclarativeInjectedArgs() throws Exception {
+        ToolSpec spec =
+                M.readValue(
+                        "name: t\n"
+                                + "function: pkg:fn\n"
+                                + "injected_args:\n"
+                                + "  tenant_id:\n"
+                                + "    source: config\n"
+                                + "    key: tenant.id\n",
+                        ToolSpec.class);
+        assertThat(spec.getInjectedArgs())
+                .containsExactlyEntriesOf(
+                        java.util.Map.of(
+                                "tenant_id", ToolParameterInjection.fromConfig("tenant.id")));
+    }
+
+    @Test
+    void toolWithInjectedArgsDefaultsSourceToSensoryMemory() throws Exception {
+        ToolSpec spec =
+                M.readValue(
+                        "name: t\n"
+                                + "function: pkg:fn\n"
+                                + "injected_args:\n"
+                                + "  tenant_id:\n"
+                                + "    key: request.tenant_id\n",
+                        ToolSpec.class);
+        assertThat(spec.getInjectedArgs())
+                .containsExactlyEntriesOf(
+                        java.util.Map.of(
+                                "tenant_id",
+                                ToolParameterInjection.fromSensoryMemory("request.tenant_id")));
     }
 
     @Test

--- a/docs/content/docs/development/tool_use.md
+++ b/docs/content/docs/development/tool_use.md
@@ -179,6 +179,113 @@ ReActAgent reviewAnalysisReactAgent = new ReActAgent(
 - Use `AgentsExecutionEnvironment.add_resource` to register the tool to the execution environment
 - Reference the tool by its name in the `tools` list of the `ResourceDescriptor`
 
+## Tool Parameter Injection
+
+Some tools need runtime data that should not be chosen by the model, such as a tenant id, account id, request trace id, or other framework-owned context. Mark those parameters as injected so they are hidden from the model-facing tool schema, and declare where the runtime should read each value.
+
+The model only sees and provides normal tool parameters. The injected parameters are merged into the tool call immediately before the built-in `tool_call_action` executes the tool.
+
+{{< tabs "Inject Tool Parameters" >}}
+
+{{< tab "Python" >}}
+```python
+from flink_agents.api.agents import Agent
+from flink_agents.api.decorators import tool
+from flink_agents.api.tools import InjectedArg
+
+
+class OrderAgent(Agent):
+
+    @tool(injected_args={"tenant_id": InjectedArg.from_config("tenant_id")})
+    @staticmethod
+    def query_order(order_id: str, tenant_id: str) -> str:
+        """Query an order.
+
+        Parameters
+        ----------
+        order_id : str
+            The order id to query.
+        """
+        return query_order_from_store(order_id=order_id, tenant_id=tenant_id)
+```
+{{< /tab >}}
+
+{{< tab "Java" >}}
+```java
+public class OrderAgent extends Agent {
+
+    @Tool(description = "Query an order.")
+    public static String queryOrder(
+            @ToolParam(name = "order_id") String orderId,
+            @ToolParam(
+                    name = "tenant_id",
+                    injected = true,
+                    source = ToolParameterSource.CONFIG,
+                    key = "tenant_id")
+                    String tenantId) {
+        return queryOrderFromStore(orderId, tenantId);
+    }
+}
+```
+{{< /tab >}}
+
+{{< /tabs >}}
+
+Configure the injected value on the agent execution environment. Python uses `agents_env.get_config().set_str("tenant_id", "tenant-a")`; Java uses `agentsEnv.getConfig().setStr("tenant_id", "tenant-a")`.
+
+Injected values can also come from memory when the value is attached to the current request or session instead of static environment configuration:
+
+{{< tabs "Inject Tool Parameters From Memory" >}}
+
+{{< tab "Python" >}}
+```python
+from flink_agents.api.decorators import tool
+from flink_agents.api.tools import InjectedArg
+
+
+@tool(
+    injected_args={
+        "trace_id": InjectedArg.from_sensory_memory("request.trace_id"),
+    }
+)
+def lookup_order(order_id: str, trace_id: str) -> str:
+    return query_order_with_trace(order_id=order_id, trace_id=trace_id)
+```
+{{< /tab >}}
+
+{{< tab "Java" >}}
+```java
+@Tool(description = "Look up an order.")
+public static String lookupOrder(
+        @ToolParam(name = "order_id") String orderId,
+        @ToolParam(
+                name = "trace_id",
+                injected = true,
+                source = ToolParameterSource.SENSORY_MEMORY,
+                key = "request.trace_id")
+                String traceId) {
+    return queryOrderWithTrace(orderId, traceId);
+}
+```
+{{< /tab >}}
+
+{{< /tabs >}}
+
+The supported sources are `config`, `sensory_memory`, and `short_term_memory`.
+If `source` is omitted, it defaults to `sensory_memory`.
+For Java annotation-based tools, `@ToolParam(injected = true)` is what marks the
+parameter as framework-injected and hidden from the model; `source` and `key` only
+configure where the value is read from.
+If the same injected parameter is declared both on the tool function and by a
+descriptor such as YAML, the declarations must resolve to the same source and key;
+conflicting declarations fail during agent plan construction.
+
+Injected parameters are part of the tool execution contract, not the model contract:
+
+- They are not included in the JSON schema sent to the model.
+- They are not written back to the original `ToolRequestEvent`.
+- If a model supplies an argument with the same name, the injected value wins during execution.
+
 ## MCP Tool
 
 See [MCP]({{< ref "docs/development/mcp" >}}) for details.

--- a/docs/content/docs/development/yaml.md
+++ b/docs/content/docs/development/yaml.md
@@ -137,6 +137,7 @@ prompts:
 | `function` | yes | Fully-qualified callable in the form `<module-or-class>:<qualname>`. See [Function references](#function-references). |
 | `type` | no | Implementation language: `python` or `java`. Defaults to `python` (see [Selecting the implementation language](#selecting-the-implementation-language)). |
 | `parameter_types` | java only | Required for Java tools — one Java type FQN per declared parameter, in order. Forbidden for Python tools (the signature is reflected from the callable). |
+| `injected_args` | no | Tool arguments injected by the framework at execution time. Declare a map from tool parameter name to `{source, key}`. These arguments are hidden from the model-facing tool schema. |
 
 ```yaml
 tools:
@@ -153,6 +154,58 @@ tools:
     type: java
     function: com.example.MyTools:add
     parameter_types: [java.lang.Integer, java.lang.Integer]
+```
+
+To hide framework-owned arguments from the model, declare them in `injected_args` and bind each argument to a runtime source:
+
+```yaml
+agents:
+  - name: order_agent
+    tools:
+      - name: query_order
+        function: my_pkg.tools:query_order
+        injected_args:
+          tenant_id:
+            source: config
+            key: tenant_id
+```
+
+The supported `source` values are `config`, `sensory_memory`, and `short_term_memory`. If omitted, `source` defaults to `sensory_memory`. For `config`, `key` is read from the agent execution environment configuration. For memory sources, `key` is the memory path.
+
+For Java tools loaded from YAML, the `injected_args` entry itself marks the parameter
+as framework-injected and hides it from the model-facing schema. The Java method may
+use `@ToolParam(name = "...")` to provide stable parameter names, but it does not need
+`@ToolParam(injected = true)` when injection is declared in YAML.
+If both YAML and the tool function declare the same injected parameter, they must use
+the same source and key; conflicting declarations fail during agent plan construction.
+
+Per-request values, such as a trace id written to sensory memory before tool execution, can be injected the same way:
+
+```yaml
+agents:
+  - name: traced_order_agent
+    tools:
+      - name: lookup_order
+        function: my_pkg.tools:lookup_order
+        injected_args:
+          trace_id:
+            source: sensory_memory
+            key: request.trace_id
+```
+
+```yaml
+# Java-loaded YAML
+agents:
+  - name: java_order_agent
+    tools:
+      - name: queryOrder
+        type: java
+        function: com.example.OrderTools:queryOrder
+        parameter_types: [java.lang.String, java.lang.String]
+        injected_args:
+          tenant_id:
+            source: config
+            key: tenant_id
 ```
 
 **Skills** — bundles of agent skill assets loaded from one or more sources. At least one of `paths` / `urls` / `classpath` / `package` must be non-empty; multiple sources can coexist.

--- a/docs/yaml-schema.json
+++ b/docs/yaml-schema.json
@@ -205,6 +205,29 @@
       "title": "DescriptorSpec",
       "type": "object"
     },
+    "InjectedArg": {
+      "description": "Declarative source binding for a framework-injected tool parameter.",
+      "properties": {
+        "key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Key"
+        },
+        "source": {
+          "$ref": "#/$defs/ToolParameterSource",
+          "default": "sensory_memory"
+        }
+      },
+      "title": "InjectedArg",
+      "type": "object"
+    },
     "MessageRole": {
       "description": "Role of a message in a chat conversation.",
       "enum": [
@@ -340,6 +363,16 @@
       "title": "SkillsSpec",
       "type": "object"
     },
+    "ToolParameterSource": {
+      "description": "Source for a framework-injected tool parameter.",
+      "enum": [
+        "config",
+        "sensory_memory",
+        "short_term_memory"
+      ],
+      "title": "ToolParameterSource",
+      "type": "string"
+    },
     "ToolSpec": {
       "additionalProperties": false,
       "description": "Points ``function:`` at a callable tool.\n\n``function`` is written as ``<module-or-class>:<qualname>`` \u2014 the\ncolon separates the Python module (or Java class FQN) from the\nattribute path inside it. For Python, the right side may be a\nnested ``Class.method``.\n\n``parameter_types`` is required when ``type: java`` and is forbidden\notherwise (Python tools are reflected from the callable signature).\nThe list contains one string per declared parameter of the Java\nmethod, in declaration order \u2014 the loader uses it to disambiguate\noverloaded methods on the Java class. Each string is one of:\n\n- A Java primitive name: one of ``boolean``, ``byte``, ``short``,\n  ``int``, ``long``, ``float``, ``double``, ``char``.\n- A fully-qualified Java reference type (including boxed\n  primitives), e.g. ``java.lang.Double``, ``java.lang.String``,\n  ``java.util.List``.\n\nGeneric type arguments are not part of the JVM method descriptor\nand must not be included (``java.util.List``, not\n``java.util.List<String>``).",
@@ -355,6 +388,21 @@
           ],
           "default": null,
           "title": "Function"
+        },
+        "injected_args": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/InjectedArg"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              }
+            ]
+          },
+          "title": "Injected Args",
+          "type": "object"
         },
         "name": {
           "title": "Name",

--- a/e2e-test/cross-language-event-snapshots/python/tool_response_event.json
+++ b/e2e-test/cross-language-event-snapshots/python/tool_response_event.json
@@ -8,6 +8,12 @@
       "call_bbbb": 42,
       "call_cccc": true
     },
+    "success": {
+      "call_aaaa": true,
+      "call_bbbb": true,
+      "call_cccc": true
+    },
+    "error": {},
     "external_ids": {
       "call_aaaa": null,
       "call_bbbb": null,

--- a/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/ToolParameterInjectionAgent.java
+++ b/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/ToolParameterInjectionAgent.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.integration.test;
+
+import org.apache.flink.agents.api.Event;
+import org.apache.flink.agents.api.EventType;
+import org.apache.flink.agents.api.InputEvent;
+import org.apache.flink.agents.api.OutputEvent;
+import org.apache.flink.agents.api.agents.Agent;
+import org.apache.flink.agents.api.annotation.Action;
+import org.apache.flink.agents.api.annotation.ChatModelConnection;
+import org.apache.flink.agents.api.annotation.ChatModelSetup;
+import org.apache.flink.agents.api.annotation.Tool;
+import org.apache.flink.agents.api.annotation.ToolParam;
+import org.apache.flink.agents.api.chat.messages.ChatMessage;
+import org.apache.flink.agents.api.chat.messages.MessageRole;
+import org.apache.flink.agents.api.chat.model.BaseChatModelConnection;
+import org.apache.flink.agents.api.chat.model.BaseChatModelSetup;
+import org.apache.flink.agents.api.context.RunnerContext;
+import org.apache.flink.agents.api.event.ChatRequestEvent;
+import org.apache.flink.agents.api.event.ChatResponseEvent;
+import org.apache.flink.agents.api.resource.ResourceContext;
+import org.apache.flink.agents.api.resource.ResourceDescriptor;
+import org.apache.flink.agents.api.tools.ToolParameterSource;
+import org.apache.flink.api.java.functions.KeySelector;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** E2E agent covering tool parameter injection in a real Flink job. */
+public class ToolParameterInjectionAgent extends Agent {
+
+    /** Key selector for order ids. */
+    public static class OrderKeySelector implements KeySelector<String, String> {
+        @Override
+        public String getKey(String value) {
+            return value;
+        }
+    }
+
+    /** Mock chat connection that emits one queryOrder tool call, then echoes the tool result. */
+    public static class MockToolChatConnection extends BaseChatModelConnection {
+        public MockToolChatConnection(
+                ResourceDescriptor descriptor, ResourceContext resourceContext) {
+            super(descriptor, resourceContext);
+        }
+
+        @Override
+        public ChatMessage chat(
+                List<ChatMessage> messages,
+                List<org.apache.flink.agents.api.tools.Tool> tools,
+                Map<String, Object> modelParams) {
+            ChatMessage lastMessage = messages.get(messages.size() - 1);
+            if (lastMessage.getRole() == MessageRole.TOOL) {
+                return new ChatMessage(MessageRole.ASSISTANT, lastMessage.getContent());
+            }
+
+            for (org.apache.flink.agents.api.tools.Tool tool : tools) {
+                String inputSchema = tool.getMetadata().getInputSchema();
+                if (inputSchema.contains("tenant_id")) {
+                    throw new IllegalStateException(
+                            "Injected argument leaked into tool schema: " + inputSchema);
+                }
+            }
+            String orderId = lastMessage.getContent();
+            return new ChatMessage(
+                    MessageRole.ASSISTANT,
+                    "",
+                    List.of(
+                            Map.of(
+                                    "id",
+                                    "call-" + orderId,
+                                    "type",
+                                    "function",
+                                    "function",
+                                    Map.of(
+                                            "name",
+                                            "queryOrder",
+                                            "arguments",
+                                            Map.of("order_id", orderId)))));
+        }
+    }
+
+    /** Mock chat model setup bound to queryOrder. */
+    public static class MockToolChatModel extends BaseChatModelSetup {
+        public MockToolChatModel(ResourceDescriptor descriptor, ResourceContext resourceContext) {
+            super(descriptor, resourceContext);
+        }
+
+        @Override
+        public Map<String, Object> getParameters() {
+            return new HashMap<>();
+        }
+    }
+
+    @ChatModelConnection
+    public static ResourceDescriptor mockChatConnection() {
+        return ResourceDescriptor.Builder.newBuilder(MockToolChatConnection.class.getName())
+                .build();
+    }
+
+    @ChatModelSetup
+    public static ResourceDescriptor mockChatModel() {
+        return ResourceDescriptor.Builder.newBuilder(MockToolChatModel.class.getName())
+                .addInitialArgument("connection", "mockChatConnection")
+                .addInitialArgument("model", "mock")
+                .addInitialArgument("tools", List.of("queryOrder"))
+                .build();
+    }
+
+    @Tool(description = "Query order in the current tenant.")
+    public static String queryOrder(
+            @ToolParam(name = "order_id") String orderId,
+            @ToolParam(name = "tenant_id", injected = true, source = ToolParameterSource.CONFIG)
+                    String tenantId) {
+        return "checked:" + tenantId + ":" + orderId;
+    }
+
+    @Action(EventType.InputEvent)
+    public static void requestTool(Event event, RunnerContext ctx) {
+        String orderId = String.valueOf(InputEvent.fromEvent(event).getInput());
+        ctx.sendEvent(
+                new ChatRequestEvent(
+                        "mockChatModel", List.of(new ChatMessage(MessageRole.USER, orderId))));
+    }
+
+    @Action(EventType.ChatResponseEvent)
+    public static void emitResult(Event event, RunnerContext ctx) {
+        ChatResponseEvent responseEvent = ChatResponseEvent.fromEvent(event);
+        ctx.sendEvent(new OutputEvent(responseEvent.getResponse().getContent()));
+    }
+}

--- a/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/ToolParameterInjectionTest.java
+++ b/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/ToolParameterInjectionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.integration.test;
+
+import org.apache.flink.agents.api.AgentsExecutionEnvironment;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.CloseableIterator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/** E2E tests for tool parameter injection. */
+public class ToolParameterInjectionTest {
+
+    @Test
+    public void testToolParameterInjectionFlinkJob() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+
+        DataStream<String> inputStream = env.fromElements("order-1", "order-2");
+        AgentsExecutionEnvironment agentsEnv =
+                AgentsExecutionEnvironment.getExecutionEnvironment(env);
+        agentsEnv.getConfig().setStr("tenant_id", "tenant-java");
+
+        DataStream<Object> outputStream =
+                agentsEnv
+                        .fromDataStream(
+                                inputStream, new ToolParameterInjectionAgent.OrderKeySelector())
+                        .apply(new ToolParameterInjectionAgent())
+                        .toDataStream();
+
+        CloseableIterator<Object> results = outputStream.collectAsync();
+        agentsEnv.execute();
+
+        List<String> actual = new ArrayList<>();
+        while (results.hasNext()) {
+            actual.add(String.valueOf(results.next()));
+        }
+        actual.sort(Comparator.naturalOrder());
+
+        Assertions.assertEquals(
+                List.of("checked:tenant-java:order-1", "checked:tenant-java:order-2"), actual);
+    }
+}

--- a/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/yaml/YamlChatActions.java
+++ b/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/yaml/YamlChatActions.java
@@ -79,6 +79,17 @@ public final class YamlChatActions {
     }
 
     /**
+     * Query an order in the injected tenant. Referenced by the YAML parameter-injection fixture;
+     * the {@code tenant_id} parameter is declared as injected in YAML, not on this method.
+     */
+    @Tool(description = "Query order in the current tenant")
+    public static String queryOrder(
+            @ToolParam(name = "order_id", description = "The order id") String orderId,
+            @ToolParam(name = "tenant_id", description = "The tenant id") String tenantId) {
+        return "yaml-checked:" + tenantId + ":" + orderId;
+    }
+
+    /**
      * Route the incoming text to the math or creative chat model. The math model has access to the
      * {@code add} tool; the creative model does not. Routing is a simple keyword check on the
      * input. Stash the record's {@code id} in short-term memory so {@code processChatResponse} can

--- a/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/yaml/YamlToolParameterInjectionIntegrationTest.java
+++ b/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/yaml/YamlToolParameterInjectionIntegrationTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.integration.test.yaml;
+
+import org.apache.flink.agents.api.AgentsExecutionEnvironment;
+import org.apache.flink.agents.integration.test.ToolParameterInjectionAgent;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.CloseableIterator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** End-to-end tests for YAML-declared tool parameter injection. */
+public class YamlToolParameterInjectionIntegrationTest {
+
+    /**
+     * YAML {@code injected_args} hides {@code tenant_id} from schema and injects it at call time.
+     */
+    @Test
+    public void testYamlToolParameterInjectionAgent() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+
+        DataStream<String> inputStream = env.fromData("order-1", "order-2");
+
+        AgentsExecutionEnvironment agentsEnv =
+                AgentsExecutionEnvironment.getExecutionEnvironment(env);
+        agentsEnv.getConfig().setStr("tenant_id", "tenant-yaml");
+        agentsEnv.loadYaml(yamlFixture("yaml_tool_parameter_injection_agent.yaml"));
+
+        DataStream<Object> outputStream =
+                agentsEnv
+                        .fromDataStream(
+                                inputStream, new ToolParameterInjectionAgent.OrderKeySelector())
+                        .apply("yaml_tool_parameter_injection_agent")
+                        .toDataStream();
+
+        CloseableIterator<Object> results = outputStream.collectAsync();
+        agentsEnv.execute();
+
+        List<String> actual = new ArrayList<>();
+        while (results.hasNext()) {
+            actual.add(String.valueOf(results.next()));
+        }
+        actual.sort(String::compareTo);
+
+        Assertions.assertEquals(
+                List.of("yaml-checked:tenant-yaml:order-1", "yaml-checked:tenant-yaml:order-2"),
+                actual);
+    }
+
+    private static Path yamlFixture(String name) {
+        URL resource =
+                YamlToolParameterInjectionIntegrationTest.class
+                        .getClassLoader()
+                        .getResource("yaml/" + name);
+        Objects.requireNonNull(resource, "fixture not found on classpath: yaml/" + name);
+        return Paths.get(resource.getPath());
+    }
+}

--- a/e2e-test/flink-agents-end-to-end-tests-integration/src/test/resources/yaml/yaml_tool_parameter_injection_agent.yaml
+++ b/e2e-test/flink-agents-end-to-end-tests-integration/src/test/resources/yaml/yaml_tool_parameter_injection_agent.yaml
@@ -1,0 +1,36 @@
+agents:
+  - name: yaml_tool_parameter_injection_agent
+    description: YAML-driven e2e agent with declarative tool parameter injection.
+
+    chat_model_connections:
+      - name: mockChatConnection
+        type: java
+        clazz: org.apache.flink.agents.integration.test.ToolParameterInjectionAgent$MockToolChatConnection
+
+    chat_model_setups:
+      - name: mockChatModel
+        type: java
+        clazz: org.apache.flink.agents.integration.test.ToolParameterInjectionAgent$MockToolChatModel
+        connection: mockChatConnection
+        model: mock
+        tools: [queryOrder]
+
+    tools:
+      - name: queryOrder
+        type: java
+        function: org.apache.flink.agents.integration.test.yaml.YamlChatActions:queryOrder
+        parameter_types: [java.lang.String, java.lang.String]
+        injected_args:
+          tenant_id:
+            source: config
+            key: tenant_id
+
+    actions:
+      - name: request_tool
+        type: java
+        function: org.apache.flink.agents.integration.test.ToolParameterInjectionAgent:requestTool
+        trigger_conditions: [input]
+      - name: emit_result
+        type: java
+        function: org.apache.flink.agents.integration.test.ToolParameterInjectionAgent:emitResult
+        trigger_conditions: [chat_response]

--- a/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
@@ -22,7 +22,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.flink.agents.api.agents.Agent;
-import org.apache.flink.agents.api.annotation.*;
+import org.apache.flink.agents.api.annotation.ChatModelConnection;
+import org.apache.flink.agents.api.annotation.ChatModelSetup;
+import org.apache.flink.agents.api.annotation.EmbeddingModelConnection;
+import org.apache.flink.agents.api.annotation.EmbeddingModelSetup;
+import org.apache.flink.agents.api.annotation.MCPServer;
+import org.apache.flink.agents.api.annotation.Prompt;
+import org.apache.flink.agents.api.annotation.Tool;
+import org.apache.flink.agents.api.annotation.VectorStore;
+import org.apache.flink.agents.api.function.JavaFunctionUtils;
 import org.apache.flink.agents.api.resource.Resource;
 import org.apache.flink.agents.api.resource.ResourceDescriptor;
 import org.apache.flink.agents.api.resource.ResourceType;
@@ -31,6 +39,8 @@ import org.apache.flink.agents.api.resource.python.PythonResourceWrapper;
 import org.apache.flink.agents.api.skills.SkillSourceSpec;
 import org.apache.flink.agents.api.skills.Skills;
 import org.apache.flink.agents.api.tools.ToolMetadata;
+import org.apache.flink.agents.api.tools.ToolParameterInjection;
+import org.apache.flink.agents.api.tools.ToolParameterInjectionValidator;
 import org.apache.flink.agents.plan.actions.Action;
 import org.apache.flink.agents.plan.actions.ChatModelAction;
 import org.apache.flink.agents.plan.actions.ContextRetrievalAction;
@@ -343,7 +353,8 @@ public class AgentPlan implements Serializable {
         JavaFunction javaFunction =
                 new JavaFunction(method.getDeclaringClass(), method.getName(), paramTypes);
 
-        FunctionTool tool = new FunctionTool(metadata, javaFunction);
+        FunctionTool tool =
+                new FunctionTool(metadata, javaFunction, FunctionTool.getInjectedArgs(method));
         JavaSerializableResourceProvider provider =
                 JavaSerializableResourceProvider.createResourceProvider(name, TOOL, tool);
 
@@ -658,11 +669,9 @@ public class AgentPlan implements Serializable {
         if (f instanceof org.apache.flink.agents.api.function.JavaFunction) {
             org.apache.flink.agents.api.function.JavaFunction jf =
                     (org.apache.flink.agents.api.function.JavaFunction) f;
-            Class<?>[] params = resolveParameterTypes(jf.getParameterTypes());
-            Class<?> clazz =
-                    Class.forName(
-                            jf.getQualName(), true, Thread.currentThread().getContextClassLoader());
-            return new org.apache.flink.agents.plan.JavaFunction(clazz, jf.getMethodName(), params);
+            Method method = JavaFunctionUtils.resolveMethod(jf);
+            return new org.apache.flink.agents.plan.JavaFunction(
+                    method.getDeclaringClass(), method.getName(), method.getParameterTypes());
         }
         if (f instanceof org.apache.flink.agents.api.function.PythonFunction) {
             org.apache.flink.agents.api.function.PythonFunction pf =
@@ -671,40 +680,6 @@ public class AgentPlan implements Serializable {
                     pf.getModule(), pf.getQualName());
         }
         throw new IllegalStateException("Unknown api.function.Function: " + f);
-    }
-
-    private static Class<?>[] resolveParameterTypes(List<String> names)
-            throws ClassNotFoundException {
-        Class<?>[] out = new Class<?>[names.size()];
-        for (int i = 0; i < names.size(); i++) {
-            out[i] = resolveParameterType(names.get(i));
-        }
-        return out;
-    }
-
-    private static Class<?> resolveParameterType(String name) throws ClassNotFoundException {
-        switch (name) {
-            case "boolean":
-                return boolean.class;
-            case "byte":
-                return byte.class;
-            case "short":
-                return short.class;
-            case "int":
-                return int.class;
-            case "long":
-                return long.class;
-            case "float":
-                return float.class;
-            case "double":
-                return double.class;
-            case "char":
-                return char.class;
-            case "void":
-                return void.class;
-            default:
-                return Class.forName(name, true, Thread.currentThread().getContextClassLoader());
-        }
     }
 
     /**
@@ -718,15 +693,21 @@ public class AgentPlan implements Serializable {
         if (func instanceof org.apache.flink.agents.api.function.JavaFunction) {
             org.apache.flink.agents.api.function.JavaFunction jf =
                     (org.apache.flink.agents.api.function.JavaFunction) func;
-            Class<?>[] params = resolveParameterTypes(jf.getParameterTypes());
-            Class<?> clazz =
-                    Class.forName(
-                            jf.getQualName(), true, Thread.currentThread().getContextClassLoader());
-            Method method = clazz.getMethod(jf.getMethodName(), params);
-            ToolMetadata metadata = ToolMetadataFactory.fromStaticMethod(method);
+            Method method = JavaFunctionUtils.resolveMethod(jf);
+            Map<String, ToolParameterInjection> injectedArgs =
+                    mergeInjectedArgs(
+                            FunctionTool.getInjectedArgs(method),
+                            apiTool.getInjectedArgs(),
+                            resourceName);
+            ToolParameterInjectionValidator.validate(func, injectedArgs, resourceName);
+            ToolMetadata metadata =
+                    ToolMetadataFactory.fromStaticMethod(method, injectedArgs.keySet());
             org.apache.flink.agents.plan.JavaFunction planFunc =
-                    new org.apache.flink.agents.plan.JavaFunction(clazz, method.getName(), params);
-            FunctionTool tool = new FunctionTool(metadata, planFunc);
+                    new org.apache.flink.agents.plan.JavaFunction(
+                            method.getDeclaringClass(),
+                            method.getName(),
+                            method.getParameterTypes());
+            FunctionTool tool = new FunctionTool(metadata, planFunc, injectedArgs);
             addResourceProvider(
                     JavaSerializableResourceProvider.createResourceProvider(
                             resourceName, TOOL, tool));
@@ -739,7 +720,7 @@ public class AgentPlan implements Serializable {
             // Placeholder metadata: ResourceCache will replace it with introspected values from
             // the Python bridge via FunctionTool.setPythonResourceAdapter at first resolve.
             ToolMetadata metadata = new ToolMetadata(resourceName, "", "{}");
-            FunctionTool tool = new FunctionTool(metadata, planFunc);
+            FunctionTool tool = new FunctionTool(metadata, planFunc, apiTool.getInjectedArgs());
             addResourceProvider(
                     JavaSerializableResourceProvider.createResourceProvider(
                             resourceName, TOOL, tool));
@@ -747,5 +728,31 @@ public class AgentPlan implements Serializable {
             throw new IllegalStateException(
                     "Unknown api.function.Function for tool '" + resourceName + "': " + func);
         }
+    }
+
+    private static Map<String, ToolParameterInjection> mergeInjectedArgs(
+            Map<String, ToolParameterInjection> annotatedArgs,
+            Map<String, ToolParameterInjection> declaredArgs,
+            String resourceName) {
+        Map<String, ToolParameterInjection> merged = new LinkedHashMap<>();
+        if (annotatedArgs != null) {
+            merged.putAll(annotatedArgs);
+        }
+        if (declaredArgs != null) {
+            declaredArgs.forEach(
+                    (name, injection) -> {
+                        ToolParameterInjection existing = merged.get(name);
+                        if (existing != null && !existing.equals(injection)) {
+                            throw new IllegalArgumentException(
+                                    "Tool '"
+                                            + resourceName
+                                            + "': injected_args conflict for parameter '"
+                                            + name
+                                            + "' between @ToolParam and descriptor.");
+                        }
+                        merged.put(name, injection);
+                    });
+        }
+        return Map.copyOf(merged);
     }
 }

--- a/plan/src/main/java/org/apache/flink/agents/plan/actions/ToolCallAction.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/actions/ToolCallAction.java
@@ -19,15 +19,20 @@ package org.apache.flink.agents.plan.actions;
 
 import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.api.agents.AgentExecutionOptions;
+import org.apache.flink.agents.api.configuration.ConfigOption;
 import org.apache.flink.agents.api.context.DurableCallable;
+import org.apache.flink.agents.api.context.MemoryObject;
 import org.apache.flink.agents.api.context.RunnerContext;
 import org.apache.flink.agents.api.event.ToolRequestEvent;
 import org.apache.flink.agents.api.event.ToolResponseEvent;
 import org.apache.flink.agents.api.resource.ResourceType;
 import org.apache.flink.agents.api.tools.Tool;
+import org.apache.flink.agents.api.tools.ToolParameterInjection;
+import org.apache.flink.agents.api.tools.ToolParameterSource;
 import org.apache.flink.agents.api.tools.ToolParameters;
 import org.apache.flink.agents.api.tools.ToolResponse;
 import org.apache.flink.agents.plan.JavaFunction;
+import org.apache.flink.agents.plan.tools.FunctionTool;
 
 import java.util.HashMap;
 import java.util.List;
@@ -59,25 +64,29 @@ public class ToolCallAction {
             Map<String, Object> function = (Map<String, Object>) toolCall.get("function");
             String name = (String) function.get("name");
             Map<String, Object> arguments = (Map<String, Object>) function.get("arguments");
+            Map<String, Object> mergedArguments =
+                    arguments == null ? new HashMap<>() : new HashMap<>(arguments);
 
             if (toolCall.containsKey("original_id")) {
                 externalIds.put(id, (String) toolCall.get("original_id"));
             }
 
             Tool tool = null;
+            String diagnosticError = null;
             try {
                 tool = (Tool) ctx.getResource(name, ResourceType.TOOL);
             } catch (Exception e) {
-                success.put(id, false);
-                responses.put(
-                        id, ToolResponse.error(String.format("Tool %s does not exist.", name)));
-                error.put(id, e.getMessage());
+                diagnosticError = e.getMessage();
             }
 
             if (tool != null) {
                 try {
+                    // Framework-owned injected args must win over model-provided values so hidden
+                    // context such as tenant ids cannot be spoofed by a tool call payload.
+                    mergedArguments.putAll(resolveInjectedArguments(tool, ctx));
                     ToolResponse response;
                     final Tool toolRef = tool;
+                    final Map<String, Object> callArguments = mergedArguments;
                     DurableCallable<ToolResponse> callable =
                             new DurableCallable<>() {
                                 @Override
@@ -92,24 +101,87 @@ public class ToolCallAction {
 
                                 @Override
                                 public ToolResponse call() throws Exception {
-                                    return toolRef.call(new ToolParameters(arguments));
+                                    return toolRef.call(new ToolParameters(callArguments));
                                 }
                             };
                     response =
                             toolCallAsync
                                     ? ctx.durableExecuteAsync(callable)
                                     : ctx.durableExecute(callable);
-                    success.put(id, true);
+                    success.put(id, response.isSuccess());
                     responses.put(id, response);
+                    if (!response.isSuccess() && response.getError() != null) {
+                        error.put(id, response.getError());
+                    }
                 } catch (Exception e) {
                     success.put(id, false);
                     responses.put(
                             id, ToolResponse.error(String.format("Tool %s execute failed.", name)));
                     error.put(id, e.getMessage());
                 }
+            } else {
+                success.put(id, false);
+                responses.put(
+                        id, ToolResponse.error(String.format("Tool %s does not exist.", name)));
+                error.put(id, diagnosticError != null ? diagnosticError : "Tool does not exist.");
             }
         }
         ctx.sendEvent(
                 new ToolResponseEvent(toolRequest.getId(), responses, success, error, externalIds));
+    }
+
+    private static Map<String, Object> resolveInjectedArguments(Tool tool, RunnerContext ctx)
+            throws Exception {
+        Map<String, Object> result = new HashMap<>();
+        if (!(tool instanceof FunctionTool)) {
+            return result;
+        }
+        FunctionTool functionTool = (FunctionTool) tool;
+        for (Map.Entry<String, ToolParameterInjection> entry :
+                functionTool.getInjectedArgs().entrySet()) {
+            result.put(entry.getKey(), resolveInjectedArgument(entry.getValue(), ctx));
+        }
+        return result;
+    }
+
+    private static Object resolveInjectedArgument(
+            ToolParameterInjection injection, RunnerContext ctx) throws Exception {
+        String key = injection.getKey();
+        ToolParameterSource source = injection.getSource();
+        switch (source) {
+            case CONFIG:
+                Object value = ctx.getConfig().get(new ConfigOption<>(key, Object.class, null));
+                if (value == null) {
+                    throw new IllegalArgumentException(
+                            "Missing config for injected tool parameter: " + key);
+                }
+                return value;
+            case SENSORY_MEMORY:
+                return getMemoryValue(ctx.getSensoryMemory(), "sensory_memory", key);
+            case SHORT_TERM_MEMORY:
+                return getMemoryValue(ctx.getShortTermMemory(), "short_term_memory", key);
+            default:
+                throw new IllegalArgumentException("Unsupported tool parameter source: " + source);
+        }
+    }
+
+    private static Object getMemoryValue(MemoryObject memory, String source, String path)
+            throws Exception {
+        if (memory == null) {
+            throw new IllegalStateException(
+                    "Cannot inject tool parameter from "
+                            + source
+                            + " because memory is not initialized.");
+        }
+        if (!memory.isExist(path)) {
+            throw new IllegalArgumentException(
+                    "Missing memory path for injected tool parameter: " + path);
+        }
+        MemoryObject value = memory.get(path);
+        if (value == null || value.isNestedObject()) {
+            throw new IllegalArgumentException(
+                    "Memory path for injected tool parameter must reference a value: " + path);
+        }
+        return value.getValue();
     }
 }

--- a/plan/src/main/java/org/apache/flink/agents/plan/tools/FunctionTool.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/tools/FunctionTool.java
@@ -21,12 +21,15 @@
 package org.apache.flink.agents.plan.tools;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.flink.agents.api.annotation.ToolParam;
 import org.apache.flink.agents.api.resource.python.PythonResourceAdapter;
 import org.apache.flink.agents.api.tools.Tool;
 import org.apache.flink.agents.api.tools.ToolMetadata;
+import org.apache.flink.agents.api.tools.ToolParameterInjection;
 import org.apache.flink.agents.api.tools.ToolParameters;
 import org.apache.flink.agents.api.tools.ToolResponse;
 import org.apache.flink.agents.api.tools.ToolType;
@@ -40,6 +43,8 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -51,14 +56,25 @@ import java.util.Map;
 @JsonDeserialize(using = FunctionToolJsonDeserializer.class)
 public class FunctionTool extends Tool {
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     private final Function function;
+    private Map<String, ToolParameterInjection> injectedArgs;
 
     @JsonIgnore private transient PythonResourceAdapter pythonResourceAdapter;
 
     /** Create a FunctionTool from ToolMetadata and Function */
     public FunctionTool(ToolMetadata metadata, Function function) {
+        this(metadata, function, Map.of());
+    }
+
+    public FunctionTool(
+            ToolMetadata metadata,
+            Function function,
+            Map<String, ToolParameterInjection> injectedArgs) {
         super(metadata);
         this.function = function;
+        this.injectedArgs = normalizeInjectedArgs(injectedArgs);
     }
 
     /** Create a FunctionTool from a static method annotated with @Tool */
@@ -72,14 +88,18 @@ public class FunctionTool extends Tool {
                 method.getAnnotation(org.apache.flink.agents.api.annotation.Tool.class);
         String name = method.getName();
         String description = toolAnnotation != null ? toolAnnotation.description() : "";
+        Map<String, ToolParameterInjection> injectedArgs = getInjectedArgs(method);
 
         ToolMetadata metadata =
-                new ToolMetadata(name, description, SchemaUtils.generateSchema(method));
+                new ToolMetadata(
+                        name,
+                        description,
+                        SchemaUtils.generateSchema(method, injectedArgs.keySet()));
         JavaFunction javaFunction =
                 new JavaFunction(
                         method.getDeclaringClass(), method.getName(), method.getParameterTypes());
 
-        return new FunctionTool(metadata, javaFunction);
+        return new FunctionTool(metadata, javaFunction, injectedArgs);
     }
 
     /**
@@ -92,15 +112,16 @@ public class FunctionTool extends Tool {
             throw new IllegalArgumentException(
                     "FunctionTool only supports static methods. Method: " + method.getName());
         }
+        Map<String, ToolParameterInjection> injectedArgs = getInjectedArgs(method);
         ToolMetadata metadata =
                 new ToolMetadata(
                         method.getName(),
                         description != null ? description : "",
-                        SchemaUtils.generateSchema(method));
+                        SchemaUtils.generateSchema(method, injectedArgs.keySet()));
         JavaFunction javaFunction =
                 new JavaFunction(
                         method.getDeclaringClass(), method.getName(), method.getParameterTypes());
-        return new FunctionTool(metadata, javaFunction);
+        return new FunctionTool(metadata, javaFunction, injectedArgs);
     }
 
     @Override
@@ -156,6 +177,8 @@ public class FunctionTool extends Tool {
                                     + "' has no PythonResourceAdapter; runtime should inject one"
                                     + " before invocation."));
         }
+        // ToolCallAction resolves injected parameters before FunctionTool is invoked; this adapter
+        // only forwards the final keyword arguments across the language boundary.
         Map<String, Object> kwargs = new HashMap<>();
         for (String name : parameters.getParameterNames()) {
             kwargs.put(name, parameters.getParameter(name));
@@ -169,6 +192,14 @@ public class FunctionTool extends Tool {
         return function;
     }
 
+    public Map<String, ToolParameterInjection> getInjectedArgs() {
+        return injectedArgs;
+    }
+
+    public List<String> getInjectedArgNames() {
+        return List.copyOf(injectedArgs.keySet());
+    }
+
     /**
      * Refresh this tool's metadata via the Python bridge when the underlying function is a {@link
      * PythonFunction}. No-op for Java-backed tools.
@@ -176,7 +207,9 @@ public class FunctionTool extends Tool {
      * <p>Called by the runtime resource cache the first time the tool is resolved, so the
      * placeholder metadata that {@code AgentPlan.registerApiFunctionTool} writes for Python tools
      * gets replaced with real introspected values (name, description, inputSchema) sourced from the
-     * Python callable's signature and docstring.
+     * Python callable's signature and docstring. Callable-declared injected args returned by the
+     * bridge are merged into this tool so the Java-side ToolCallAction can inject them at execution
+     * time.
      */
     public void setPythonResourceAdapter(PythonResourceAdapter adapter) {
         if (!(function instanceof PythonFunction)) {
@@ -184,11 +217,85 @@ public class FunctionTool extends Tool {
         }
         this.pythonResourceAdapter = adapter;
         PythonFunction pf = (PythonFunction) function;
-        Map<String, String> flat = adapter.getPythonToolMetadata(pf.getModule(), pf.getQualName());
+        Map<String, String> flat =
+                adapter.getPythonToolMetadata(
+                        pf.getModule(), pf.getQualName(), getInjectedArgNames());
+        this.injectedArgs =
+                mergeInjectedArgs(
+                        parseInjectedArgs(flat.get("injectedArgs")),
+                        this.injectedArgs,
+                        flat.getOrDefault("name", pf.getQualName()));
         setMetadata(
                 new ToolMetadata(
                         flat.get("name"),
                         flat.getOrDefault("description", ""),
                         flat.getOrDefault("inputSchema", "{}")));
+    }
+
+    public static Map<String, ToolParameterInjection> getInjectedArgs(Method method) {
+        Map<String, ToolParameterInjection> result = new LinkedHashMap<>();
+        for (Parameter parameter : method.getParameters()) {
+            if (!parameter.isAnnotationPresent(ToolParam.class)) {
+                continue;
+            }
+            ToolParam toolParam = parameter.getAnnotation(ToolParam.class);
+            if (!toolParam.injected()) {
+                continue;
+            }
+            String name = toolParam.name().isEmpty() ? parameter.getName() : toolParam.name();
+            ToolParameterInjection injection =
+                    new ToolParameterInjection(toolParam.source(), toolParam.key())
+                            .withDefaultKey(name);
+            result.put(name, injection);
+        }
+        return result;
+    }
+
+    private static Map<String, ToolParameterInjection> parseInjectedArgs(String payload) {
+        if (payload == null || payload.isEmpty()) {
+            return Map.of();
+        }
+        try {
+            return normalizeInjectedArgs(
+                    OBJECT_MAPPER.readValue(
+                            payload, new TypeReference<Map<String, ToolParameterInjection>>() {}));
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to parse Python tool injectedArgs.", e);
+        }
+    }
+
+    private static Map<String, ToolParameterInjection> mergeInjectedArgs(
+            Map<String, ToolParameterInjection> annotatedArgs,
+            Map<String, ToolParameterInjection> declaredArgs,
+            String toolName) {
+        Map<String, ToolParameterInjection> merged = new LinkedHashMap<>();
+        if (annotatedArgs != null) {
+            merged.putAll(annotatedArgs);
+        }
+        if (declaredArgs != null) {
+            declaredArgs.forEach(
+                    (name, injection) -> {
+                        ToolParameterInjection existing = merged.get(name);
+                        if (existing != null && !existing.equals(injection)) {
+                            throw new IllegalArgumentException(
+                                    "Tool '"
+                                            + toolName
+                                            + "': injected_args conflict for parameter '"
+                                            + name
+                                            + "' between callable annotation and descriptor.");
+                        }
+                        merged.put(name, injection);
+                    });
+        }
+        return Map.copyOf(merged);
+    }
+
+    private static Map<String, ToolParameterInjection> normalizeInjectedArgs(
+            Map<String, ToolParameterInjection> injectedArgs) {
+        Map<String, ToolParameterInjection> result = new LinkedHashMap<>();
+        if (injectedArgs != null) {
+            injectedArgs.forEach((name, spec) -> result.put(name, spec.withDefaultKey(name)));
+        }
+        return Map.copyOf(result);
     }
 }

--- a/plan/src/main/java/org/apache/flink/agents/plan/tools/SchemaUtils.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/tools/SchemaUtils.java
@@ -26,32 +26,52 @@ import org.apache.flink.agents.api.annotation.ToolParam;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 public class SchemaUtils {
     /** Generate JSON schema from method signature for tool parameters. */
     public static String generateSchema(Method method) throws JsonProcessingException {
+        return generateSchema(method, Set.of());
+    }
+
+    /**
+     * Generate JSON schema from method signature for model-visible tool parameters.
+     *
+     * <p>Injected parameters may be declared either on the Java method via {@link ToolParam} or
+     * externally, for example by YAML/API descriptors. Both forms must be hidden from the
+     * model-facing schema.
+     */
+    public static String generateSchema(Method method, Collection<String> injectedParamNames)
+            throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
         Map<String, Object> schema = new HashMap<>();
         schema.put("type", "object");
 
         Map<String, Object> properties = new HashMap<>();
         List<String> required = new java.util.ArrayList<>();
+        Set<String> injected =
+                injectedParamNames == null ? Set.of() : new HashSet<>(injectedParamNames);
 
         Parameter[] parameters = method.getParameters();
         for (Parameter param : parameters) {
+            ToolParam toolParam = param.getAnnotation(ToolParam.class);
             String paramName = param.getName();
             String paramDescription = null;
 
             // Check for custom parameter name from annotation
-            if (param.isAnnotationPresent(ToolParam.class)) {
-                ToolParam toolParam = param.getAnnotation(ToolParam.class);
-                if (!Objects.requireNonNull(toolParam).name().isEmpty()) {
-                    paramName = toolParam.name();
-                }
+            if (toolParam != null && !Objects.requireNonNull(toolParam).name().isEmpty()) {
+                paramName = toolParam.name();
+            }
+            if ((toolParam != null && toolParam.injected()) || injected.contains(paramName)) {
+                continue;
+            }
+            if (toolParam != null) {
                 if (toolParam.required()) {
                     required.add(paramName);
                 }

--- a/plan/src/main/java/org/apache/flink/agents/plan/tools/ToolMetadataFactory.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/tools/ToolMetadataFactory.java
@@ -26,6 +26,8 @@ import org.apache.flink.agents.api.tools.ToolMetadata;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.Collection;
+import java.util.Set;
 
 /**
  * Plan-level utility for creating ToolMetadata from annotated methods. it handles the
@@ -35,6 +37,11 @@ public class ToolMetadataFactory {
 
     /** Create ToolMetadata from a static method annotated with @Tool. */
     public static ToolMetadata fromStaticMethod(Method method) throws JsonProcessingException {
+        return fromStaticMethod(method, Set.of());
+    }
+
+    public static ToolMetadata fromStaticMethod(
+            Method method, Collection<String> injectedParamNames) throws JsonProcessingException {
         if (!Modifier.isStatic(method.getModifiers())) {
             throw new IllegalArgumentException("Only static methods are supported");
         }
@@ -46,7 +53,7 @@ public class ToolMetadataFactory {
 
         String name = method.getName();
         String description = toolAnnotation.description();
-        String schema = SchemaUtils.generateSchema(method);
+        String schema = SchemaUtils.generateSchema(method, injectedParamNames);
 
         return new ToolMetadata(name, description, schema);
     }

--- a/plan/src/main/java/org/apache/flink/agents/plan/tools/serializer/FunctionToolJsonDeserializer.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/tools/serializer/FunctionToolJsonDeserializer.java
@@ -24,12 +24,15 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import org.apache.flink.agents.api.tools.ToolMetadata;
+import org.apache.flink.agents.api.tools.ToolParameterInjection;
 import org.apache.flink.agents.plan.Function;
 import org.apache.flink.agents.plan.JavaFunction;
 import org.apache.flink.agents.plan.PythonFunction;
 import org.apache.flink.agents.plan.tools.FunctionTool;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Custom deserializer for {@link FunctionTool} that handles the deserialization of the metadata and
@@ -61,7 +64,30 @@ public class FunctionToolJsonDeserializer extends StdDeserializer<FunctionTool> 
             throw new IOException("Unsupported function type: " + funcType);
         }
 
-        return new FunctionTool(metadata, func);
+        Map<String, ToolParameterInjection> injectedArgs = new LinkedHashMap<>();
+        JsonNode injectedArgsNode = node.get("injected_args");
+        if (injectedArgsNode != null && injectedArgsNode.isObject()) {
+            ObjectMapper mapper = new ObjectMapper();
+            injectedArgsNode
+                    .fields()
+                    .forEachRemaining(
+                            entry -> {
+                                try {
+                                    injectedArgs.put(
+                                            entry.getKey(),
+                                            mapper.treeToValue(
+                                                            entry.getValue(),
+                                                            ToolParameterInjection.class)
+                                                    .withDefaultKey(entry.getKey()));
+                                } catch (IOException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+        } else if (injectedArgsNode != null && !injectedArgsNode.isNull()) {
+            throw new IOException("'injected_args' must be an object.");
+        }
+
+        return new FunctionTool(metadata, func, injectedArgs);
     }
 
     private PythonFunction deserializePythonFunction(JsonNode execNode) {

--- a/plan/src/main/java/org/apache/flink/agents/plan/tools/serializer/FunctionToolJsonSerializer.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/tools/serializer/FunctionToolJsonSerializer.java
@@ -46,6 +46,7 @@ public class FunctionToolJsonSerializer extends StdSerializer<FunctionTool> {
         jsonGenerator.writeStartObject();
 
         jsonGenerator.writeObjectField("metadata", tool.getMetadata());
+        jsonGenerator.writeObjectField("injected_args", tool.getInjectedArgs());
 
         jsonGenerator.writeFieldName("function");
         if (tool.getFunction() instanceof JavaFunction) {

--- a/plan/src/test/java/org/apache/flink/agents/plan/AgentPlanDeclareToolMethodTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/AgentPlanDeclareToolMethodTest.java
@@ -20,6 +20,7 @@
 
 package org.apache.flink.agents.plan;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.api.EventType;
@@ -32,16 +33,24 @@ import org.apache.flink.agents.api.resource.ResourceContext;
 import org.apache.flink.agents.api.resource.ResourceType;
 import org.apache.flink.agents.api.tools.Tool;
 import org.apache.flink.agents.api.tools.ToolMetadata;
+import org.apache.flink.agents.api.tools.ToolParameterInjection;
+import org.apache.flink.agents.api.tools.ToolParameterSource;
 import org.apache.flink.agents.api.tools.ToolParameters;
 import org.apache.flink.agents.api.tools.ToolResponse;
+import org.apache.flink.agents.api.yaml.YamlLoader;
 import org.apache.flink.agents.plan.resourceprovider.ResourceProvider;
+import org.apache.flink.agents.plan.tools.FunctionTool;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -82,6 +91,18 @@ class AgentPlanDeclareToolMethodTest {
             return String.format(
                     "Weather in %s: %.1f°%s, Sunny",
                     location, temp, "fahrenheit".equals(units) ? "F" : "C");
+        }
+
+        @org.apache.flink.agents.api.annotation.Tool(description = "Query an order")
+        public static String queryOrder(
+                @ToolParam(name = "order_id") String orderId,
+                @ToolParam(
+                                name = "tenant_id",
+                                injected = true,
+                                source = ToolParameterSource.CONFIG,
+                                key = "tenant.id")
+                        String tenantId) {
+            return tenantId + ":" + orderId;
         }
 
         @Action(EventType.InputEvent)
@@ -190,6 +211,185 @@ class AgentPlanDeclareToolMethodTest {
                                         "getWeather", String.class, String.class)));
         AgentPlan addedPlan = new AgentPlan(agent);
         checkToolCall(addedPlan);
+    }
+
+    @Test
+    @DisplayName("Validate injected args on tools added to agent instance")
+    void validateInjectedArgsOnAgentAddedTool() throws Exception {
+        Agent agent = new Agent();
+        agent.addResource(
+                "getWeather",
+                ResourceType.TOOL,
+                new org.apache.flink.agents.api.tools.FunctionTool(
+                        org.apache.flink.agents.api.function.JavaFunction.fromMethod(
+                                TestAgent.class.getMethod(
+                                        "getWeather", String.class, String.class)),
+                        Map.of("tenent_id", ToolParameterInjection.fromConfig("tenant_id"))));
+
+        assertThatThrownBy(() -> new AgentPlan(agent))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unknown parameter")
+                .hasMessageContaining("tenent_id");
+    }
+
+    @Test
+    @DisplayName("Injected args declared on API function tool are hidden from Java metadata")
+    void hideApiFunctionToolInjectedArgsFromJavaMetadata() throws Exception {
+        Agent agent = new Agent();
+        agent.addResource(
+                "getWeather",
+                ResourceType.TOOL,
+                new org.apache.flink.agents.api.tools.FunctionTool(
+                        org.apache.flink.agents.api.function.JavaFunction.fromMethod(
+                                TestAgent.class.getMethod(
+                                        "getWeather", String.class, String.class)),
+                        Map.of("units", ToolParameterInjection.fromConfig("units"))));
+
+        AgentPlan plan = new AgentPlan(agent);
+        Tool weather =
+                (Tool)
+                        plan.getResourceProviders()
+                                .get(ResourceType.TOOL)
+                                .get("getWeather")
+                                .provide(
+                                        ResourceContext.fromGetResource(
+                                                (n, t) -> {
+                                                    throw new UnsupportedOperationException(
+                                                            "No dependencies expected");
+                                                }));
+        String schema = weather.getMetadata().getInputSchema();
+        JsonNode properties = new ObjectMapper().readTree(schema).get("properties");
+
+        assertTrue(properties.has("location"));
+        assertFalse(properties.has("units"));
+    }
+
+    @Test
+    @DisplayName("Annotation-only injected args are preserved on API function tools")
+    void preserveAnnotationOnlyInjectedArgsOnApiFunctionTool() throws Exception {
+        Agent agent = new Agent();
+        agent.addResource(
+                "queryOrder",
+                ResourceType.TOOL,
+                new org.apache.flink.agents.api.tools.FunctionTool(
+                        org.apache.flink.agents.api.function.JavaFunction.fromMethod(
+                                TestAgent.class.getMethod(
+                                        "queryOrder", String.class, String.class))));
+
+        AgentPlan plan = new AgentPlan(agent);
+        FunctionTool tool =
+                (FunctionTool)
+                        plan.getResourceProviders()
+                                .get(ResourceType.TOOL)
+                                .get("queryOrder")
+                                .provide(
+                                        ResourceContext.fromGetResource(
+                                                (n, t) -> {
+                                                    throw new UnsupportedOperationException(
+                                                            "No dependencies expected");
+                                                }));
+        JsonNode properties =
+                new ObjectMapper().readTree(tool.getMetadata().getInputSchema()).get("properties");
+
+        assertEquals(
+                Map.of("tenant_id", ToolParameterInjection.fromConfig("tenant.id")),
+                tool.getInjectedArgs());
+        assertTrue(properties.has("order_id"));
+        assertFalse(properties.has("tenant_id"));
+    }
+
+    @Test
+    @DisplayName("Matching descriptor injected args are accepted with Java annotations")
+    void acceptMatchingDescriptorInjectedArgsWithJavaAnnotations() throws Exception {
+        Agent agent = new Agent();
+        agent.addResource(
+                "queryOrder",
+                ResourceType.TOOL,
+                new org.apache.flink.agents.api.tools.FunctionTool(
+                        org.apache.flink.agents.api.function.JavaFunction.fromMethod(
+                                TestAgent.class.getMethod(
+                                        "queryOrder", String.class, String.class)),
+                        Map.of("tenant_id", ToolParameterInjection.fromConfig("tenant.id"))));
+
+        AgentPlan plan = new AgentPlan(agent);
+        FunctionTool tool =
+                (FunctionTool)
+                        plan.getResourceProviders()
+                                .get(ResourceType.TOOL)
+                                .get("queryOrder")
+                                .provide(
+                                        ResourceContext.fromGetResource(
+                                                (n, t) -> {
+                                                    throw new UnsupportedOperationException(
+                                                            "No dependencies expected");
+                                                }));
+
+        assertEquals(
+                Map.of("tenant_id", ToolParameterInjection.fromConfig("tenant.id")),
+                tool.getInjectedArgs());
+    }
+
+    @Test
+    @DisplayName("Conflicting descriptor injected args fail fast with Java annotations")
+    void rejectConflictingDescriptorInjectedArgsWithJavaAnnotations() throws Exception {
+        Agent agent = new Agent();
+        agent.addResource(
+                "queryOrder",
+                ResourceType.TOOL,
+                new org.apache.flink.agents.api.tools.FunctionTool(
+                        org.apache.flink.agents.api.function.JavaFunction.fromMethod(
+                                TestAgent.class.getMethod(
+                                        "queryOrder", String.class, String.class)),
+                        Map.of(
+                                "tenant_id",
+                                ToolParameterInjection.fromSensoryMemory("request.tenant_id"))));
+
+        assertThatThrownBy(() -> new AgentPlan(agent))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("injected_args conflict")
+                .hasMessageContaining("tenant_id");
+    }
+
+    @Test
+    @DisplayName("YAML-declared injected args are hidden from Java metadata")
+    void hideYamlInjectedArgsFromJavaMetadata(@TempDir Path tmp) throws Exception {
+        Path yaml = tmp.resolve("agent.yaml");
+        Files.writeString(
+                yaml,
+                "agents:\n"
+                        + "  - name: a\n"
+                        + "    tools:\n"
+                        + "      - name: getWeather\n"
+                        + "        type: java\n"
+                        + "        function: "
+                        + TestAgent.class.getName()
+                        + ":getWeather\n"
+                        + "        parameter_types: [java.lang.String, java.lang.String]\n"
+                        + "        injected_args:\n"
+                        + "          units:\n"
+                        + "            source: config\n"
+                        + "            key: units\n");
+
+        Agent agent = YamlLoader.buildAgents(yaml).getAgents().get("a");
+        AgentPlan plan = new AgentPlan(agent);
+        Tool weather =
+                (Tool)
+                        plan.getResourceProviders()
+                                .get(ResourceType.TOOL)
+                                .get("getWeather")
+                                .provide(
+                                        ResourceContext.fromGetResource(
+                                                (n, t) -> {
+                                                    throw new UnsupportedOperationException(
+                                                            "No dependencies expected");
+                                                }));
+        JsonNode properties =
+                new ObjectMapper()
+                        .readTree(weather.getMetadata().getInputSchema())
+                        .get("properties");
+
+        assertTrue(properties.has("location"));
+        assertFalse(properties.has("units"));
     }
 
     @Test

--- a/plan/src/test/java/org/apache/flink/agents/plan/FunctionToolPlanTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/FunctionToolPlanTest.java
@@ -20,6 +20,7 @@
 
 package org.apache.flink.agents.plan;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.flink.agents.api.agents.Agent;
@@ -28,6 +29,7 @@ import org.apache.flink.agents.api.annotation.ToolParam;
 import org.apache.flink.agents.api.resource.ResourceContext;
 import org.apache.flink.agents.api.resource.ResourceType;
 import org.apache.flink.agents.api.tools.ToolMetadata;
+import org.apache.flink.agents.api.tools.ToolParameterInjection;
 import org.apache.flink.agents.api.tools.ToolParameters;
 import org.apache.flink.agents.api.tools.ToolResponse;
 import org.apache.flink.agents.plan.tools.FunctionTool;
@@ -60,6 +62,12 @@ class FunctionToolPlanTest {
             default:
                 throw new IllegalArgumentException("Unknown operation: " + op);
         }
+    }
+
+    public static String queryOrder(
+            @ToolParam(name = "order_id") String orderId,
+            @ToolParam(name = "tenant_id", injected = true) String tenantId) {
+        return tenantId + ":" + orderId;
     }
 
     static class TestAgent extends Agent {
@@ -141,5 +149,20 @@ class FunctionToolPlanTest {
                                 new HashMap<>(Map.of("a", 10, "b", 2.5, "operation", "div"))));
         assertTrue(ok.isSuccess());
         assertEquals(4.0, (Double) ok.getResult(), 1e-9);
+    }
+
+    @Test
+    @DisplayName("Injected @ToolParam is hidden from metadata schema")
+    void injectedToolParamHiddenFromMetadata() throws Exception {
+        Method m = FunctionToolPlanTest.class.getMethod("queryOrder", String.class, String.class);
+        FunctionTool tool = FunctionTool.fromStaticMethod("query order", m);
+
+        JsonNode schema = new ObjectMapper().readTree(tool.getMetadata().getInputSchema());
+
+        assertEquals(
+                Map.of("tenant_id", ToolParameterInjection.fromSensoryMemory("tenant_id")),
+                tool.getInjectedArgs());
+        assertTrue(schema.get("properties").has("order_id"));
+        assertFalse(schema.get("properties").has("tenant_id"));
     }
 }

--- a/plan/src/test/java/org/apache/flink/agents/plan/actions/ToolCallActionTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/actions/ToolCallActionTest.java
@@ -1,0 +1,397 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.plan.actions;
+
+import org.apache.flink.agents.api.Event;
+import org.apache.flink.agents.api.annotation.ToolParam;
+import org.apache.flink.agents.api.configuration.ReadableConfiguration;
+import org.apache.flink.agents.api.context.DurableCallable;
+import org.apache.flink.agents.api.context.MemoryObject;
+import org.apache.flink.agents.api.context.MemoryRef;
+import org.apache.flink.agents.api.context.RunnerContext;
+import org.apache.flink.agents.api.event.ToolRequestEvent;
+import org.apache.flink.agents.api.event.ToolResponseEvent;
+import org.apache.flink.agents.api.memory.BaseLongTermMemory;
+import org.apache.flink.agents.api.metrics.FlinkAgentsMetricGroup;
+import org.apache.flink.agents.api.resource.Resource;
+import org.apache.flink.agents.api.resource.ResourceType;
+import org.apache.flink.agents.api.tools.Tool;
+import org.apache.flink.agents.api.tools.ToolMetadata;
+import org.apache.flink.agents.api.tools.ToolParameterInjection;
+import org.apache.flink.agents.api.tools.ToolParameters;
+import org.apache.flink.agents.api.tools.ToolResponse;
+import org.apache.flink.agents.api.tools.ToolType;
+import org.apache.flink.agents.plan.AgentConfiguration;
+import org.apache.flink.agents.plan.JavaFunction;
+import org.apache.flink.agents.plan.tools.FunctionTool;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ToolCallActionTest {
+
+    public static String queryOrder(
+            @ToolParam(name = "orderId") String orderId,
+            @ToolParam(name = "tenant_id") String tenantId) {
+        return tenantId + ":" + orderId;
+    }
+
+    static class FailingTool extends Tool {
+        FailingTool() {
+            super(new ToolMetadata("queryOrder", "Query order.", "{}"));
+        }
+
+        @Override
+        public ToolType getToolType() {
+            return ToolType.FUNCTION;
+        }
+
+        @Override
+        public ToolResponse call(ToolParameters parameters) {
+            throw new RuntimeException("database timeout");
+        }
+    }
+
+    static class FakeRunnerContext implements RunnerContext {
+        private final List<Event> sentEvents = new ArrayList<>();
+        private final AgentConfiguration config =
+                new AgentConfiguration(Map.of("tenant_id", "tenant-1"));
+        private ToolParameterInjection injection = ToolParameterInjection.fromConfig("tenant_id");
+        private MemoryObject sensoryMemory;
+        private MemoryObject shortTermMemory;
+
+        FakeRunnerContext withInjection(ToolParameterInjection injection) {
+            this.injection = injection;
+            return this;
+        }
+
+        FakeRunnerContext withSensoryMemory(Map<String, Object> values) {
+            this.sensoryMemory = new FakeMemoryObject(values);
+            return this;
+        }
+
+        FakeRunnerContext withShortTermMemory(Map<String, Object> values) {
+            this.shortTermMemory = new FakeMemoryObject(values);
+            return this;
+        }
+
+        @Override
+        public void sendEvent(Event event) {
+            sentEvents.add(event);
+        }
+
+        @Override
+        public MemoryObject getSensoryMemory() {
+            return sensoryMemory;
+        }
+
+        @Override
+        public MemoryObject getShortTermMemory() {
+            return shortTermMemory;
+        }
+
+        @Override
+        public BaseLongTermMemory getLongTermMemory() {
+            return null;
+        }
+
+        @Override
+        public FlinkAgentsMetricGroup getAgentMetricGroup() {
+            return null;
+        }
+
+        @Override
+        public FlinkAgentsMetricGroup getActionMetricGroup() {
+            return null;
+        }
+
+        @Override
+        public Resource getResource(String name, ResourceType type) throws Exception {
+            assertThat(name).isEqualTo("queryOrder");
+            assertThat(type).isEqualTo(ResourceType.TOOL);
+            return new FunctionTool(
+                    new ToolMetadata("queryOrder", "Query order.", "{}"),
+                    new JavaFunction(
+                            ToolCallActionTest.class,
+                            "queryOrder",
+                            new Class[] {String.class, String.class}),
+                    Map.of("tenant_id", injection));
+        }
+
+        @Override
+        public ReadableConfiguration getConfig() {
+            return config;
+        }
+
+        @Override
+        public Map<String, Object> getActionConfig() {
+            return Map.of();
+        }
+
+        @Override
+        public Object getActionConfigValue(String key) {
+            return null;
+        }
+
+        @Override
+        public <T> T durableExecute(DurableCallable<T> callable) throws Exception {
+            return callable.call();
+        }
+
+        @Override
+        public <T> T durableExecuteAsync(DurableCallable<T> callable) throws Exception {
+            return callable.call();
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    static class FakeMemoryObject implements MemoryObject {
+        private final Map<String, Object> values;
+        private final Object value;
+
+        FakeMemoryObject(Map<String, Object> values) {
+            this(values, null);
+        }
+
+        FakeMemoryObject(Map<String, Object> values, Object value) {
+            this.values = values;
+            this.value = value;
+        }
+
+        @Override
+        public MemoryObject get(String path) throws Exception {
+            if (!values.containsKey(path)) {
+                throw new IllegalArgumentException("Missing path: " + path);
+            }
+            return new FakeMemoryObject(values, values.get(path));
+        }
+
+        @Override
+        public MemoryObject get(MemoryRef ref) throws Exception {
+            return get(ref.getPath());
+        }
+
+        @Override
+        public MemoryRef set(String path, Object value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public MemoryObject newObject(String path, boolean overwrite) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isExist(String path) {
+            return values.containsKey(path);
+        }
+
+        @Override
+        public List<String> getFieldNames() {
+            return new ArrayList<>(values.keySet());
+        }
+
+        @Override
+        public Map<String, Object> getFields() {
+            return Collections.unmodifiableMap(values);
+        }
+
+        @Override
+        public Object getValue() {
+            return value;
+        }
+
+        @Override
+        public boolean isNestedObject() {
+            return value == null;
+        }
+    }
+
+    @Test
+    void processToolRequestInjectsArgsFromConfigBeforeDurableToolCall() throws Exception {
+        FakeRunnerContext ctx = new FakeRunnerContext();
+
+        Map<String, Object> arguments =
+                new HashMap<>(Map.of("orderId", "order-1", "tenant_id", "model-tenant"));
+        ToolRequestEvent event =
+                new ToolRequestEvent(
+                        "model",
+                        List.of(
+                                Map.of(
+                                        "id",
+                                        "call-1",
+                                        "type",
+                                        "function",
+                                        "function",
+                                        Map.of("name", "queryOrder", "arguments", arguments))));
+
+        ToolCallAction.processToolRequest(event, ctx);
+
+        ToolResponseEvent response = ToolResponseEvent.fromEvent(ctx.sentEvents.get(0));
+        assertThat(response.getResponses().get("call-1").getResult()).isEqualTo("tenant-1:order-1");
+        assertThat(arguments)
+                .containsOnly(
+                        Map.entry("orderId", "order-1"), Map.entry("tenant_id", "model-tenant"));
+    }
+
+    @Test
+    void processToolRequestInjectsArgsFromSensoryMemory() throws Exception {
+        FakeRunnerContext ctx =
+                new FakeRunnerContext()
+                        .withInjection(
+                                ToolParameterInjection.fromSensoryMemory("request.tenant_id"))
+                        .withSensoryMemory(Map.of("request.tenant_id", "tenant-sensory"));
+
+        ToolCallAction.processToolRequest(toolRequest("queryOrder"), ctx);
+
+        ToolResponseEvent response = ToolResponseEvent.fromEvent(ctx.sentEvents.get(0));
+        assertThat(response.getResponses().get("call-1").getResult())
+                .isEqualTo("tenant-sensory:order-1");
+    }
+
+    @Test
+    void processToolRequestInjectsArgsFromShortTermMemory() throws Exception {
+        FakeRunnerContext ctx =
+                new FakeRunnerContext()
+                        .withInjection(
+                                ToolParameterInjection.fromShortTermMemory("session.tenant_id"))
+                        .withShortTermMemory(Map.of("session.tenant_id", "tenant-short"));
+
+        ToolCallAction.processToolRequest(toolRequest("queryOrder"), ctx);
+
+        ToolResponseEvent response = ToolResponseEvent.fromEvent(ctx.sentEvents.get(0));
+        assertThat(response.getResponses().get("call-1").getResult())
+                .isEqualTo("tenant-short:order-1");
+    }
+
+    @Test
+    void processToolRequestReportsMissingMemoryPath() throws Exception {
+        FakeRunnerContext ctx =
+                new FakeRunnerContext()
+                        .withInjection(
+                                ToolParameterInjection.fromSensoryMemory("request.tenant_id"))
+                        .withSensoryMemory(Map.of());
+
+        ToolCallAction.processToolRequest(toolRequest("queryOrder"), ctx);
+
+        ToolResponseEvent response = ToolResponseEvent.fromEvent(ctx.sentEvents.get(0));
+        assertThat(response.getSuccess()).containsEntry("call-1", false);
+        assertThat(response.getError())
+                .containsEntry(
+                        "call-1",
+                        "Missing memory path for injected tool parameter: request.tenant_id");
+    }
+
+    @Test
+    void processToolRequestReportsNestedMemoryPath() throws Exception {
+        FakeRunnerContext ctx =
+                new FakeRunnerContext()
+                        .withInjection(
+                                ToolParameterInjection.fromSensoryMemory("request.tenant_id"))
+                        .withSensoryMemory(Collections.singletonMap("request.tenant_id", null));
+
+        ToolCallAction.processToolRequest(toolRequest("queryOrder"), ctx);
+
+        ToolResponseEvent response = ToolResponseEvent.fromEvent(ctx.sentEvents.get(0));
+        assertThat(response.getSuccess()).containsEntry("call-1", false);
+        assertThat(response.getError())
+                .containsEntry(
+                        "call-1",
+                        "Memory path for injected tool parameter must reference a value: request.tenant_id");
+    }
+
+    @Test
+    void processToolRequestReportsUninitializedMemory() throws Exception {
+        FakeRunnerContext ctx =
+                new FakeRunnerContext()
+                        .withInjection(
+                                ToolParameterInjection.fromSensoryMemory("request.tenant_id"));
+
+        ToolCallAction.processToolRequest(toolRequest("queryOrder"), ctx);
+
+        ToolResponseEvent response = ToolResponseEvent.fromEvent(ctx.sentEvents.get(0));
+        assertThat(response.getSuccess()).containsEntry("call-1", false);
+        assertThat(response.getError())
+                .containsEntry(
+                        "call-1",
+                        "Cannot inject tool parameter from sensory_memory because memory is not initialized.");
+    }
+
+    @Test
+    void processToolRequestKeepsDiagnosticErrorWhenToolExecutionFails() throws Exception {
+        FakeRunnerContext ctx =
+                new FakeRunnerContext() {
+                    @Override
+                    public Resource getResource(String name, ResourceType type) {
+                        return new FailingTool();
+                    }
+                };
+
+        ToolCallAction.processToolRequest(toolRequest("queryOrder"), ctx);
+
+        ToolResponseEvent response = ToolResponseEvent.fromEvent(ctx.sentEvents.get(0));
+        assertThat(response.getSuccess()).containsEntry("call-1", false);
+        assertThat(response.getResponses().get("call-1").getError())
+                .isEqualTo("Tool queryOrder execute failed.");
+        assertThat(response.getError()).containsEntry("call-1", "database timeout");
+    }
+
+    @Test
+    void processToolRequestReturnsErrorForMissingTool() throws Exception {
+        FakeRunnerContext ctx =
+                new FakeRunnerContext() {
+                    @Override
+                    public Resource getResource(String name, ResourceType type) {
+                        throw new RuntimeException("missing resource");
+                    }
+                };
+
+        ToolCallAction.processToolRequest(toolRequest("queryOrder"), ctx);
+
+        ToolResponseEvent response = ToolResponseEvent.fromEvent(ctx.sentEvents.get(0));
+        assertThat(response.getSuccess()).containsEntry("call-1", false);
+        assertThat(response.getResponses().get("call-1").getError())
+                .isEqualTo("Tool queryOrder does not exist.");
+        assertThat(response.getError()).containsEntry("call-1", "missing resource");
+    }
+
+    private static ToolRequestEvent toolRequest(String toolName) {
+        return new ToolRequestEvent(
+                "model",
+                List.of(
+                        Map.of(
+                                "id",
+                                "call-1",
+                                "type",
+                                "function",
+                                "function",
+                                Map.of(
+                                        "name",
+                                        toolName,
+                                        "arguments",
+                                        Map.of("orderId", "order-1")))));
+    }
+}

--- a/plan/src/test/java/org/apache/flink/agents/plan/compatibility/CreateJavaAgentPlanFromJson.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/compatibility/CreateJavaAgentPlanFromJson.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -184,6 +185,9 @@ public class CreateJavaAgentPlanFromJson {
         metadata.put("args_schema", argsSchema);
 
         serialized.put("metadata", metadata);
+        serialized.put(
+                "injected_args",
+                Map.of("tenant_id", Map.of("source", "config", "key", "tenant.id")));
 
         Map<String, String> func = new HashMap<>();
         func.put("func_type", "PythonFunction");
@@ -200,13 +204,40 @@ public class CreateJavaAgentPlanFromJson {
                         "FunctionTool",
                         serialized);
 
-        Map<ResourceType, Map<String, ResourceProvider>> resourceProviders = new HashMap<>();
         Map<String, ResourceProvider> chatModels = new HashMap<>();
-        Map<String, ResourceProvider> tools = new HashMap<>();
         chatModels.put("chat_model", resourceProvider);
-        tools.put("add", serializableResourceProvider);
-        resourceProviders.put(ResourceType.CHAT_MODEL, chatModels);
-        resourceProviders.put(ResourceType.TOOL, tools);
-        assertEquals(resourceProviders, agentPlan.getResourceProviders());
+        assertEquals(chatModels, agentPlan.getResourceProviders().get(ResourceType.CHAT_MODEL));
+
+        ResourceProvider actualToolProvider =
+                agentPlan.getResourceProviders().get(ResourceType.TOOL).get("add");
+        assertInstanceOf(PythonSerializableResourceProvider.class, actualToolProvider);
+        PythonSerializableResourceProvider actualSerializableToolProvider =
+                (PythonSerializableResourceProvider) actualToolProvider;
+        assertEquals(
+                serializableResourceProvider.getName(), actualSerializableToolProvider.getName());
+        assertEquals(
+                serializableResourceProvider.getType(), actualSerializableToolProvider.getType());
+        assertEquals(
+                serializableResourceProvider.getModule(),
+                actualSerializableToolProvider.getModule());
+        assertEquals(
+                serializableResourceProvider.getClazz(), actualSerializableToolProvider.getClazz());
+
+        Map<String, Object> actualSerialized = actualSerializableToolProvider.getSerialized();
+        Map<String, Object> actualMetadata = (Map<String, Object>) actualSerialized.get("metadata");
+        Map<String, Object> actualArgsSchema =
+                (Map<String, Object>) actualMetadata.get("args_schema");
+        Map<String, Object> actualProperties =
+                (Map<String, Object>) actualArgsSchema.get("properties");
+        assertTrue(actualProperties.containsKey("a"));
+        assertTrue(actualProperties.containsKey("b"));
+        assertFalse(actualProperties.containsKey("tenant_id"));
+
+        Map<String, Object> actualInjectedArgs =
+                (Map<String, Object>) actualSerialized.get("injected_args");
+        Map<String, Object> tenantInjection =
+                (Map<String, Object>) actualInjectedArgs.get("tenant_id");
+        assertEquals("config", tenantInjection.get("source"));
+        assertEquals("tenant.id", tenantInjection.get("key"));
     }
 }

--- a/plan/src/test/java/org/apache/flink/agents/plan/compatibility/GenerateAgentPlanJson.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/compatibility/GenerateAgentPlanJson.java
@@ -23,7 +23,10 @@ import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.api.EventType;
 import org.apache.flink.agents.api.agents.Agent;
 import org.apache.flink.agents.api.annotation.Action;
+import org.apache.flink.agents.api.annotation.Tool;
+import org.apache.flink.agents.api.annotation.ToolParam;
 import org.apache.flink.agents.api.context.RunnerContext;
+import org.apache.flink.agents.api.tools.ToolParameterSource;
 import org.apache.flink.agents.plan.AgentPlan;
 
 import java.io.BufferedWriter;
@@ -56,6 +59,19 @@ public class GenerateAgentPlanJson {
         @Action({EventType.InputEvent, MyEvent.EVENT_TYPE})
         public void secondAction(Event event, RunnerContext context) {
             // Test action implementation
+        }
+
+        @Tool
+        public static int add(
+                @ToolParam(name = "a", description = "The first operand") int a,
+                @ToolParam(name = "b", description = "The second operand") int b,
+                @ToolParam(
+                                name = "tenant_id",
+                                injected = true,
+                                source = ToolParameterSource.CONFIG,
+                                key = "tenant.id")
+                        String tenantId) {
+            return a + b;
         }
     }
 

--- a/plan/src/test/java/org/apache/flink/agents/plan/serializer/AgentPlanJsonDeserializerTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/serializer/AgentPlanJsonDeserializerTest.java
@@ -22,15 +22,20 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.api.InputEvent;
 import org.apache.flink.agents.api.context.RunnerContext;
+import org.apache.flink.agents.api.resource.ResourceContext;
+import org.apache.flink.agents.api.resource.ResourceType;
+import org.apache.flink.agents.api.tools.ToolMetadata;
+import org.apache.flink.agents.api.tools.ToolParameterInjection;
 import org.apache.flink.agents.plan.AgentPlan;
 import org.apache.flink.agents.plan.JavaFunction;
 import org.apache.flink.agents.plan.actions.Action;
+import org.apache.flink.agents.plan.resourceprovider.ResourceProvider;
+import org.apache.flink.agents.plan.tools.FunctionTool;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -67,11 +72,62 @@ public class AgentPlanJsonDeserializerTest {
 
         // Check the flink agent config
         Map<String, Object> configData = agentPlan.getConfigData();
-        assertThat(configData.keySet()).hasSize(4);
+        assertEquals(4, configData.keySet().size());
         assertEquals(1, configData.get("key1"));
         assertEquals(1.5, configData.get("key2"));
         assertEquals(true, configData.get("key3"));
         assertEquals("v1", configData.get("key4"));
+    }
+
+    @Test
+    public void testDeserializeToolWithInjectedArgs() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        FunctionTool originalTool =
+                new FunctionTool(
+                        new ToolMetadata("query_order", "Query order.", "{}"),
+                        new JavaFunction(
+                                MyAction.class.getName(),
+                                "doNothing",
+                                new Class[] {Event.class, RunnerContext.class}),
+                        Map.of(
+                                "tenant_id",
+                                ToolParameterInjection.fromSensoryMemory("request.tenant_id")));
+
+        String json =
+                mapper.writeValueAsString(
+                        Map.of(
+                                "actions",
+                                Map.of(),
+                                "actions_by_event",
+                                Map.of(),
+                                "resource_providers",
+                                Map.of(
+                                        "tool",
+                                        Map.of(
+                                                "query_order",
+                                                Map.of(
+                                                        "name",
+                                                        "query_order",
+                                                        "type",
+                                                        "tool",
+                                                        "module",
+                                                        FunctionTool.class.getPackageName(),
+                                                        "clazz",
+                                                        FunctionTool.class.getName(),
+                                                        "serializedResource",
+                                                        mapper.writeValueAsString(originalTool),
+                                                        "__resource_provider_type__",
+                                                        "JavaSerializableResourceProvider")))));
+
+        AgentPlan agentPlan = mapper.readValue(json, AgentPlan.class);
+
+        ResourceProvider provider =
+                agentPlan.getResourceProviders().get(ResourceType.TOOL).get("query_order");
+        FunctionTool deserializedTool =
+                (FunctionTool) provider.provide(ResourceContext.fromGetResource((n, t) -> null));
+        assertEquals(
+                Map.of("tenant_id", ToolParameterInjection.fromSensoryMemory("request.tenant_id")),
+                deserializedTool.getInjectedArgs());
     }
 
     private static class MyEvent extends Event {

--- a/plan/src/test/java/org/apache/flink/agents/plan/serializer/AgentPlanJsonSerializerTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/serializer/AgentPlanJsonSerializerTest.java
@@ -18,13 +18,17 @@
 
 package org.apache.flink.agents.plan.serializer;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.api.EventType;
 import org.apache.flink.agents.api.InputEvent;
 import org.apache.flink.agents.api.OutputEvent;
 import org.apache.flink.agents.api.agents.Agent;
+import org.apache.flink.agents.api.annotation.Tool;
+import org.apache.flink.agents.api.annotation.ToolParam;
 import org.apache.flink.agents.api.context.RunnerContext;
+import org.apache.flink.agents.api.tools.ToolParameterSource;
 import org.apache.flink.agents.plan.AgentConfiguration;
 import org.apache.flink.agents.plan.AgentPlan;
 import org.apache.flink.agents.plan.JavaFunction;
@@ -64,6 +68,22 @@ public class AgentPlanJsonSerializerTest {
         // Non-annotated method should be ignored
         public void regularMethod() {
             // This should not be included in the AgentPlan
+        }
+    }
+
+    /** Test Agent class with @Tool annotated methods. */
+    public static class TestAgentWithInjectedTool extends Agent {
+
+        @Tool
+        public static String queryOrder(
+                @ToolParam(name = "order_id", description = "Order id.") String orderId,
+                @ToolParam(
+                                name = "tenant_id",
+                                injected = true,
+                                source = ToolParameterSource.CONFIG,
+                                key = "tenant.id")
+                        String tenantId) {
+            return tenantId + ":" + orderId;
         }
     }
 
@@ -229,5 +249,31 @@ public class AgentPlanJsonSerializerTest {
 
         // Verify that config data from AgentConfiguration is present
         assertThat(json).contains("\"conf_data\":{\"config.key\":\"config.value\"}");
+    }
+
+    @Test
+    public void testSerializeAgentPlanWithInjectedToolArgs() throws Exception {
+        AgentPlan agentPlan =
+                new AgentPlan(new TestAgentWithInjectedTool(), new AgentConfiguration());
+
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(agentPlan);
+
+        JsonNode plan = mapper.readTree(json);
+        JsonNode tools =
+                plan.get("resource_providers").has("tool")
+                        ? plan.get("resource_providers").get("tool")
+                        : plan.get("resource_providers").get("TOOL");
+        JsonNode serializedTool =
+                mapper.readTree(tools.get("queryOrder").get("serializedResource").asText());
+        JsonNode inputSchema =
+                mapper.readTree(serializedTool.get("metadata").get("inputSchema").asText());
+
+        assertThat(inputSchema.get("properties").has("order_id")).isTrue();
+        assertThat(inputSchema.get("properties").has("tenant_id")).isFalse();
+        assertThat(serializedTool.get("injected_args").get("tenant_id").get("source").asText())
+                .isEqualTo("config");
+        assertThat(serializedTool.get("injected_args").get("tenant_id").get("key").asText())
+                .isEqualTo("tenant.id");
     }
 }

--- a/plan/src/test/java/org/apache/flink/agents/plan/tools/FunctionToolSetPythonAdapterTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/tools/FunctionToolSetPythonAdapterTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.agents.plan.tools;
 
 import org.apache.flink.agents.api.resource.python.PythonResourceAdapter;
 import org.apache.flink.agents.api.tools.ToolMetadata;
+import org.apache.flink.agents.api.tools.ToolParameterInjection;
 import org.apache.flink.agents.plan.JavaFunction;
 import org.apache.flink.agents.plan.PythonFunction;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import org.mockito.Mockito;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -42,7 +44,7 @@ class FunctionToolSetPythonAdapterTest {
         FunctionTool tool = new FunctionTool(placeholder, pf);
 
         PythonResourceAdapter adapter = Mockito.mock(PythonResourceAdapter.class);
-        when(adapter.getPythonToolMetadata("pkg.mod", "notify"))
+        when(adapter.getPythonToolMetadata(eq("pkg.mod"), eq("notify"), anyList()))
                 .thenReturn(
                         Map.of(
                                 "name", "notify",
@@ -56,7 +58,38 @@ class FunctionToolSetPythonAdapterTest {
         assertThat(tool.getMetadata().getName()).isEqualTo("notify");
         assertThat(tool.getMetadata().getDescription()).isEqualTo("Send a notification.");
         assertThat(tool.getMetadata().getInputSchema()).contains("recipient id");
-        verify(adapter, times(1)).getPythonToolMetadata(eq("pkg.mod"), eq("notify"));
+        verify(adapter, times(1)).getPythonToolMetadata(eq("pkg.mod"), eq("notify"), anyList());
+    }
+
+    @Test
+    void mergesPythonCallableInjectedArgsFromAdapter() {
+        ToolMetadata placeholder = new ToolMetadata("notify", "", "{}");
+        PythonFunction pf = new PythonFunction("pkg.mod", "notify");
+        FunctionTool tool =
+                new FunctionTool(
+                        placeholder,
+                        pf,
+                        Map.of(
+                                "request_id",
+                                ToolParameterInjection.fromSensoryMemory("request.id")));
+
+        PythonResourceAdapter adapter = Mockito.mock(PythonResourceAdapter.class);
+        when(adapter.getPythonToolMetadata(eq("pkg.mod"), eq("notify"), anyList()))
+                .thenReturn(
+                        Map.of(
+                                "name", "notify",
+                                "description", "Send a notification.",
+                                "inputSchema", "{\"properties\":{\"id\":{\"type\":\"string\"}}}",
+                                "injectedArgs",
+                                        "{\"tenant_id\":{\"source\":\"config\","
+                                                + "\"key\":\"tenant.id\"}}"));
+
+        tool.setPythonResourceAdapter(adapter);
+
+        assertThat(tool.getInjectedArgs())
+                .containsEntry("tenant_id", ToolParameterInjection.fromConfig("tenant.id"))
+                .containsEntry(
+                        "request_id", ToolParameterInjection.fromSensoryMemory("request.id"));
     }
 
     @Test
@@ -74,7 +107,8 @@ class FunctionToolSetPythonAdapterTest {
 
         // Metadata untouched
         assertThat(tool.getMetadata()).isSameAs(original);
-        verify(adapter, never()).getPythonToolMetadata(Mockito.anyString(), Mockito.anyString());
+        verify(adapter, never())
+                .getPythonToolMetadata(Mockito.anyString(), Mockito.anyString(), anyList());
     }
 
     /** Helper static method to back JavaFunction in the no-op test. */

--- a/plan/src/test/java/org/apache/flink/agents/plan/tools/FunctionToolTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/tools/FunctionToolTest.java
@@ -22,11 +22,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.agents.api.annotation.Tool;
 import org.apache.flink.agents.api.annotation.ToolParam;
 import org.apache.flink.agents.api.tools.ToolMetadata;
+import org.apache.flink.agents.api.tools.ToolParameterInjection;
 import org.apache.flink.agents.plan.JavaFunction;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
+import java.util.Map;
 
 public class FunctionToolTest {
     @Tool(description = "Performs basic arithmetic operations")
@@ -72,11 +74,18 @@ public class FunctionToolTest {
                         method.getDeclaringClass(),
                         method.getName(),
                         new Class[] {Double.class, Double.class, String.class});
-        FunctionTool tool = new FunctionTool(metadata, javaFunction);
+        FunctionTool tool =
+                new FunctionTool(
+                        metadata,
+                        javaFunction,
+                        Map.of(
+                                "tenant_id",
+                                ToolParameterInjection.fromSensoryMemory("request.tenant_id")));
         ObjectMapper mapper = new ObjectMapper();
         String json = mapper.writeValueAsString(tool);
         FunctionTool deserialize = mapper.readValue(json, FunctionTool.class);
         Assertions.assertEquals(tool.getMetadata(), deserialize.getMetadata());
         Assertions.assertEquals(tool.getFunction(), deserialize.getFunction());
+        Assertions.assertEquals(tool.getInjectedArgs(), deserialize.getInjectedArgs());
     }
 }

--- a/plan/src/test/java/org/apache/flink/agents/plan/tools/SchemaUtilsTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/tools/SchemaUtilsTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.agents.api.annotation.ToolParam;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -46,6 +47,10 @@ class SchemaUtilsTest {
         public void methodWithCustomObject(
                 @ToolParam(name = "objectParam", description = "A custom object parameter")
                         Object customObject) {}
+
+        public void methodWithExternallyInjectedRequiredParam(
+                @ToolParam(name = "order_id", description = "The order id") String orderId,
+                @ToolParam(name = "tenant_id", description = "The tenant id") String tenantId) {}
     }
 
     private final ObjectMapper mapper = new ObjectMapper();
@@ -93,6 +98,36 @@ class SchemaUtilsTest {
         assertTrue(required.toString().contains("boolParam"));
         // intParam should not be required (explicitly set to false)
         assertFalse(required.toString().contains("intParam"));
+    }
+
+    @Test
+    void testGenerateSchemaHidesExternallyInjectedParameter() throws Exception {
+        Method method =
+                TestClass.class.getMethod(
+                        "methodWithBasicTypes", String.class, int.class, boolean.class);
+        String schema = SchemaUtils.generateSchema(method, Set.of("intParam"));
+        JsonNode jsonNode = mapper.readTree(schema);
+
+        JsonNode properties = jsonNode.get("properties");
+        assertTrue(properties.has("stringParam"));
+        assertFalse(properties.has("intParam"));
+        assertTrue(properties.has("boolParam"));
+        assertFalse(jsonNode.get("required").toString().contains("intParam"));
+    }
+
+    @Test
+    void testGenerateSchemaHidesExternallyInjectedRequiredParameter() throws Exception {
+        Method method =
+                TestClass.class.getMethod(
+                        "methodWithExternallyInjectedRequiredParam", String.class, String.class);
+        String schema = SchemaUtils.generateSchema(method, Set.of("tenant_id"));
+        JsonNode jsonNode = mapper.readTree(schema);
+
+        JsonNode properties = jsonNode.get("properties");
+        assertTrue(properties.has("order_id"));
+        assertFalse(properties.has("tenant_id"));
+        assertFalse(jsonNode.get("required").toString().contains("tenant_id"));
+        assertFalse(schema.contains("tenant_id"));
     }
 
     @Test

--- a/python/flink_agents/api/decorators.py
+++ b/python/flink_agents/api/decorators.py
@@ -18,6 +18,11 @@
 from typing import Callable, Type
 
 from flink_agents.api.function import Function, JavaFunction, PythonFunction
+from flink_agents.api.tools.tool_parameter_injection import (
+    InjectedArg,
+    normalize_injected_args,
+    validate_injected_arg_names,
+)
 
 
 def _validate_target(target: Function, owner: str) -> None:
@@ -162,21 +167,37 @@ def embedding_model_setup(func: Callable) -> Callable:
     return func
 
 
-def tool(func: Callable) -> Callable:
+def tool(
+    func: Callable | None = None,
+    *,
+    injected_args: dict[str, InjectedArg | dict] | None = None,
+) -> Callable:
     """Decorator for marking a function declaring a tool.
 
     Parameters
     ----------
     func : Callable
         Function to be decorated.
+    injected_args : dict, optional
+        Mapping from parameter name to its framework-owned value source.
+        These arguments are hidden from the model-facing tool schema.
 
     Returns:
     -------
     Callable
         Decorator function that marks the target function declare a tool.
     """
-    func._is_tool = True
-    return func
+    injected = normalize_injected_args(injected_args)
+
+    def decorator(target: Callable) -> Callable:
+        validate_injected_arg_names(target, injected)
+        target._is_tool = True
+        target._injected_args = injected
+        return target
+
+    if func is not None:
+        return decorator(func)
+    return decorator
 
 
 def prompt(func: Callable) -> Callable:

--- a/python/flink_agents/api/events/tool_event.py
+++ b/python/flink_agents/api/events/tool_event.py
@@ -92,7 +92,9 @@ class ToolResponseEvent(Event):
         self,
         request_id: UUID,
         responses: Dict[UUID, Any],
-        external_ids: Dict[UUID, str | None],
+        external_ids: Dict[UUID, str | None] | None = None,
+        success: Dict[UUID, bool] | None = None,
+        error: Dict[UUID, str] | None = None,
     ) -> None:
         """Create a ToolResponseEvent."""
         super().__init__(
@@ -100,7 +102,11 @@ class ToolResponseEvent(Event):
             attributes={
                 "request_id": request_id,
                 "responses": responses,
-                "external_ids": external_ids,
+                "success": success
+                if success is not None
+                else dict.fromkeys(responses, True),
+                "error": error if error is not None else {},
+                "external_ids": external_ids if external_ids is not None else {},
             },
         )
 
@@ -109,11 +115,15 @@ class ToolResponseEvent(Event):
     def from_event(cls, event: Event) -> "ToolResponseEvent":
         assert "request_id" in event.attributes
         assert "responses" in event.attributes
-        assert "external_ids" in event.attributes
+        responses = event.attributes["responses"]
         result = ToolResponseEvent(
             request_id=event.attributes["request_id"],
-            responses=event.attributes["responses"],
-            external_ids=event.attributes["external_ids"],
+            responses=responses,
+            external_ids=event.attributes.get("external_ids", {}),
+            success=event.attributes.get(
+                "success", dict.fromkeys(responses, True)
+            ),
+            error=event.attributes.get("error", {}),
         )
         result.id = event.id
         return result
@@ -128,6 +138,16 @@ class ToolResponseEvent(Event):
     def responses(self) -> Dict[UUID, Any]:
         """Return the tool call responses."""
         return self.get_attr("responses")
+
+    @property
+    def success(self) -> Dict[UUID, bool]:
+        """Return whether each tool call succeeded."""
+        return self.get_attr("success")
+
+    @property
+    def error(self) -> Dict[UUID, str]:
+        """Return diagnostic errors for failed tool calls."""
+        return self.get_attr("error")
 
     @property
     def external_ids(self) -> Dict[UUID, str | None]:

--- a/python/flink_agents/api/tests/test_cross_language_event_snapshots.py
+++ b/python/flink_agents/api/tests/test_cross_language_event_snapshots.py
@@ -297,18 +297,18 @@ def test_tool_response_event_python_snapshot_is_stable() -> None:
     )
 
 
-def test_java_tool_response_event_is_shape_mismatched_when_consumed_by_python() -> None:
+def test_python_can_deserialize_java_tool_response_event_status_fields() -> None:
     base = _read_java_snapshot("tool_response_event.json")
     typed = ToolResponseEvent.from_event(base)
 
     assert typed.request_id == _FIXED_REQUEST_ID
+    assert typed.success[_FIXED_TOOL_CALL_ID] is True
+    assert typed.error == {}
 
     response_value = typed.responses[_FIXED_TOOL_CALL_ID]
     assert isinstance(response_value, dict)
     assert "result" in response_value
 
-    assert "success" not in typed.attributes
-    assert "error" not in typed.attributes
     assert "timestamp" not in typed.attributes
 
 

--- a/python/flink_agents/api/tests/test_decorators.py
+++ b/python/flink_agents/api/tests/test_decorators.py
@@ -17,11 +17,12 @@
 #################################################################################
 import pytest
 
-from flink_agents.api.decorators import action
+from flink_agents.api.decorators import action, tool
 from flink_agents.api.events.event import Event, InputEvent, OutputEvent
 from flink_agents.api.events.event_type import EventType
 from flink_agents.api.function import JavaFunction, PythonFunction
 from flink_agents.api.runner_context import RunnerContext
+from flink_agents.api.tools import InjectedArg
 
 
 def test_action_decorator() -> None:
@@ -169,3 +170,65 @@ def test_action_decorator_target_error_names_decorated_function() -> None:
         @action(EventType.InputEvent, target=bad)
         def my_named_stub(event: Event, ctx: RunnerContext) -> None:
             pass
+
+
+def test_tool_decorator_supports_injected_args() -> None:
+    @tool(injected_args={"tenant_id": InjectedArg.from_config("tenant_id")})
+    def query_order(order_id: str, tenant_id: str) -> str:
+        return f"{tenant_id}:{order_id}"
+
+    assert query_order._is_tool is True
+    assert query_order._injected_args == {"tenant_id": InjectedArg.from_config("tenant_id")}
+
+
+def test_tool_decorator_defaults_injected_arg_source_to_sensory_memory() -> None:
+    @tool(injected_args={"tenant_id": {"key": "request.tenant_id"}})
+    def query_order(order_id: str, tenant_id: str) -> str:
+        return f"{tenant_id}:{order_id}"
+
+    assert query_order._injected_args == {
+        "tenant_id": InjectedArg.from_sensory_memory("request.tenant_id")
+    }
+
+
+def test_tool_decorator_rejects_unknown_injected_arg_name() -> None:
+    with pytest.raises(
+        ValueError,
+        match="Injected tool parameter\\(s\\) tenent_id do not match function",
+    ):
+
+        @tool(injected_args={"tenent_id": InjectedArg.from_config("tenant_id")})
+        def query_order(order_id: str, tenant_id: str) -> str:
+            return f"{tenant_id}:{order_id}"
+
+
+def test_tool_decorator_allows_injected_arg_with_kwargs() -> None:
+    @tool(injected_args={"tenant_id": InjectedArg.from_config("tenant_id")})
+    def query_order(order_id: str, **kwargs: str) -> str:
+        return f"{kwargs['tenant_id']}:{order_id}"
+
+    assert query_order._injected_args == {"tenant_id": InjectedArg.from_config("tenant_id")}
+
+
+def test_tool_decorator_rejects_list_injected_args() -> None:
+    with pytest.raises(TypeError, match="'injected_args' must be a dict"):
+
+        @tool(injected_args=["tenant_id"])
+        def query_order(order_id: str, tenant_id: str) -> str:
+            return f"{tenant_id}:{order_id}"
+
+
+def test_tool_decorator_rejects_string_injected_arg_spec() -> None:
+    with pytest.raises(TypeError, match="Unsupported injected arg spec"):
+
+        @tool(injected_args={"tenant_id": "tenant.id"})
+        def query_order(order_id: str, tenant_id: str) -> str:
+            return f"{tenant_id}:{order_id}"
+
+
+def test_tool_decorator_rejects_invalid_injected_arg_spec() -> None:
+    with pytest.raises(TypeError, match="Unsupported injected arg spec"):
+
+        @tool(injected_args={"tenant_id": 1})
+        def query_order(order_id: str, tenant_id: str) -> str:
+            return f"{tenant_id}:{order_id}"

--- a/python/flink_agents/api/tools/function_tool.py
+++ b/python/flink_agents/api/tools/function_tool.py
@@ -15,16 +15,30 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 #################################################################################
+from pydantic import Field, model_validator
 from typing_extensions import override
 
 from flink_agents.api.function import JavaFunction, PythonFunction
 from flink_agents.api.resource import ResourceType, SerializableResource
+from flink_agents.api.tools.tool_parameter_injection import (
+    InjectedArg,
+    normalize_injected_args,
+)
 
 
 class FunctionTool(SerializableResource):
     """Declarative function tool: carries a function descriptor."""
 
     func: PythonFunction | JavaFunction
+    injected_args: dict[str, InjectedArg] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_injected_args(cls, data: dict) -> dict:
+        if isinstance(data, dict) and "injected_args" in data:
+            data = dict(data)
+            data["injected_args"] = normalize_injected_args(data["injected_args"])
+        return data
 
     @classmethod
     @override

--- a/python/flink_agents/api/tools/tool.py
+++ b/python/flink_agents/api/tools/tool.py
@@ -24,6 +24,12 @@ from pydantic import BaseModel, field_serializer, model_validator
 from typing_extensions import override
 
 from flink_agents.api.resource import ResourceType, SerializableResource
+from flink_agents.api.tools.tool_parameter_injection import (
+    InjectedArg,
+    merge_injected_args,
+    normalize_injected_args,
+    validate_injected_arg_names,
+)
 from flink_agents.api.tools.utils import create_model_from_schema
 
 if TYPE_CHECKING:
@@ -108,12 +114,25 @@ class Tool(SerializableResource, ABC):
     metadata: ToolMetadata | None = None
 
     @staticmethod
-    def from_callable(func: typing.Callable) -> "FunctionTool":
+    def from_callable(
+        func: typing.Callable,
+        *,
+        injected_args: dict[str, InjectedArg | dict] | None = None,
+    ) -> "FunctionTool":
         """Wrap a Python callable as a declarative ``FunctionTool``."""
         from flink_agents.api.function import PythonFunction
         from flink_agents.api.tools.function_tool import FunctionTool
 
-        return FunctionTool(func=PythonFunction.from_callable(func))
+        declared = normalize_injected_args(injected_args)
+        annotated = getattr(func, "_injected_args", None)
+        normalized = merge_injected_args(
+            annotated, declared, tool_name=getattr(func, "__qualname__", str(func))
+        )
+        validate_injected_arg_names(func, normalized)
+        return FunctionTool(
+            func=PythonFunction.from_callable(func),
+            injected_args=normalized,
+        )
 
     @property
     def name(self) -> str:

--- a/python/flink_agents/api/tools/tool_parameter_injection.py
+++ b/python/flink_agents/api/tools/tool_parameter_injection.py
@@ -1,0 +1,132 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+import inspect
+from collections.abc import Callable
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class ToolParameterSource(str, Enum):
+    """Source for a framework-injected tool parameter."""
+
+    CONFIG = "config"
+    SENSORY_MEMORY = "sensory_memory"
+    SHORT_TERM_MEMORY = "short_term_memory"
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ToolParameterSource | None":
+        if not isinstance(value, str):
+            return None
+        normalized = value.lower()
+        for source in cls:
+            if source.value == normalized:
+                return source
+        return None
+
+
+class InjectedArg(BaseModel):
+    """Declarative source binding for a framework-injected tool parameter."""
+
+    source: ToolParameterSource = ToolParameterSource.SENSORY_MEMORY
+    key: str | None = None
+
+    @staticmethod
+    def from_config(key: str) -> "InjectedArg":
+        """Create an injected argument read from global agent config."""
+        return InjectedArg(source=ToolParameterSource.CONFIG, key=key)
+
+    @staticmethod
+    def from_sensory_memory(path: str) -> "InjectedArg":
+        """Create an injected argument read from sensory memory."""
+        return InjectedArg(source=ToolParameterSource.SENSORY_MEMORY, key=path)
+
+    @staticmethod
+    def from_short_term_memory(path: str) -> "InjectedArg":
+        """Create an injected argument read from short-term memory."""
+        return InjectedArg(source=ToolParameterSource.SHORT_TERM_MEMORY, key=path)
+
+    def with_default_key(self, key: str) -> "InjectedArg":
+        """Use the tool parameter name when no explicit key is configured."""
+        if self.key:
+            return self
+        return InjectedArg(source=self.source, key=key)
+
+
+def normalize_injected_args(
+    injected_args: dict[str, InjectedArg | dict] | None,
+) -> dict[str, InjectedArg]:
+    """Normalize public injected_args forms into a param -> source map."""
+    if injected_args is None:
+        return {}
+    if not isinstance(injected_args, dict):
+        msg = "'injected_args' must be a dict mapping parameter names to injection specs."
+        raise TypeError(msg)
+    result: dict[str, InjectedArg] = {}
+    for name, spec in injected_args.items():
+        if isinstance(spec, InjectedArg):
+            result[name] = spec.with_default_key(name)
+        elif isinstance(spec, dict):
+            result[name] = InjectedArg.model_validate(spec).with_default_key(name)
+        else:
+            msg = f"Unsupported injected arg spec for {name!r}: {spec!r}"
+            raise TypeError(msg)
+    return result
+
+
+def merge_injected_args(
+    annotated_args: dict[str, InjectedArg] | None,
+    declared_args: dict[str, InjectedArg] | None,
+    *,
+    tool_name: str,
+) -> dict[str, InjectedArg]:
+    """Merge decorator-declared and descriptor-declared injected args."""
+    merged = dict(annotated_args or {})
+    for name, spec in (declared_args or {}).items():
+        existing = merged.get(name)
+        if existing is not None and existing != spec:
+            msg = (
+                f"Tool {tool_name!r}: injected_args conflict for parameter "
+                f"{name!r} between @tool and descriptor."
+            )
+            raise ValueError(msg)
+        merged[name] = spec
+    return merged
+
+
+def validate_injected_arg_names(
+    func: Callable, injected_args: dict[str, InjectedArg]
+) -> None:
+    """Validate that declarative injected args target real callable parameters."""
+    if not injected_args:
+        return
+    signature = inspect.signature(func)
+    parameters = signature.parameters
+    if any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters.values()
+    ):
+        return
+    unknown = [name for name in injected_args if name not in parameters]
+    if unknown:
+        msg = (
+            "Injected tool parameter(s) "
+            f"{', '.join(sorted(unknown))} do not match function "
+            f"{func.__qualname__} parameters."
+        )
+        raise ValueError(msg)

--- a/python/flink_agents/api/tools/utils.py
+++ b/python/flink_agents/api/tools/utils.py
@@ -18,16 +18,19 @@
 import json
 import typing
 from inspect import signature
-from typing import Any, Callable, Dict, Optional, Type, Union
+from typing import Any, Callable, Dict, Iterable, Optional, Type, Union
 
 from docstring_parser import parse
 from pydantic import BaseModel, create_model
 from pydantic.fields import Field, FieldInfo
 
 
-def create_schema_from_function(name: str, func: Callable) -> Type[BaseModel]:
+def create_schema_from_function(
+    name: str, func: Callable, injected_args: Iterable[str] | None = None
+) -> Type[BaseModel]:
     """Create a pydantic schema from a function's signature."""
     docstr = func.__doc__
+    injected = set(injected_args or ())
 
     docstr = parse(docstr)
     doc_params = {}
@@ -37,6 +40,8 @@ def create_schema_from_function(name: str, func: Callable) -> Type[BaseModel]:
     fields = {}
     params = signature(func).parameters
     for param_name in params:
+        if param_name in injected:
+            continue
         param_type = params[param_name].annotation
         param_default = params[param_name].default
         description = doc_params.get(param_name)

--- a/python/flink_agents/api/yaml/loader.py
+++ b/python/flink_agents/api/yaml/loader.py
@@ -188,7 +188,7 @@ def _build_tool(spec: ToolSpec) -> FunctionTool:
         language=spec.type,
         parameter_types=spec.parameter_types,
     )
-    return FunctionTool(func=func)
+    return FunctionTool(func=func, injected_args=spec.injected_args)
 
 
 def _build_prompt(spec: PromptSpec) -> Prompt:

--- a/python/flink_agents/api/yaml/specs.py
+++ b/python/flink_agents/api/yaml/specs.py
@@ -29,6 +29,11 @@ from typing import Any, Dict, List, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from flink_agents.api.tools.tool_parameter_injection import (
+    InjectedArg,
+    normalize_injected_args,
+)
+
 Language = Literal["python", "java"]
 """Implementation language of a YAML-declared resource, action, or tool."""
 
@@ -121,6 +126,15 @@ class ToolSpec(BaseModel):
     function: str | None = None
     type: Language | None = None
     parameter_types: List[str] | None = None
+    injected_args: Dict[str, InjectedArg | dict] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_injected_args(cls, data: dict) -> dict:
+        if isinstance(data, dict) and "injected_args" in data:
+            data = dict(data)
+            data["injected_args"] = normalize_injected_args(data["injected_args"])
+        return data
 
 
 class PackageSkillSpec(BaseModel):

--- a/python/flink_agents/api/yaml/tests/fixtures/loader_targets.py
+++ b/python/flink_agents/api/yaml/tests/fixtures/loader_targets.py
@@ -35,6 +35,10 @@ def notify(id: str, message: str) -> str:
     return f"notified {id}: {message}"
 
 
+def query_order(order_id: str, tenant_id: str) -> str:
+    return f"{tenant_id}:{order_id}"
+
+
 class Counter:
     """Holder for a class-method action target — exercises the
     ``module:Class.method`` form in YAML function references.

--- a/python/flink_agents/api/yaml/tests/test_loader.py
+++ b/python/flink_agents/api/yaml/tests/test_loader.py
@@ -28,6 +28,7 @@ from flink_agents.api.function import JavaFunction, PythonFunction
 from flink_agents.api.prompts.prompt import LocalPrompt
 from flink_agents.api.resource import ResourceDescriptor, ResourceName, ResourceType
 from flink_agents.api.skills import Skills, SkillSourceSpec
+from flink_agents.api.tools import InjectedArg
 from flink_agents.api.tools.function_tool import FunctionTool
 from flink_agents.api.yaml.loader import (
     _build_skills,
@@ -618,3 +619,58 @@ def test_build_agents_builds_java_tool_descriptor(tmp_path: Path) -> None:
     assert tool.func.qualname == "com.example.Tools"
     assert tool.func.method_name == "add"
     assert tool.func.parameter_types == ["int", "int"]
+
+
+def test_build_agents_builds_tool_injected_args(tmp_path: Path) -> None:
+    yaml_text = (
+        "agents:\n"
+        "  - name: a\n"
+        "    tools:\n"
+        "      - name: query_order\n"
+        f"        function: {_TARGETS_MODULE}:query_order\n"
+        "        injected_args:\n"
+        "          tenant_id:\n"
+        "            source: config\n"
+        "            key: tenant.id\n"
+        "    actions:\n"
+        "      - name: noop\n"
+        f"        function: {_TARGETS_MODULE}:increment\n"
+        "        trigger_conditions: [input]\n"
+    )
+    p = tmp_path / "tool_injection.yaml"
+    p.write_text(yaml_text)
+    agents, _, _ = build_agents(p)
+    agent = agents["a"]
+
+    tool = agent.resources[ResourceType.TOOL]["query_order"]
+    assert isinstance(tool, FunctionTool)
+    assert tool.injected_args == {"tenant_id": InjectedArg.from_config("tenant.id")}
+
+
+def test_build_agents_keeps_unknown_tool_injected_arg_for_plan_validation(
+    tmp_path: Path,
+) -> None:
+    yaml_text = (
+        "agents:\n"
+        "  - name: a\n"
+        "    tools:\n"
+        "      - name: query_order\n"
+        f"        function: {_TARGETS_MODULE}:query_order\n"
+        "        injected_args:\n"
+        "          tenent_id:\n"
+        "            source: config\n"
+        "            key: tenant.id\n"
+        "    actions:\n"
+        "      - name: noop\n"
+        f"        function: {_TARGETS_MODULE}:increment\n"
+        "        trigger_conditions: [input]\n"
+    )
+    p = tmp_path / "bad_tool_injection.yaml"
+    p.write_text(yaml_text)
+
+    agents, _, _ = build_agents(p)
+    agent = agents["a"]
+
+    tool = agent.resources[ResourceType.TOOL]["query_order"]
+    assert isinstance(tool, FunctionTool)
+    assert tool.injected_args == {"tenent_id": InjectedArg.from_config("tenant.id")}

--- a/python/flink_agents/api/yaml/tests/test_specs.py
+++ b/python/flink_agents/api/yaml/tests/test_specs.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
+from flink_agents.api.tools import InjectedArg
 from flink_agents.api.yaml.specs import (
     ActionSpec,
     AgentSpec,
@@ -65,6 +66,65 @@ def test_descriptor_spec_accepts_python_and_java() -> None:
 def test_descriptor_spec_rejects_unknown_type() -> None:
     with pytest.raises(ValidationError):
         DescriptorSpec.model_validate({"name": "n", "clazz": "x.Y", "type": "go"})
+
+
+def test_tool_spec_rejects_list_injected_args() -> None:
+    with pytest.raises(TypeError, match="'injected_args' must be a dict"):
+        ToolSpec.model_validate(
+            {"name": "t", "function": "pkg:fn", "injected_args": ["tenant_id"]}
+        )
+
+
+def test_tool_spec_rejects_string_injected_arg_spec() -> None:
+    with pytest.raises(TypeError, match="Unsupported injected arg spec"):
+        ToolSpec.model_validate(
+            {
+                "name": "t",
+                "function": "pkg:fn",
+                "injected_args": {"tenant_id": "tenant.id"},
+            }
+        )
+
+
+def test_tool_spec_accepts_declarative_injected_args() -> None:
+    spec = ToolSpec.model_validate(
+        {
+            "name": "t",
+            "function": "pkg:fn",
+            "injected_args": {"tenant_id": {"source": "config", "key": "tenant.id"}},
+        }
+    )
+    assert spec.injected_args == {
+        "tenant_id": InjectedArg.from_config("tenant.id"),
+    }
+
+
+def test_tool_spec_defaults_injected_arg_source_to_sensory_memory() -> None:
+    spec = ToolSpec.model_validate(
+        {
+            "name": "t",
+            "function": "pkg:fn",
+            "injected_args": {"tenant_id": {"key": "request.tenant_id"}},
+        }
+    )
+    assert spec.injected_args == {
+        "tenant_id": InjectedArg.from_sensory_memory("request.tenant_id"),
+    }
+
+
+def test_tool_spec_accepts_uppercase_injected_arg_source() -> None:
+    spec = ToolSpec.model_validate(
+        {
+            "name": "t",
+            "function": "pkg:fn",
+            "injected_args": {
+                "tenant_id": {"source": "SENSORY_MEMORY", "key": "request.tenant_id"}
+            },
+        }
+    )
+    assert spec.injected_args == {
+        "tenant_id": InjectedArg.from_sensory_memory("request.tenant_id"),
+    }
 
 
 def test_message_role_values() -> None:

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/execute_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/execute_test.py
@@ -96,7 +96,7 @@ def test_durable_execute_basic_flink(tmp_path: Path) -> None:
 
     check_result(
         result_dir=result_dir,
-        groud_truth_dir=Path(
+        ground_truth_dir=Path(
             f"{current_dir}/../resources/ground_truth/test_execute_basic.txt"
         ),
     )
@@ -148,7 +148,7 @@ def test_durable_execute_multiple_calls_flink(tmp_path: Path) -> None:
 
     check_result(
         result_dir=result_dir,
-        groud_truth_dir=Path(
+        ground_truth_dir=Path(
             f"{current_dir}/../resources/ground_truth/test_execute_multiple.txt"
         ),
     )
@@ -200,7 +200,7 @@ def test_durable_execute_with_async_flink(tmp_path: Path) -> None:
 
     check_result(
         result_dir=result_dir,
-        groud_truth_dir=Path(
+        ground_truth_dir=Path(
             f"{current_dir}/../resources/ground_truth/test_execute_with_async.txt"
         ),
     )
@@ -252,7 +252,7 @@ def test_durable_execute_async_exception_flink(tmp_path: Path) -> None:
 
     check_result(
         result_dir=result_dir,
-        groud_truth_dir=Path(
+        ground_truth_dir=Path(
             f"{current_dir}/../resources/ground_truth/test_execute_async_exception.txt"
         ),
     )

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/flink_intergration_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/flink_intergration_test.py
@@ -94,7 +94,7 @@ def test_from_datastream_to_datastream(tmp_path: Path) -> None:
 
     check_result(
         result_dir=result_dir,
-        groud_truth_dir=Path(
+        ground_truth_dir=Path(
             f"{current_dir}/../resources/ground_truth/test_from_datastream_to_datastream.txt"
         ),
     )
@@ -169,7 +169,7 @@ def test_from_table_to_table(tmp_path: Path) -> None:
 
     check_result(
         result_dir=result_dir,
-        groud_truth_dir=Path(
+        ground_truth_dir=Path(
             f"{current_dir}/../resources/ground_truth/test_from_table_to_table.txt"
         ),
     )
@@ -242,7 +242,7 @@ def test_from_datastream_to_table(tmp_path: Path) -> None:
 
     check_result(
         result_dir=result_dir,
-        groud_truth_dir=Path(
+        ground_truth_dir=Path(
             f"{current_dir}/../resources/ground_truth/test_from_table_to_table.txt"
         ),
     )

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/tool_parameter_injection_agent.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/tool_parameter_injection_agent.py
@@ -1,0 +1,151 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+from pyflink.datastream import KeySelector
+
+from flink_agents.api.agents.agent import Agent
+from flink_agents.api.chat_message import ChatMessage, MessageRole
+from flink_agents.api.chat_models.chat_model import (
+    BaseChatModelConnection,
+    BaseChatModelSetup,
+)
+from flink_agents.api.decorators import (
+    action,
+    chat_model_connection,
+    chat_model_setup,
+    tool,
+)
+from flink_agents.api.events.chat_event import ChatRequestEvent, ChatResponseEvent
+from flink_agents.api.events.event import Event, InputEvent, OutputEvent
+from flink_agents.api.resource import ResourceDescriptor
+from flink_agents.api.runner_context import RunnerContext
+from flink_agents.api.tools import InjectedArg
+from flink_agents.api.tools.tool import Tool as BaseTool
+
+
+class OrderKeySelector(KeySelector):
+    """Key orders by their identifier."""
+
+    def get_key(self, value: str) -> str:
+        """Return the order id as key."""
+        return value
+
+
+class ToolParameterInjectionAgent(Agent):
+    """E2E agent covering tool parameter injection in a real Flink job."""
+
+    @chat_model_connection
+    @staticmethod
+    def mock_connection() -> ResourceDescriptor:
+        """Declare the mock chat connection."""
+        return ResourceDescriptor(
+            clazz=f"{MockToolChatConnection.__module__}.{MockToolChatConnection.__name__}"
+        )
+
+    @chat_model_setup
+    @staticmethod
+    def mock_model() -> ResourceDescriptor:
+        """Declare the mock chat model bound to query_order."""
+        return ResourceDescriptor(
+            clazz=f"{MockToolChatModel.__module__}.{MockToolChatModel.__name__}",
+            connection="mock_connection",
+            model="mock",
+            tools=["query_order"],
+        )
+
+    @tool(injected_args={"tenant_id": InjectedArg.from_config("tenant_id")})
+    @staticmethod
+    def query_order(order_id: str, tenant_id: str) -> str:
+        """Query order in the current tenant.
+
+        Parameters
+        ----------
+        order_id : str
+            The order id requested by the model.
+        tenant_id : str
+            The tenant id injected by runtime.
+
+        Returns:
+        -------
+        str:
+            The tenant-scoped order identifier.
+        """
+        return f"checked:{tenant_id}:{order_id}"
+
+    @action(InputEvent.EVENT_TYPE)
+    @staticmethod
+    def request_chat(event: Event, ctx: RunnerContext) -> None:
+        """Send a chat request that lets the mock model call the tool."""
+        order_id = str(InputEvent.from_event(event).input)
+        ctx.send_event(
+            ChatRequestEvent(
+                model="mock_model",
+                messages=[ChatMessage(role=MessageRole.USER, content=order_id)],
+            )
+        )
+
+    @action(ChatResponseEvent.EVENT_TYPE)
+    @staticmethod
+    def emit_result(event: Event, ctx: RunnerContext) -> None:
+        """Emit the final assistant response as output."""
+        response_event = ChatResponseEvent.from_event(event)
+        ctx.send_event(OutputEvent(output=response_event.response.content))
+
+
+class MockToolChatConnection(BaseChatModelConnection):
+    """Mock model connection that emits a tool call, then echoes tool output."""
+
+    def chat(
+        self,
+        messages: list[ChatMessage],
+        tools: list[BaseTool] | None = None,
+        **kwargs: object,
+    ) -> ChatMessage:
+        """Return a tool call for user input, or echo the tool response."""
+        last_message = messages[-1]
+        if last_message.role == MessageRole.TOOL:
+            return ChatMessage(role=MessageRole.ASSISTANT, content=last_message.content)
+
+        for candidate_tool in tools or []:
+            if "tenant_id" in str(candidate_tool.metadata.get_parameters_dict()):
+                msg = "Injected argument leaked into tool schema."
+                raise RuntimeError(msg)
+
+        order_id = str(last_message.content)
+        return ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="",
+            tool_calls=[
+                {
+                    "id": f"call-{order_id}",
+                    "type": "function",
+                    "function": {
+                        "name": "query_order",
+                        "arguments": {"order_id": order_id},
+                    },
+                }
+            ],
+        )
+
+
+class MockToolChatModel(BaseChatModelSetup):
+    """Mock chat model setup."""
+
+    @property
+    def model_kwargs(self):
+        """Return model kwargs."""
+        return {}

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/tool_parameter_injection_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/tool_parameter_injection_test.py
@@ -1,0 +1,79 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+from pathlib import Path
+
+from pyflink.common import Encoder, WatermarkStrategy
+from pyflink.common.typeinfo import Types
+from pyflink.datastream import RuntimeExecutionMode, StreamExecutionEnvironment
+from pyflink.datastream.connectors.file_system import (
+    FileSource,
+    StreamFormat,
+    StreamingFileSink,
+)
+
+from flink_agents.api.execution_environment import AgentsExecutionEnvironment
+from flink_agents.e2e_tests.e2e_tests_integration.tool_parameter_injection_agent import (
+    OrderKeySelector,
+    ToolParameterInjectionAgent,
+)
+from flink_agents.e2e_tests.test_utils import check_result
+
+current_dir = Path(__file__).parent
+
+
+def test_tool_parameter_injection_flink_job(tmp_path: Path) -> None:
+    """Run a full Flink job through built-in tool_call_action with injected args."""
+    env = StreamExecutionEnvironment.get_execution_environment()
+    env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
+    env.set_parallelism(1)
+
+    input_datastream = env.from_source(
+        source=FileSource.for_record_stream_format(
+            StreamFormat.text_line_format(),
+            f"file:///{current_dir}/../resources/tool_parameter_injection_input",
+        ).build(),
+        watermark_strategy=WatermarkStrategy.no_watermarks(),
+        source_name="tool_parameter_injection_source",
+    ).map(lambda x: str(x))
+
+    agents_env = AgentsExecutionEnvironment.get_execution_environment(env=env)
+    agents_env.get_config().set_str("tenant_id", "tenant-python")
+    output_datastream = (
+        agents_env.from_datastream(input_datastream, key_selector=OrderKeySelector())
+        .apply(ToolParameterInjectionAgent())
+        .to_datastream()
+    )
+
+    result_dir = tmp_path / "results"
+    result_dir.mkdir(parents=True, exist_ok=True)
+
+    output_datastream.map(lambda x: str(x), Types.STRING()).add_sink(
+        StreamingFileSink.for_row_format(
+            base_path=str(result_dir.absolute()),
+            encoder=Encoder.simple_string_encoder(),
+        ).build()
+    )
+
+    agents_env.execute()
+
+    check_result(
+        result_dir=result_dir,
+        ground_truth_dir=Path(
+            f"{current_dir}/../resources/ground_truth/test_tool_parameter_injection.txt"
+        ),
+    )

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/yaml_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/yaml_test.py
@@ -43,17 +43,23 @@ from pyflink.datastream.connectors.file_system import (
 )
 
 from flink_agents.api.execution_environment import AgentsExecutionEnvironment
+from flink_agents.e2e_tests.e2e_tests_integration.tool_parameter_injection_agent import (
+    OrderKeySelector,
+)
 from flink_agents.e2e_tests.e2e_tests_integration.yaml_test_actions import (
     YamlChatInput,
     YamlChatKeySelector,
     YamlChatOutput,
 )
-from flink_agents.e2e_tests.test_utils import pull_model
+from flink_agents.e2e_tests.test_utils import check_result, pull_model
 
 current_dir = Path(__file__).parent
 _RESOURCES = current_dir.parent / "resources"
+_PYTHON_PATH = os.pathsep.join(
+    [str(current_dir.parents[2]), sysconfig.get_paths()["purelib"]]
+)
 
-os.environ["PYTHONPATH"] = sysconfig.get_paths()["purelib"]
+os.environ["PYTHONPATH"] = _PYTHON_PATH
 
 _OLLAMA_MODEL = "qwen3:1.7b"
 _client = pull_model(_OLLAMA_MODEL)
@@ -69,7 +75,7 @@ def test_single_yaml_agent(tmp_path: Path) -> None:
     plain creative chat model declared in the same YAML.
     """
     config = Configuration()
-    config.set_string("python.pythonpath", sysconfig.get_paths()["purelib"])
+    config.set_string("python.pythonpath", _PYTHON_PATH)
     env = StreamExecutionEnvironment.get_execution_environment(config)
     env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
     env.set_parallelism(1)
@@ -139,7 +145,7 @@ def test_chained_yaml_agents(tmp_path: Path) -> None:
     the second LLM hop.
     """
     config = Configuration()
-    config.set_string("python.pythonpath", sysconfig.get_paths()["purelib"])
+    config.set_string("python.pythonpath", _PYTHON_PATH)
     env = StreamExecutionEnvironment.get_execution_environment(config)
     env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
     env.set_parallelism(1)
@@ -198,6 +204,53 @@ def test_chained_yaml_agents(tmp_path: Path) -> None:
     final_answer = answers[1]
     assert "3" in final_answer, (
         f"math result missing from chained output: {final_answer!r}"
+    )
+
+
+def test_yaml_tool_parameter_injection_agent(tmp_path: Path) -> None:
+    """YAML ``injected_args`` hides tenant_id from schema and injects it at call time."""
+    config = Configuration()
+    config.set_string("python.pythonpath", _PYTHON_PATH)
+    env = StreamExecutionEnvironment.get_execution_environment(config)
+    env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
+    env.set_parallelism(1)
+
+    input_datastream = env.from_source(
+        source=FileSource.for_record_stream_format(
+            StreamFormat.text_line_format(),
+            f"file:///{_RESOURCES}/tool_parameter_injection_input",
+        ).build(),
+        watermark_strategy=WatermarkStrategy.no_watermarks(),
+        source_name="yaml_tool_parameter_injection_source",
+    ).map(lambda x: str(x))
+
+    agents_env = AgentsExecutionEnvironment.get_execution_environment(env=env)
+    agents_env.get_config().set_str("tenant_id", "tenant-yaml")
+    agents_env.load_yaml(_RESOURCES / "yaml_tool_parameter_injection_agent.yaml")
+
+    output_datastream = (
+        agents_env.from_datastream(input_datastream, key_selector=OrderKeySelector())
+        .apply("yaml_tool_parameter_injection_agent")
+        .to_datastream()
+    )
+
+    result_dir = tmp_path / "results"
+    result_dir.mkdir(parents=True, exist_ok=True)
+
+    output_datastream.map(lambda x: str(x), Types.STRING()).add_sink(
+        StreamingFileSink.for_row_format(
+            base_path=str(result_dir.absolute()),
+            encoder=Encoder.simple_string_encoder(),
+        ).build()
+    )
+
+    agents_env.execute()
+
+    check_result(
+        result_dir=result_dir,
+        ground_truth_dir=_RESOURCES
+        / "ground_truth"
+        / "test_yaml_tool_parameter_injection.txt",
     )
 
 

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/yaml_test_actions.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/yaml_test_actions.py
@@ -75,6 +75,24 @@ def add(a: int, b: int) -> int:
     return a + b
 
 
+def query_order(order_id: str, tenant_id: str) -> str:
+    """Query an order in the injected tenant.
+
+    Parameters
+    ----------
+    order_id : str
+        The order id requested by the model.
+    tenant_id : str
+        The tenant id injected by runtime.
+
+    Returns:
+    -------
+    str:
+        The tenant-scoped order identifier.
+    """
+    return f"yaml-checked:{tenant_id}:{order_id}"
+
+
 def process_input(event: Event, ctx: RunnerContext) -> None:
     """Route the incoming text to the math or creative chat model.
 

--- a/python/flink_agents/e2e_tests/resources/ground_truth/test_from_table_to_table.txt
+++ b/python/flink_agents/e2e_tests/resources/ground_truth/test_from_table_to_table.txt
@@ -1,10 +1,10 @@
-'{"id":1,"review":"Great product! Works perfectly and lasts a long time. first action second action","review_score":3.0}
-'{"id":2,"review":"The item arrived damaged, and the packaging was poor. first action second action","review_score":5.0}
-'{"id":3,"review":"Highly satisfied with the performance and value for money. first action second action","review_score":7.0}
-'{"id":3,"review":"Not as good as expected. It stopped working after a week. first action second action","review_score":8.0}
-'{"id":1,"review":"Fast shipping and excellent customer service. Would buy again! first action second action","review_score":8.0}
-'{"id":2,"review":"Too complicated to set up. Instructions were unclear. first action second action","review_score":8.0}
-'{"id":2,"review":"Good quality, but overview_scored for what it does. first action second action","review_score":8.0}
-'{"id":1,"review":"Exactly what I needed. Easy to use and very reliable. first action second action","review_score":8.0}
-'{"id":2,"review":"Worst purchase ever. Waste of money and time. first action second action","review_score":8.0}
-'{"id":2,"review":"Looks nice and functions well, but could be more durable. first action second action","review_score":8.0}
+{"id":1,"review":"Great product! Works perfectly and lasts a long time. first action second action","review_score":3.0}
+{"id":2,"review":"The item arrived damaged, and the packaging was poor. first action second action","review_score":5.0}
+{"id":3,"review":"Highly satisfied with the performance and value for money. first action second action","review_score":7.0}
+{"id":3,"review":"Not as good as expected. It stopped working after a week. first action second action","review_score":8.0}
+{"id":1,"review":"Fast shipping and excellent customer service. Would buy again! first action second action","review_score":8.0}
+{"id":2,"review":"Too complicated to set up. Instructions were unclear. first action second action","review_score":8.0}
+{"id":2,"review":"Good quality, but overview_scored for what it does. first action second action","review_score":8.0}
+{"id":1,"review":"Exactly what I needed. Easy to use and very reliable. first action second action","review_score":8.0}
+{"id":2,"review":"Worst purchase ever. Waste of money and time. first action second action","review_score":8.0}
+{"id":2,"review":"Looks nice and functions well, but could be more durable. first action second action","review_score":8.0}

--- a/python/flink_agents/e2e_tests/resources/ground_truth/test_tool_parameter_injection.txt
+++ b/python/flink_agents/e2e_tests/resources/ground_truth/test_tool_parameter_injection.txt
@@ -1,0 +1,2 @@
+checked:tenant-python:order-1
+checked:tenant-python:order-2

--- a/python/flink_agents/e2e_tests/resources/ground_truth/test_yaml_tool_parameter_injection.txt
+++ b/python/flink_agents/e2e_tests/resources/ground_truth/test_yaml_tool_parameter_injection.txt
@@ -1,0 +1,2 @@
+yaml-checked:tenant-yaml:order-1
+yaml-checked:tenant-yaml:order-2

--- a/python/flink_agents/e2e_tests/resources/tool_parameter_injection_input/input.txt
+++ b/python/flink_agents/e2e_tests/resources/tool_parameter_injection_input/input.txt
@@ -1,0 +1,2 @@
+order-1
+order-2

--- a/python/flink_agents/e2e_tests/resources/yaml_tool_parameter_injection_agent.yaml
+++ b/python/flink_agents/e2e_tests/resources/yaml_tool_parameter_injection_agent.yaml
@@ -1,0 +1,30 @@
+agents:
+  - name: yaml_tool_parameter_injection_agent
+    description: YAML-driven e2e agent with declarative tool parameter injection.
+
+    chat_model_connections:
+      - name: mock_connection
+        clazz: flink_agents.e2e_tests.e2e_tests_integration.tool_parameter_injection_agent.MockToolChatConnection
+
+    chat_model_setups:
+      - name: mock_model
+        clazz: flink_agents.e2e_tests.e2e_tests_integration.tool_parameter_injection_agent.MockToolChatModel
+        connection: mock_connection
+        model: mock
+        tools: [query_order]
+
+    tools:
+      - name: query_order
+        function: flink_agents.e2e_tests.e2e_tests_integration.yaml_test_actions:query_order
+        injected_args:
+          tenant_id:
+            source: config
+            key: tenant_id
+
+    actions:
+      - name: request_chat
+        function: flink_agents.e2e_tests.e2e_tests_integration.tool_parameter_injection_agent:ToolParameterInjectionAgent.request_chat
+        trigger_conditions: [input]
+      - name: emit_result
+        function: flink_agents.e2e_tests.e2e_tests_integration.tool_parameter_injection_agent:ToolParameterInjectionAgent.emit_result
+        trigger_conditions: [chat_response]

--- a/python/flink_agents/e2e_tests/test_utils.py
+++ b/python/flink_agents/e2e_tests/test_utils.py
@@ -164,20 +164,32 @@ def pull_model(ollama_model: str) -> Client:
     return client
 
 
-def check_result(*, result_dir: Path, groud_truth_dir: Path) -> None:
+def check_result(*, result_dir: Path, ground_truth_dir: Path) -> None:
     """Util function for checking flink job execution result."""
-    actual_result = []
+    actual_lines: list[str] = []
     for file in result_dir.iterdir():
         if file.is_dir():
             for child in file.iterdir():
                 with child.open() as f:
-                    actual_result.extend(f.readlines())
+                    actual_lines.extend(f.readlines())
         if file.is_file():
             with file.open() as f:
-                actual_result.extend(f.readlines())
+                actual_lines.extend(f.readlines())
 
-    with groud_truth_dir.open() as f:
-        expected = f.readlines().sort()
+    with ground_truth_dir.open() as f:
+        expected_lines = f.readlines()
 
-    actual_result = actual_result.sort()
-    assert actual_result == expected
+    def _normalize(line: str) -> str:
+        stripped = line.strip()
+        try:
+            return json.dumps(json.loads(stripped), sort_keys=True)
+        except (json.JSONDecodeError, ValueError):
+            return stripped
+
+    actual = sorted(_normalize(line) for line in actual_lines if line.strip())
+    expected = sorted(_normalize(line) for line in expected_lines if line.strip())
+    assert actual, "No actual results found in result_dir"
+    assert expected, "No expected results found in ground_truth_dir"
+    assert actual == expected, (
+        f"Result mismatch:\n  actual={actual}\n  expected={expected}"
+    )

--- a/python/flink_agents/plan/actions/tool_call_action.py
+++ b/python/flink_agents/plan/actions/tool_call_action.py
@@ -20,12 +20,19 @@ import logging
 from flink_agents.api.core_options import AgentExecutionOptions
 from flink_agents.api.events.event import Event
 from flink_agents.api.events.tool_event import ToolRequestEvent, ToolResponseEvent
+from flink_agents.api.memory_object import MemoryObject
 from flink_agents.api.resource import ResourceType
 from flink_agents.api.runner_context import RunnerContext
+from flink_agents.api.tools.tool_parameter_injection import (
+    InjectedArg,
+    ToolParameterSource,
+)
 from flink_agents.plan.actions.action import Action
 from flink_agents.plan.function import PythonFunction
+from flink_agents.plan.tools.function_tool import FunctionTool
 
 _logger = logging.getLogger(__name__)
+
 
 async def process_tool_request(event: Event, ctx: RunnerContext) -> None:
     """Built-in action for processing tool call requests."""
@@ -37,27 +44,99 @@ async def process_tool_request(event: Event, ctx: RunnerContext) -> None:
         _logger.debug("Processing tool call asynchronously.")
 
     responses = {}
+    success = {}
+    error = {}
     external_ids = {}
     for tool_call in event.tool_calls:
-        id = tool_call["id"]
+        call_id = tool_call["id"]
         name = tool_call["function"]["name"]
         kwargs = tool_call["function"]["arguments"]
-        tool = ctx.get_resource(name, ResourceType.TOOL)
         external_id = tool_call.get("original_id")
+
+        try:
+            tool = ctx.get_resource(name, ResourceType.TOOL)
+        except Exception as e:
+            tool = None
+            error[call_id] = str(e)
         if not tool:
-            response = f"Tool `{name}` does not exist."
+            responses[call_id] = f"Tool `{name}` does not exist."
+            success[call_id] = False
+            error.setdefault(call_id, f"Tool `{name}` does not exist.")
+            external_ids[call_id] = external_id
+            continue
         else:
-            if tool_call_async:
-                response = await ctx.durable_execute_async(tool.call, **kwargs)
-            else:
-                response = ctx.durable_execute(tool.call, **kwargs)
-        responses[id] = response
-        external_ids[id] = external_id
+            try:
+                call_kwargs = dict(kwargs or {})
+                # Framework-owned injected args must win over model-provided values so
+                # hidden context such as tenant ids cannot be spoofed by tool calls.
+                call_kwargs.update(_resolve_injected_arguments(tool, ctx))
+                if tool_call_async:
+                    response = await ctx.durable_execute_async(
+                        tool.call, **call_kwargs
+                    )
+                else:
+                    response = ctx.durable_execute(tool.call, **call_kwargs)
+                responses[call_id] = response
+                success[call_id] = True
+            except Exception as e:
+                responses[call_id] = f"Tool `{name}` execute failed."
+                success[call_id] = False
+                error[call_id] = str(e)
+
+        external_ids[call_id] = external_id
     ctx.send_event(
         ToolResponseEvent(
-            request_id=event.id, responses=responses, external_ids=external_ids
+            request_id=event.id,
+            responses=responses,
+            external_ids=external_ids,
+            success=success,
+            error=error,
         )
     )
+
+
+def _resolve_injected_arguments(tool: object, ctx: RunnerContext) -> dict:
+    if not isinstance(tool, FunctionTool):
+        return {}
+    return {
+        name: _resolve_injected_argument(injection, ctx)
+        for name, injection in tool.injected_args.items()
+    }
+
+
+def _resolve_injected_argument(injection: InjectedArg, ctx: RunnerContext) -> object:
+    key = injection.key
+    if not key:
+        msg = "Injected tool parameter is missing key"
+        raise ValueError(msg)
+    if injection.source == ToolParameterSource.CONFIG:
+        conf_data = ctx.config.conf_data
+        if key not in conf_data:
+            msg = f"Missing config for injected tool parameter: {key}"
+            raise ValueError(msg)
+        return conf_data[key]
+    if injection.source == ToolParameterSource.SENSORY_MEMORY:
+        return _get_memory_value(ctx.sensory_memory, "sensory_memory", key)
+    if injection.source == ToolParameterSource.SHORT_TERM_MEMORY:
+        return _get_memory_value(ctx.short_term_memory, "short_term_memory", key)
+    msg = f"Unsupported tool parameter source: {injection.source}"
+    raise ValueError(msg)
+
+
+def _get_memory_value(memory: MemoryObject, source: str, path: str) -> object:
+    if memory is None:
+        msg = (
+            f"Cannot inject tool parameter from {source} because memory is not initialized."
+        )
+        raise ValueError(msg)
+    if not memory.is_exist(path):
+        msg = f"Missing memory path for injected tool parameter: {path}"
+        raise ValueError(msg)
+    value = memory.get(path)
+    if isinstance(value, MemoryObject):
+        msg = f"Memory path for injected tool parameter must reference a value: {path}"
+        raise TypeError(msg)
+    return value
 
 
 TOOL_CALL_ACTION = Action(

--- a/python/flink_agents/plan/agent_plan.py
+++ b/python/flink_agents/plan/agent_plan.py
@@ -328,8 +328,6 @@ def _to_plan_function(func: ApiFunction) -> PythonFunction | JavaFunction:
     raise TypeError(msg)
 
 
-
-
 def _get_resource_providers(
     agent: Agent, config: AgentConfiguration
 ) -> List[ResourceProvider]:
@@ -359,16 +357,21 @@ def _get_resource_providers(
                     )
 
         elif hasattr(value, "_is_tool"):
+            injected_args = getattr(value, "_injected_args", None)
             if isinstance(value, staticmethod):
                 value = value.__func__
+                injected_args = injected_args or getattr(value, "_injected_args", None)
 
             if callable(value):
                 # TODO: support other tool type.
-                tool = Tool.from_callable(func=value)
+                tool = Tool.from_callable(func=value, injected_args=injected_args)
                 resource_providers.append(
                     PythonSerializableResourceProvider.from_resource(
                         name=name,
-                        resource=FunctionTool(func=_to_plan_function(tool.func)),
+                        resource=FunctionTool(
+                            func=_to_plan_function(tool.func),
+                            injected_args=dict(tool.injected_args),
+                        ),
                     )
                 )
         elif hasattr(value, "_is_prompt"):
@@ -402,7 +405,10 @@ def _get_resource_providers(
             PythonSerializableResourceProvider.from_resource(
                 name=name,
                 resource=(
-                    FunctionTool(func=_to_plan_function(tool.func))
+                    FunctionTool(
+                        func=_to_plan_function(tool.func),
+                        injected_args=dict(tool.injected_args),
+                    )
                     if isinstance(tool, ApiFunctionTool)
                     else tool
                 ),

--- a/python/flink_agents/plan/tests/actions/test_chat_model_action_retry.py
+++ b/python/flink_agents/plan/tests/actions/test_chat_model_action_retry.py
@@ -344,3 +344,57 @@ class TestProcessToolResponsePromptArgsForwarding:
         assert captured_prompt_args[0] == saved_prompt_args
         assert len(sent_events) == 1
         assert isinstance(sent_events[0], ChatResponseEvent)
+
+    def test_failed_tool_response_uses_generic_response_message(self) -> None:
+        initial_request_id = uuid4()
+        tool_request_event_id = uuid4()
+        tool_call_id = "call-1"
+
+        captured_messages: list[Sequence[ChatMessage]] = []
+
+        def mock_chat(messages: Sequence[ChatMessage], **kwargs: Any) -> ChatMessage:
+            captured_messages.append(messages)
+            return ChatMessage(role=MessageRole.ASSISTANT, content="done")
+
+        chat_model = MagicMock()
+        chat_model.chat = mock_chat
+
+        ctx, _, _, sensory_memory = _create_mock_runner_context(
+            chat_model, max_retries=0, retry_wait_interval_sec=0
+        )
+        sensory_memory.set(
+            "_TOOL_REQUEST_EVENT_CONTEXT",
+            {
+                str(tool_request_event_id): {
+                    "initial_request_id": str(initial_request_id),
+                    "model": "test-model",
+                    "prompt_args": {},
+                    "output_schema": None,
+                }
+            },
+        )
+        sensory_memory.set(
+            "_TOOL_CALL_CONTEXT",
+            {
+                str(initial_request_id): [
+                    ChatMessage(
+                        role=MessageRole.USER, content="hi"
+                    ).model_dump(mode="json")
+                ]
+            },
+        )
+
+        tool_response_event = ToolResponseEvent(
+            request_id=tool_request_event_id,
+            responses={tool_call_id: "Tool `query_order` execute failed."},
+            external_ids={},
+            success={tool_call_id: False},
+            error={tool_call_id: "Missing config for injected tool parameter: tenant_id"},
+        )
+
+        asyncio.run(process_chat_request_or_tool_response(tool_response_event, ctx))
+
+        assert captured_messages
+        tool_message = captured_messages[0][-1]
+        assert tool_message.role == MessageRole.TOOL
+        assert tool_message.content == "Tool `query_order` execute failed."

--- a/python/flink_agents/plan/tests/actions/test_tool_call_action.py
+++ b/python/flink_agents/plan/tests/actions/test_tool_call_action.py
@@ -1,0 +1,290 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+import asyncio
+from typing import Any
+
+from flink_agents.api.core_options import AgentExecutionOptions
+from flink_agents.api.events.tool_event import ToolRequestEvent, ToolResponseEvent
+from flink_agents.api.memory_object import MemoryObject
+from flink_agents.api.resource import ResourceType
+from flink_agents.api.tools import InjectedArg
+from flink_agents.plan.actions.tool_call_action import process_tool_request
+from flink_agents.plan.configuration import AgentConfiguration
+from flink_agents.plan.function import PythonFunction
+from flink_agents.plan.tools.function_tool import FunctionTool
+
+
+def query_order(order_id: str, tenant_id: str) -> str:
+    return f"{tenant_id}:{order_id}"
+
+
+class _Context:
+    def __init__(
+        self,
+        config: Any | None = None,
+        injected_args: dict[str, InjectedArg] | None = None,
+        sensory_memory: Any | None = None,
+        short_term_memory: Any | None = None,
+    ) -> None:
+        self.config = config or AgentConfiguration({"tenant_id": "tenant-1"})
+        if isinstance(self.config, AgentConfiguration):
+            self.config.set(AgentExecutionOptions.TOOL_CALL_ASYNC, False)
+        self.injected_args = injected_args or {
+            "tenant_id": InjectedArg.from_config("tenant_id")
+        }
+        self.sensory_memory = sensory_memory
+        self.short_term_memory = short_term_memory
+        self.sent_events = []
+
+    def get_resource(self, name: str, type: ResourceType) -> FunctionTool:
+        assert name == "query_order"
+        assert type == ResourceType.TOOL
+        return FunctionTool(
+            func=PythonFunction.from_callable(query_order),
+            injected_args=self.injected_args,
+        )
+
+    def durable_execute(self, func: Any, **kwargs: Any) -> Any:
+        return func(**kwargs)
+
+    async def durable_execute_async(self, func: Any, **kwargs: Any) -> Any:
+        return func(**kwargs)
+
+    def send_event(self, event: Any) -> None:
+        self.sent_events.append(event)
+
+
+class _Memory:
+    def __init__(self, values: dict[str, Any]) -> None:
+        self.values = values
+
+    def is_exist(self, path: str) -> bool:
+        return path in self.values
+
+    def get(self, path: str) -> Any:
+        return self.values[path]
+
+
+class _NestedMemoryObject(MemoryObject):
+    def get(self, path_or_ref: Any) -> Any:
+        return None
+
+    def set(self, path: str, value: Any) -> Any:
+        raise NotImplementedError
+
+    def new_object(self, path: str, *, overwrite: bool = False) -> "_NestedMemoryObject":
+        raise NotImplementedError
+
+    def is_exist(self, path: str) -> bool:
+        return False
+
+    def get_field_names(self) -> list[str]:
+        return []
+
+    def get_fields(self) -> dict[str, Any]:
+        return {}
+
+
+class _WrongConfig:
+    def get(self, option: Any) -> bool:
+        assert option == AgentExecutionOptions.TOOL_CALL_ASYNC
+        return False
+
+
+def test_tool_call_action_injects_args_from_config_without_mutating_request() -> None:
+    ctx = _Context()
+    arguments = {"order_id": "order-1"}
+    event = ToolRequestEvent(
+        model="model",
+        tool_calls=[
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "query_order", "arguments": arguments},
+            }
+        ],
+    )
+
+    asyncio.run(process_tool_request(event, ctx))
+
+    response = ToolResponseEvent.from_event(ctx.sent_events[0])
+    assert response.responses["call-1"] == "tenant-1:order-1"
+    assert response.success["call-1"] is True
+    assert response.error == {}
+    assert arguments == {"order_id": "order-1"}
+
+
+def test_tool_call_action_injected_arg_overrides_model_argument() -> None:
+    ctx = _Context()
+    arguments = {"order_id": "order-1", "tenant_id": "model-tenant"}
+    event = ToolRequestEvent(
+        model="model",
+        tool_calls=[
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "query_order", "arguments": arguments},
+            }
+        ],
+    )
+
+    asyncio.run(process_tool_request(event, ctx))
+
+    response = ToolResponseEvent.from_event(ctx.sent_events[0])
+    assert response.responses["call-1"] == "tenant-1:order-1"
+    assert response.success["call-1"] is True
+
+
+def test_tool_call_action_injects_args_from_sensory_memory() -> None:
+    ctx = _Context(
+        injected_args={
+            "tenant_id": InjectedArg.from_sensory_memory("request.tenant_id")
+        },
+        sensory_memory=_Memory({"request.tenant_id": "tenant-sensory"}),
+    )
+
+    asyncio.run(process_tool_request(tool_request(), ctx))
+
+    response = ToolResponseEvent.from_event(ctx.sent_events[0])
+    assert response.responses["call-1"] == "tenant-sensory:order-1"
+    assert response.success["call-1"] is True
+
+
+def test_tool_call_action_injects_args_from_short_term_memory() -> None:
+    ctx = _Context(
+        injected_args={
+            "tenant_id": InjectedArg.from_short_term_memory("session.tenant_id")
+        },
+        short_term_memory=_Memory({"session.tenant_id": "tenant-short"}),
+    )
+
+    asyncio.run(process_tool_request(tool_request(), ctx))
+
+    response = ToolResponseEvent.from_event(ctx.sent_events[0])
+    assert response.responses["call-1"] == "tenant-short:order-1"
+    assert response.success["call-1"] is True
+
+
+def test_tool_call_action_reports_missing_config_injected_arg() -> None:
+    ctx = _Context(AgentConfiguration({}))
+    event = ToolRequestEvent(
+        model="model",
+        tool_calls=[
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "query_order", "arguments": {"order_id": "order-1"}},
+            }
+        ],
+    )
+
+    asyncio.run(process_tool_request(event, ctx))
+
+    response = ToolResponseEvent.from_event(ctx.sent_events[0])
+    assert response.responses["call-1"] == "Tool `query_order` execute failed."
+    assert response.success["call-1"] is False
+    assert (
+        response.error["call-1"]
+        == "Missing config for injected tool parameter: tenant_id"
+    )
+
+
+def test_tool_call_action_reports_missing_memory_path() -> None:
+    ctx = _Context(
+        injected_args={
+            "tenant_id": InjectedArg.from_sensory_memory("request.tenant_id")
+        },
+        sensory_memory=_Memory({}),
+    )
+
+    asyncio.run(process_tool_request(tool_request(), ctx))
+
+    response = ToolResponseEvent.from_event(ctx.sent_events[0])
+    assert response.responses["call-1"] == "Tool `query_order` execute failed."
+    assert response.success["call-1"] is False
+    assert (
+        response.error["call-1"]
+        == "Missing memory path for injected tool parameter: request.tenant_id"
+    )
+
+
+def test_tool_call_action_reports_nested_memory_path() -> None:
+    ctx = _Context(
+        injected_args={
+            "tenant_id": InjectedArg.from_sensory_memory("request.tenant_id")
+        },
+        sensory_memory=_Memory({"request.tenant_id": _NestedMemoryObject()}),
+    )
+
+    asyncio.run(process_tool_request(tool_request(), ctx))
+
+    response = ToolResponseEvent.from_event(ctx.sent_events[0])
+    assert response.responses["call-1"] == "Tool `query_order` execute failed."
+    assert response.success["call-1"] is False
+    assert (
+        response.error["call-1"]
+        == "Memory path for injected tool parameter must reference a value: request.tenant_id"
+    )
+
+
+def test_tool_call_action_reports_uninitialized_memory() -> None:
+    ctx = _Context(
+        injected_args={
+            "tenant_id": InjectedArg.from_sensory_memory("request.tenant_id")
+        },
+    )
+
+    asyncio.run(process_tool_request(tool_request(), ctx))
+
+    response = ToolResponseEvent.from_event(ctx.sent_events[0])
+    assert response.responses["call-1"] == "Tool `query_order` execute failed."
+    assert response.success["call-1"] is False
+    assert (
+        response.error["call-1"]
+        == "Cannot inject tool parameter from sensory_memory because memory is not initialized."
+    )
+
+
+def test_tool_call_action_exposes_wrong_config_type() -> None:
+    ctx = _Context(config=_WrongConfig())
+
+    asyncio.run(process_tool_request(tool_request(), ctx))
+
+    response = ToolResponseEvent.from_event(ctx.sent_events[0])
+    assert response.responses["call-1"] == "Tool `query_order` execute failed."
+    assert response.success["call-1"] is False
+    assert response.error["call-1"] == "'_WrongConfig' object has no attribute 'conf_data'"
+
+
+def test_tool_call_action_uses_sync_execution_in_test_context() -> None:
+    ctx = _Context()
+
+    assert ctx.config.get(AgentExecutionOptions.TOOL_CALL_ASYNC) is False
+
+
+def tool_request() -> ToolRequestEvent:
+    return ToolRequestEvent(
+        model="model",
+        tool_calls=[
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "query_order", "arguments": {"order_id": "order-1"}},
+            }
+        ],
+    )

--- a/python/flink_agents/plan/tests/compatibility/create_python_agent_plan_from_json.py
+++ b/python/flink_agents/plan/tests/compatibility/create_python_agent_plan_from_json.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 #################################################################################
+import json
 import sys
 from pathlib import Path
 
@@ -29,6 +30,7 @@ if __name__ == "__main__":
     with Path.open(Path(json_path)) as f:
         java_plan_json = f.read()
 
+    raw_agent_plan = json.loads(java_plan_json)
     agent_plan = AgentPlan.model_validate_json(java_plan_json)
     actions = agent_plan.actions
 
@@ -80,3 +82,16 @@ if __name__ == "__main__":
 
     assert my_event in actions_by_event
     assert actions_by_event[my_event] == ["secondAction"]
+
+    # check Java tool parameter injection survives agent plan JSON
+    raw_tool_providers = raw_agent_plan["resource_providers"].get(
+        "tool", raw_agent_plan["resource_providers"].get("TOOL")
+    )
+    raw_tool_provider = raw_tool_providers["add"]
+    serialized_tool = json.loads(raw_tool_provider["serializedResource"])
+    input_schema = json.loads(serialized_tool["metadata"]["inputSchema"])
+    assert set(input_schema["properties"]) == {"a", "b"}
+    assert "tenant_id" not in input_schema["properties"]
+    assert serialized_tool["injected_args"] == {
+        "tenant_id": {"source": "config", "key": "tenant.id"}
+    }

--- a/python/flink_agents/plan/tests/compatibility/python_agent_plan_compatibility_test_agent.py
+++ b/python/flink_agents/plan/tests/compatibility/python_agent_plan_compatibility_test_agent.py
@@ -25,6 +25,7 @@ from flink_agents.api.events.event import Event
 from flink_agents.api.events.event_type import EventType
 from flink_agents.api.resource import ResourceDescriptor
 from flink_agents.api.runner_context import RunnerContext
+from flink_agents.api.tools import InjectedArg
 
 
 class MyEvent(Event):
@@ -75,9 +76,9 @@ class PythonAgentPlanCompatibilityTestAgent(Agent):
             model="mock-model",
         )
 
-    @tool
+    @tool(injected_args={"tenant_id": InjectedArg.from_config("tenant.id")})
     @staticmethod
-    def add(a: int, b: int) -> int:
+    def add(a: int, b: int, tenant_id: str) -> int:
         """Calculate the sum of a and b.
 
         Parameters
@@ -86,6 +87,8 @@ class PythonAgentPlanCompatibilityTestAgent(Agent):
             The first operand
         b : int
             The second operand
+        tenant_id : str
+            The injected tenant id
 
         Returns:
         -------

--- a/python/flink_agents/plan/tests/test_agent_plan.py
+++ b/python/flink_agents/plan/tests/test_agent_plan.py
@@ -29,6 +29,7 @@ from flink_agents.api.decorators import (
     chat_model_setup,
     embedding_model_connection,
     embedding_model_setup,
+    tool,
     vector_store,
 )
 from flink_agents.api.embedding_models.embedding_model import (
@@ -38,8 +39,11 @@ from flink_agents.api.embedding_models.embedding_model import (
 from flink_agents.api.events.event import Event, InputEvent, OutputEvent
 from flink_agents.api.events.event_type import EventType
 from flink_agents.api.function import JavaFunction
+from flink_agents.api.function import PythonFunction as ApiPythonFunction
 from flink_agents.api.resource import ResourceDescriptor, ResourceType
 from flink_agents.api.runner_context import RunnerContext
+from flink_agents.api.tools import InjectedArg
+from flink_agents.api.tools.function_tool import FunctionTool as ApiFunctionTool
 from flink_agents.api.vector_stores.vector_store import (
     BaseVectorStore,
     Document,
@@ -47,6 +51,8 @@ from flink_agents.api.vector_stores.vector_store import (
 from flink_agents.plan.agent_plan import AgentPlan
 from flink_agents.plan.configuration import AgentConfiguration
 from flink_agents.plan.function import PythonFunction
+from flink_agents.plan.resource_provider import PythonSerializableResourceProvider
+from flink_agents.plan.tools.function_tool import FunctionTool
 from flink_agents.runtime.resource_cache import ResourceCache
 
 
@@ -355,6 +361,139 @@ def test_agent_plan_deserialize(agent_plan: AgentPlan) -> None:
         expected_json = f.read()
     deserialized_agent_plan = AgentPlan.model_validate_json(expected_json)
     assert deserialized_agent_plan == agent_plan
+
+
+class AgentWithInjectedTool(Agent):
+    @tool(injected_args={"tenant_id": InjectedArg.from_config("tenant.id")})
+    @staticmethod
+    def query_order(order_id: str, tenant_id: str) -> str:
+        """Query an order.
+
+        Parameters
+        ----------
+        order_id : str
+            The order id.
+        tenant_id : str
+            The tenant id.
+        """
+        return f"{tenant_id}:{order_id}"
+
+
+def query_order(order_id: str, tenant_id: str) -> str:
+    return f"{tenant_id}:{order_id}"
+
+
+@tool(injected_args={"tenant_id": InjectedArg.from_config("tenant.id")})
+def decorated_query_order(order_id: str, tenant_id: str) -> str:
+    """Query an order.
+
+    Parameters
+    ----------
+    order_id : str
+        The order id.
+    tenant_id : str
+        The tenant id.
+    """
+    return f"{tenant_id}:{order_id}"
+
+
+def test_agent_plan_serializes_and_deserializes_tool_injected_args() -> None:
+    agent_plan = AgentPlan.from_agent(AgentWithInjectedTool(), AgentConfiguration())
+    json_value = agent_plan.model_dump_json(serialize_as_any=True)
+
+    raw_plan = json.loads(json_value)
+    raw_tool = raw_plan["resource_providers"]["tool"]["query_order"]["serialized"]
+    assert raw_tool["injected_args"] == {
+        "tenant_id": {"source": "config", "key": "tenant.id"}
+    }
+    assert "tenant_id" not in raw_tool["metadata"]["args_schema"]["properties"]
+
+    restored = AgentPlan.model_validate_json(json_value)
+    provider = restored.resource_providers[ResourceType.TOOL]["query_order"]
+    assert isinstance(provider, PythonSerializableResourceProvider)
+    assert provider.serialized["injected_args"] == {
+        "tenant_id": {"source": "config", "key": "tenant.id"}
+    }
+    tool_resource = provider.provide(None, AgentConfiguration())
+    assert isinstance(tool_resource, FunctionTool)
+    assert tool_resource.injected_args == {
+        "tenant_id": InjectedArg.from_config("tenant.id")
+    }
+
+
+def test_agent_plan_merges_decorated_python_tool_injected_args() -> None:
+    agent = Agent()
+    agent.add_resource(
+        name="query_order",
+        resource_type=ResourceType.TOOL,
+        instance=ApiFunctionTool(
+            func=ApiPythonFunction.from_callable(decorated_query_order),
+        ),
+    )
+
+    agent_plan = AgentPlan.from_agent(agent, AgentConfiguration())
+    provider = agent_plan.resource_providers[ResourceType.TOOL]["query_order"]
+    tool_resource = provider.provide(None, AgentConfiguration())
+    assert isinstance(tool_resource, FunctionTool)
+    assert tool_resource.injected_args == {
+        "tenant_id": InjectedArg.from_config("tenant.id")
+    }
+    assert (
+        "tenant_id"
+        not in tool_resource.metadata.args_schema.model_json_schema()["properties"]
+    )
+
+
+def test_agent_plan_accepts_matching_decorated_python_tool_injected_args() -> None:
+    agent = Agent()
+    agent.add_resource(
+        name="query_order",
+        resource_type=ResourceType.TOOL,
+        instance=ApiFunctionTool(
+            func=ApiPythonFunction.from_callable(decorated_query_order),
+            injected_args={"tenant_id": InjectedArg.from_config("tenant.id")},
+        ),
+    )
+
+    agent_plan = AgentPlan.from_agent(agent, AgentConfiguration())
+    provider = agent_plan.resource_providers[ResourceType.TOOL]["query_order"]
+    tool_resource = provider.provide(None, AgentConfiguration())
+    assert isinstance(tool_resource, FunctionTool)
+    assert tool_resource.injected_args == {
+        "tenant_id": InjectedArg.from_config("tenant.id")
+    }
+
+
+def test_agent_plan_rejects_conflicting_decorated_python_tool_injected_args() -> None:
+    agent = Agent()
+    agent.add_resource(
+        name="query_order",
+        resource_type=ResourceType.TOOL,
+        instance=ApiFunctionTool(
+            func=ApiPythonFunction.from_callable(decorated_query_order),
+            injected_args={
+                "tenant_id": InjectedArg.from_sensory_memory("request.tenant_id")
+            },
+        ),
+    )
+
+    with pytest.raises(ValueError, match="injected_args conflict"):
+        AgentPlan.from_agent(agent, AgentConfiguration())
+
+
+def test_agent_plan_validates_api_function_tool_injected_arg_names() -> None:
+    agent = Agent()
+    agent.add_resource(
+        name="query_order",
+        resource_type=ResourceType.TOOL,
+        instance=ApiFunctionTool(
+            func=ApiPythonFunction.from_callable(query_order),
+            injected_args={"tenent_id": InjectedArg.from_config("tenant.id")},
+        ),
+    )
+
+    with pytest.raises(ValueError, match="tenent_id do not match function"):
+        AgentPlan.from_agent(agent, AgentConfiguration())
 
 
 def test_get_resource() -> None:

--- a/python/flink_agents/plan/tests/tools/resources/function_tool.json
+++ b/python/flink_agents/plan/tests/tools/resources/function_tool.json
@@ -4,6 +4,7 @@
         "module": "flink_agents.plan.tests.tools.test_function_tool",
         "qualname": "foo"
     },
+    "injected_args": {},
     "metadata": {
         "name": "foo",
         "description": "Function for testing ToolMetadata.\n",

--- a/python/flink_agents/plan/tests/tools/test_function_tool.py
+++ b/python/flink_agents/plan/tests/tools/test_function_tool.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from flink_agents.api.tools import InjectedArg
 from flink_agents.plan.function import JavaFunction, PythonFunction
 from flink_agents.plan.tools.function_tool import FunctionTool
 
@@ -43,6 +44,19 @@ def foo(bar: int, baz: str) -> str:
         Response string value.
     """
     raise NotImplementedError
+
+
+def tool_with_injected_arg(order_id: str, tenant_id: str) -> str:
+    """Query an order.
+
+    Parameters
+    ----------
+    order_id : str
+        The order id.
+    tenant_id : str
+        The tenant id.
+    """
+    return f"{tenant_id}:{order_id}"
 
 
 @pytest.fixture(scope="module")
@@ -80,6 +94,18 @@ def test_python_function_tool_metadata_filled_eagerly() -> None:
     tool = FunctionTool(func=PythonFunction.from_callable(foo))
     assert tool.metadata is not None
     assert tool.metadata.name == "foo"
+
+
+def test_python_function_tool_hides_injected_args_from_metadata() -> None:
+    tool = FunctionTool(
+        func=PythonFunction.from_callable(tool_with_injected_arg),
+        injected_args={"tenant_id": InjectedArg.from_config("tenant_id")},
+    )
+
+    schema = tool.metadata.args_schema.model_json_schema()
+
+    assert set(schema["properties"]) == {"order_id"}
+    assert schema.get("required") == ["order_id"]
 
 
 # ---- Java function tool path -------------------------------------------------
@@ -145,7 +171,7 @@ def test_java_function_tool_metadata_filled_on_adapter_injection() -> None:
     # stored in the regular ``metadata`` field. Subsequent accesses just read
     # the field, so the adapter is not hit again.
     adapter.getJavaToolMetadata.assert_called_once_with(
-        "com.example.Tools", "add", ["int", "int"]
+        "com.example.Tools", "add", ["int", "int"], []
     )
     assert tool.metadata is not None
     assert tool.metadata.name == "add"
@@ -153,6 +179,32 @@ def test_java_function_tool_metadata_filled_on_adapter_injection() -> None:
     assert set(tool.metadata.args_schema.model_fields) == {"a", "b"}
     _ = tool.metadata
     adapter.getJavaToolMetadata.assert_called_once()
+
+
+def test_java_function_tool_merges_adapter_injected_args() -> None:
+    tool = FunctionTool(
+        func=_java_func(),
+        injected_args={"request_id": InjectedArg.from_sensory_memory("request.id")},
+    )
+    adapter = _fake_adapter()
+    adapter.getJavaToolMetadata.return_value = {
+        "name": "add",
+        "description": "Add two ints.",
+        "inputSchema": _FAKE_JAVA_SCHEMA,
+        "injectedArgs": (
+            '{"tenant_id": {"source": "config", "key": "tenant.id"}}'
+        ),
+    }
+
+    tool.set_java_resource_adapter(adapter)
+
+    adapter.getJavaToolMetadata.assert_called_once_with(
+        "com.example.Tools", "add", ["int", "int"], ["request_id"]
+    )
+    assert tool.injected_args == {
+        "tenant_id": InjectedArg.from_config("tenant.id"),
+        "request_id": InjectedArg.from_sensory_memory("request.id"),
+    }
 
 
 def test_java_function_tool_metadata_is_none_without_adapter() -> None:

--- a/python/flink_agents/plan/tools/function_tool.py
+++ b/python/flink_agents/plan/tools/function_tool.py
@@ -15,13 +15,20 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 #################################################################################
+import json
 from typing import Any
 
 from docstring_parser import parse
-from pydantic import model_validator
+from pydantic import Field, model_validator
 from typing_extensions import override
 
 from flink_agents.api.tools.tool import Tool, ToolMetadata, ToolType
+from flink_agents.api.tools.tool_parameter_injection import (
+    InjectedArg,
+    merge_injected_args,
+    normalize_injected_args,
+    validate_injected_arg_names,
+)
 from flink_agents.api.tools.utils import (
     create_model_from_java_tool_schema_str,
     create_schema_from_function,
@@ -40,23 +47,47 @@ class FunctionTool(Tool):
     """
 
     func: PythonFunction | JavaFunction
+    injected_args: dict[str, InjectedArg] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_injected_args(cls, data: dict) -> dict:
+        if isinstance(data, dict) and "injected_args" in data:
+            data = dict(data)
+            data["injected_args"] = normalize_injected_args(data["injected_args"])
+        return data
 
     @model_validator(mode="after")
     def _eager_derive_python_metadata(self) -> "FunctionTool":
+        if isinstance(self.func, PythonFunction):
+            callable_ = self.func.as_callable()
+            self.injected_args = merge_injected_args(
+                getattr(callable_, "_injected_args", None),
+                self.injected_args,
+                tool_name=callable_.__qualname__,
+            )
+            validate_injected_arg_names(callable_, self.injected_args)
         if self.metadata is None and isinstance(self.func, PythonFunction):
-            self.metadata = _python_metadata(self.func)
+            self.metadata = _python_metadata(self.func, list(self.injected_args))
         return self
 
     def set_java_resource_adapter(self, adapter: Any) -> None:
         """Inject the JVM resource adapter and derive ``metadata``. Called
-        by the runtime resource cache when the tool is first materialised;
-        no-op when ``func`` is not a ``JavaFunction``.
+        by the runtime resource cache when the tool is first materialised.
+        Java-declared injected args returned by the bridge are merged into this
+        tool so Python ``tool_call_action`` can inject them at execution time.
+        No-op when ``func`` is not a ``JavaFunction``.
         """
         if not isinstance(self.func, JavaFunction):
             return
         self.func.set_java_resource_adapter(adapter)
-        if self.metadata is None:
-            self.metadata = _java_metadata(self.func)
+        metadata, annotated_args = _java_metadata(self.func, list(self.injected_args))
+        self.injected_args = merge_injected_args(
+            annotated_args,
+            self.injected_args,
+            tool_name=metadata.name,
+        )
+        self.metadata = metadata
 
     @classmethod
     @override
@@ -70,17 +101,21 @@ class FunctionTool(Tool):
         return self.func(*args, **kwargs)
 
 
-def _python_metadata(func: PythonFunction) -> ToolMetadata:
+def _python_metadata(func: PythonFunction, injected_args: list[str] | None = None) -> ToolMetadata:
     callable_ = func.as_callable()
     description = parse(callable_.__doc__).description or ""
     return ToolMetadata(
         name=callable_.__name__,
         description=description,
-        args_schema=create_schema_from_function(callable_.__name__, func=callable_),
+        args_schema=create_schema_from_function(
+            callable_.__name__, func=callable_, injected_args=injected_args
+        ),
     )
 
 
-def _java_metadata(func: JavaFunction) -> ToolMetadata:
+def _java_metadata(
+    func: JavaFunction, injected_args: list[str] | None = None
+) -> tuple[ToolMetadata, dict[str, InjectedArg]]:
     adapter = func._j_resource_adapter
     if adapter is None:
         msg = (
@@ -91,13 +126,24 @@ def _java_metadata(func: JavaFunction) -> ToolMetadata:
         )
         raise RuntimeError(msg)
     flat = adapter.getJavaToolMetadata(
-        func.qualname, func.method_name, func.parameter_types
+        func.qualname,
+        func.method_name,
+        func.parameter_types,
+        injected_args or [],
     )
     name = flat["name"]
-    return ToolMetadata(
+    metadata = ToolMetadata(
         name=name,
-        description=flat["description"],
+        description=flat.get("description", ""),
         args_schema=create_model_from_java_tool_schema_str(
-            name, flat["inputSchema"]
+            name, flat.get("inputSchema", "{}")
         ),
     )
+    return metadata, _parse_injected_args_json(flat.get("injectedArgs"))
+
+
+def _parse_injected_args_json(payload: str | None) -> dict[str, InjectedArg]:
+    if not payload:
+        return {}
+    raw = json.loads(payload)
+    return normalize_injected_args(raw)

--- a/python/flink_agents/runtime/python_java_utils.py
+++ b/python/flink_agents/runtime/python_java_utils.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 #################################################################################
 import importlib
+import json
 import typing
 from typing import Any, Dict
 
@@ -126,20 +127,25 @@ def from_java_tool(j_tool: Any) -> JavaTool:
     return JavaTool(metadata=metadata)
 
 
-def get_python_tool_metadata(module: str, qual_name: str) -> Dict[str, str]:
+def get_python_tool_metadata(
+    module: str, qual_name: str, injected_args: list[str] | None = None
+) -> Dict[str, str]:
     """Introspect a Python callable into the flat tool-metadata shape expected by
     the Java-side ``PythonResourceAdapter.getPythonToolMetadata``.
 
     Mirrors the Python side's eager-metadata derivation for
-    ``PythonFunction``-backed ``FunctionTool``s. Returns the same three-key shape
-    ``JavaResourceAdapter.getJavaToolMetadata`` returns in the reverse direction
-    so the Java side can rebuild ``ToolMetadata`` from String fields only —
-    avoiding pemja's SIGSEGV when wrapping arbitrary Python objects on non-main
+    ``PythonFunction``-backed ``FunctionTool``s. Returns the same flat String map
+    shape ``JavaResourceAdapter.getJavaToolMetadata`` returns in the reverse
+    direction, with ``name``, ``description``, ``inputSchema``, and optional
+    ``injectedArgs`` JSON. The Java side rebuilds ``ToolMetadata`` and merges
+    callable-declared injected args from these String fields only, avoiding
+    pemja's SIGSEGV when wrapping arbitrary Python objects on non-main
     interpreter threads.
     """
     from docstring_parser import parse
 
     from flink_agents.api.function import PythonFunction
+    from flink_agents.api.tools.tool_parameter_injection import normalize_injected_args
     from flink_agents.api.tools.utils import (
         create_java_tool_schema_str_from_model,
         create_schema_from_function,
@@ -149,9 +155,26 @@ def get_python_tool_metadata(module: str, qual_name: str) -> Dict[str, str]:
     callable_ = descriptor.as_callable()
     name = callable_.__name__
     description = (parse(callable_.__doc__).description or "") if callable_.__doc__ else ""
-    args_schema_model = create_schema_from_function(name, callable_)
+    callable_injected_args = normalize_injected_args(
+        getattr(callable_, "_injected_args", None)
+    )
+    hidden_args = set(injected_args or ()) | set(callable_injected_args)
+    args_schema_model = create_schema_from_function(
+        name, callable_, injected_args=hidden_args
+    )
     input_schema = create_java_tool_schema_str_from_model(args_schema_model)
-    return {"name": name, "description": description, "inputSchema": input_schema}
+    return {
+        "name": name,
+        "description": description,
+        "inputSchema": input_schema,
+        "injectedArgs": _dump_injected_args(callable_injected_args),
+    }
+
+
+def _dump_injected_args(injected_args: Dict[str, Any]) -> str:
+    return json.dumps(
+        {name: spec.model_dump(mode="json") for name, spec in injected_args.items()}
+    )
 
 
 def invoke_python_tool(

--- a/python/flink_agents/runtime/tests/test_python_java_utils.py
+++ b/python/flink_agents/runtime/tests/test_python_java_utils.py
@@ -15,9 +15,27 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 #################################################################################
-from flink_agents.api.tools.tool_parameter_injection import (
-    InjectedArg,
-    ToolParameterSource,
-)
+import json
 
-__all__ = ["InjectedArg", "ToolParameterSource"]
+from flink_agents.api.decorators import tool
+from flink_agents.api.tools import InjectedArg
+from flink_agents.runtime.python_java_utils import get_python_tool_metadata
+
+
+@tool(injected_args={"tenant_id": InjectedArg.from_config("tenant.id")})
+def decorated_python_tool(order_id: str, tenant_id: str, request_id: str) -> str:
+    """Query order."""
+    return f"{tenant_id}:{request_id}:{order_id}"
+
+
+def test_get_python_tool_metadata_merges_callable_injected_args() -> None:
+    flat = get_python_tool_metadata(
+        __name__, "decorated_python_tool", injected_args=["request_id"]
+    )
+
+    schema = json.loads(flat["inputSchema"])
+    assert set(schema["properties"]) == {"order_id"}
+    injected_args = json.loads(flat["injectedArgs"])
+    assert injected_args == {
+        "tenant_id": {"source": "config", "key": "tenant.id"}
+    }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/JavaResourceAdapter.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/JavaResourceAdapter.java
@@ -17,12 +17,14 @@
  */
 package org.apache.flink.agents.runtime.python.utils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.agents.api.chat.messages.ChatMessage;
 import org.apache.flink.agents.api.chat.messages.MessageRole;
 import org.apache.flink.agents.api.resource.Resource;
 import org.apache.flink.agents.api.resource.ResourceContext;
 import org.apache.flink.agents.api.resource.ResourceType;
 import org.apache.flink.agents.api.tools.ToolMetadata;
+import org.apache.flink.agents.api.tools.ToolParameterInjection;
 import org.apache.flink.agents.api.tools.ToolParameters;
 import org.apache.flink.agents.api.tools.ToolResponse;
 import org.apache.flink.agents.api.vectorstores.Document;
@@ -132,25 +134,37 @@ public class JavaResourceAdapter {
      *
      * <p>Invoked from the Python side via the {@code _j_resource_adapter} bridge when a {@code
      * plan.FunctionTool} backed by a {@code JavaFunction} first materialises its metadata.
-     * Delegates to {@link ToolMetadataFactory#fromStaticMethod(Method)} once the {@code Method} is
-     * resolved, then flattens the resulting {@link ToolMetadata} into a {@code Map<String, String>}
-     * before returning.
+     * Delegates to {@link ToolMetadataFactory#fromStaticMethod(Method, java.util.Collection)} once
+     * the {@code Method} is resolved, then flattens the resulting {@link ToolMetadata} plus any
+     * method-declared injected arguments into a {@code Map<String, String>} before returning.
      *
      * <p>The flattening is required because pemja can crash with a SIGSEGV inside {@code
      * JcpPyJObject_New} when Java returns an arbitrary Java object to a Python call that originated
      * on a non-main interpreter thread (e.g. a Flink mailbox worker that resolves a tool's
      * metadata). Returning only String fields — which pemja maps natively to {@code str} —
      * sidesteps the reverse Java→Python object wrap entirely. The Python side rebuilds {@link
-     * ToolMetadata} from the flat map.
+     * ToolMetadata} and injected-argument declarations from the flat map.
      */
     public Map<String, String> getJavaToolMetadata(
             String className, String methodName, List<String> parameterTypes) throws Exception {
+        return getJavaToolMetadata(className, methodName, parameterTypes, List.of());
+    }
+
+    public Map<String, String> getJavaToolMetadata(
+            String className,
+            String methodName,
+            List<String> parameterTypes,
+            List<String> injectedArgs)
+            throws Exception {
         Method method = resolveMethod(className, methodName, parameterTypes);
-        ToolMetadata metadata = ToolMetadataFactory.fromStaticMethod(method);
+        ToolMetadata metadata = ToolMetadataFactory.fromStaticMethod(method, injectedArgs);
+        Map<String, ToolParameterInjection> annotatedInjectedArgs =
+                FunctionTool.getInjectedArgs(method);
         Map<String, String> result = new HashMap<>();
         result.put("name", metadata.getName());
         result.put("description", metadata.getDescription());
         result.put("inputSchema", metadata.getInputSchema());
+        result.put("injectedArgs", new ObjectMapper().writeValueAsString(annotatedInjectedArgs));
         return result;
     }
 

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonResourceAdapterImpl.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonResourceAdapterImpl.java
@@ -207,10 +207,17 @@ public class PythonResourceAdapterImpl implements PythonResourceAdapter {
 
     @Override
     public Map<String, String> getPythonToolMetadata(String module, String qualName) {
+        return getPythonToolMetadata(module, qualName, java.util.List.of());
+    }
+
+    @Override
+    public Map<String, String> getPythonToolMetadata(
+            String module, String qualName, java.util.List<String> injectedArgs) {
         @SuppressWarnings("unchecked")
         Map<String, String> result =
                 (Map<String, String>)
-                        interpreter.invoke(GET_PYTHON_TOOL_METADATA, module, qualName);
+                        interpreter.invoke(
+                                GET_PYTHON_TOOL_METADATA, module, qualName, injectedArgs);
         if (result == null) {
             throw new IllegalStateException(
                     "Python get_python_tool_metadata returned null for " + module + ":" + qualName);

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/ResourceCacheTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/ResourceCacheTest.java
@@ -196,6 +196,12 @@ public class ResourceCacheTest {
         }
 
         @Override
+        public Map<String, String> getPythonToolMetadata(
+                String module, String qualName, List<String> injectedArgs) {
+            return getPythonToolMetadata(module, qualName);
+        }
+
+        @Override
         public Object invokePythonTool(String module, String qualName, Map<String, Object> kwargs) {
             return null;
         }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/python/utils/JavaResourceAdapterTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/python/utils/JavaResourceAdapterTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flink.agents.runtime.python.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.agents.api.annotation.Tool;
+import org.apache.flink.agents.api.annotation.ToolParam;
+import org.apache.flink.agents.api.tools.ToolParameterSource;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JavaResourceAdapterTest {
+
+    @Test
+    void getJavaToolMetadataHidesInjectedArgsAndReturnsAnnotatedDeclaration() throws Exception {
+        JavaResourceAdapter adapter =
+                new JavaResourceAdapter(null, null, Thread.currentThread().getContextClassLoader());
+
+        Map<String, String> metadata =
+                adapter.getJavaToolMetadata(
+                        JavaResourceAdapterTest.class.getName(),
+                        "queryOrder",
+                        List.of(
+                                String.class.getName(),
+                                String.class.getName(),
+                                String.class.getName()),
+                        List.of("request_id"));
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode schema = mapper.readTree(metadata.get("inputSchema"));
+        assertThat(schema.get("properties").has("order_id")).isTrue();
+        assertThat(schema.get("properties").has("tenant_id")).isFalse();
+        assertThat(schema.get("properties").has("request_id")).isFalse();
+
+        JsonNode injectedArgs = mapper.readTree(metadata.get("injectedArgs"));
+        assertThat(injectedArgs.get("tenant_id").get("source").asText()).isEqualTo("config");
+        assertThat(injectedArgs.get("tenant_id").get("key").asText()).isEqualTo("tenant.id");
+    }
+
+    @Tool(description = "Query order.")
+    public static String queryOrder(
+            @ToolParam(name = "order_id") String orderId,
+            @ToolParam(
+                            name = "tenant_id",
+                            injected = true,
+                            source = ToolParameterSource.CONFIG,
+                            key = "tenant.id")
+                    String tenantId,
+            @ToolParam(name = "request_id") String requestId) {
+        return tenantId + ":" + requestId + ":" + orderId;
+    }
+}


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #853 

### Purpose of change

Support declarative tool parameter injection for function tools.

This change lets framework-owned arguments, such as tenant id or request context, be injected at tool execution time without exposing them to the model-facing tool schema. The injection source is declared together with the hidden tool parameter, and values are resolved by the built-in `tool_call_action` immediately before invoking the tool.

Main changes:

- Add Python API support:
  - `@tool(injected_args={"tenant_id": InjectedArg.from_config("tenant_id")})`
  - explicit injection sources for config, sensory memory, and short-term memory

- Add Java API support:
  - `@ToolParam(injected = true, source = ToolParameterSource.CONFIG, key = "tenant_id")`
  - explicit injection sources for config, sensory memory, and short-term memory

- Add YAML API support:
  - `tools[].injected_args` as an object mapping parameter names to injection specs

- Inject parameters in the built-in `tool_call_action`, after reading model arguments and before invoking the tool.

- Preserve injected argument metadata in the plan/runtime representation while filtering injected parameters from model-facing tool metadata.

- Keep cross-language tool calls supported by resolving injection before dispatching to the target tool implementation.

### Tests
UT & E2E Test
<!-- How is this change verified? -->

### API
Yes
<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
