### PR TITLE
[api][plan][python] Use request-scoped metric groups for chat token metrics

### DIFF
--- a/api/src/main/java/org/apache/flink/agents/api/chat/model/BaseChatModelSetup.java
+++ b/api/src/main/java/org/apache/flink/agents/api/chat/model/BaseChatModelSetup.java
@@ -116,7 +116,22 @@ public abstract class BaseChatModelSetup extends Resource {
      * @param completionTokens the number of completion tokens
      */
     public void recordTokenMetrics(String modelName, long promptTokens, long completionTokens) {
-        FlinkAgentsMetricGroup metricGroup = getMetricGroup();
+        recordTokenMetrics(getMetricGroup(), modelName, promptTokens, completionTokens);
+    }
+
+    /**
+     * Record token usage metrics for the given model on the provided metric group.
+     *
+     * @param metricGroup the metric group captured when the request was initiated
+     * @param modelName the name of the model used
+     * @param promptTokens the number of prompt tokens
+     * @param completionTokens the number of completion tokens
+     */
+    public void recordTokenMetrics(
+            @Nullable FlinkAgentsMetricGroup metricGroup,
+            String modelName,
+            long promptTokens,
+            long completionTokens) {
         if (metricGroup == null) {
             return;
         }

--- a/api/src/main/java/org/apache/flink/agents/api/chat/model/BaseChatModelSetup.java
+++ b/api/src/main/java/org/apache/flink/agents/api/chat/model/BaseChatModelSetup.java
@@ -109,33 +109,21 @@ public abstract class BaseChatModelSetup extends Resource {
     public abstract Map<String, Object> getParameters();
 
     /**
-     * Record token usage metrics for the given model on this setup's bound metric group.
-     *
-     * @param modelName the name of the model used
-     * @param promptTokens the number of prompt tokens
-     * @param completionTokens the number of completion tokens
-     */
-    public void recordTokenMetrics(String modelName, long promptTokens, long completionTokens) {
-        recordTokenMetrics(getMetricGroup(), modelName, promptTokens, completionTokens);
-    }
-
-    /**
      * Record token usage metrics for the given model on the provided metric group.
      *
-     * @param metricGroup the metric group captured when the request was initiated
+     * @param metricGroup the non-null metric group captured when the request was initiated
      * @param modelName the name of the model used
      * @param promptTokens the number of prompt tokens
      * @param completionTokens the number of completion tokens
      */
     public void recordTokenMetrics(
-            @Nullable FlinkAgentsMetricGroup metricGroup,
+            FlinkAgentsMetricGroup metricGroup,
             String modelName,
             long promptTokens,
             long completionTokens) {
-        if (metricGroup == null) {
-            return;
-        }
-        FlinkAgentsMetricGroup modelGroup = metricGroup.getSubGroup("model", modelName);
+        FlinkAgentsMetricGroup modelGroup =
+                Preconditions.checkNotNull(metricGroup, "Metric group must not be null.")
+                        .getSubGroup("model", modelName);
         modelGroup.getCounter("promptTokens").inc(promptTokens);
         modelGroup.getCounter("completionTokens").inc(completionTokens);
     }

--- a/api/src/test/java/org/apache/flink/agents/api/chat/model/BaseChatModelSetupTokenMetricsTest.java
+++ b/api/src/test/java/org/apache/flink/agents/api/chat/model/BaseChatModelSetupTokenMetricsTest.java
@@ -62,6 +62,10 @@ class BaseChatModelSetupTokenMetricsTest {
         public Map<String, Object> getParameters() {
             return Collections.emptyMap();
         }
+
+        FlinkAgentsMetricGroup captureMetricGroup() {
+            return getMetricGroup();
+        }
     }
 
     @BeforeEach
@@ -102,6 +106,27 @@ class BaseChatModelSetupTokenMetricsTest {
         assertDoesNotThrow(() -> setup.recordTokenMetrics("gpt-4", 100, 50));
 
         verifyNoInteractions(mockMetricGroup);
+    }
+
+    @Test
+    @DisplayName("Test token metrics use the request-scoped metric group")
+    void testRecordTokenMetricsWithRequestScopedMetricGroup() {
+        TestMetricGroup actionA = new TestMetricGroup();
+        TestMetricGroup actionB = new TestMetricGroup();
+
+        setup.setMetricGroup(actionA);
+        FlinkAgentsMetricGroup requestMetricGroup = setup.captureMetricGroup();
+
+        setup.setMetricGroup(actionB);
+        setup.recordTokenMetrics(requestMetricGroup, "gpt-4", 100, 50);
+
+        TestMetricGroup actionAModelGroup = (TestMetricGroup) actionA.getSubGroup("model", "gpt-4");
+        assertEquals(100, actionAModelGroup.counters.get("promptTokens").getCount());
+        assertEquals(50, actionAModelGroup.counters.get("completionTokens").getCount());
+
+        TestMetricGroup actionBModelGroup = (TestMetricGroup) actionB.getSubGroup("model", "gpt-4");
+        assertEquals(0, actionBModelGroup.getCounter("promptTokens").getCount());
+        assertEquals(0, actionBModelGroup.getCounter("completionTokens").getCount());
     }
 
     @Test

--- a/api/src/test/java/org/apache/flink/agents/api/chat/model/BaseChatModelSetupTokenMetricsTest.java
+++ b/api/src/test/java/org/apache/flink/agents/api/chat/model/BaseChatModelSetupTokenMetricsTest.java
@@ -35,11 +35,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /** Test cases for BaseChatModelSetup token metrics functionality. */
@@ -61,10 +59,6 @@ class BaseChatModelSetupTokenMetricsTest {
         @Override
         public Map<String, Object> getParameters() {
             return Collections.emptyMap();
-        }
-
-        FlinkAgentsMetricGroup captureMetricGroup() {
-            return getMetricGroup();
         }
     }
 
@@ -89,9 +83,7 @@ class BaseChatModelSetupTokenMetricsTest {
     @Test
     @DisplayName("Test token metrics are recorded when metric group is set")
     void testRecordTokenMetricsWithMetricGroup() {
-        setup.setMetricGroup(mockMetricGroup);
-
-        setup.recordTokenMetrics("gpt-4", 100, 50);
+        setup.recordTokenMetrics(mockMetricGroup, "gpt-4", 100, 50);
 
         verify(mockMetricGroup).getSubGroup("model", "gpt-4");
         verify(mockModelGroup).getCounter("promptTokens");
@@ -101,24 +93,13 @@ class BaseChatModelSetupTokenMetricsTest {
     }
 
     @Test
-    @DisplayName("Test token metrics are not recorded when metric group is null")
-    void testRecordTokenMetricsWithoutMetricGroup() {
-        assertDoesNotThrow(() -> setup.recordTokenMetrics("gpt-4", 100, 50));
-
-        verifyNoInteractions(mockMetricGroup);
-    }
-
-    @Test
     @DisplayName("Test token metrics use the request-scoped metric group")
     void testRecordTokenMetricsWithRequestScopedMetricGroup() {
         TestMetricGroup actionA = new TestMetricGroup();
         TestMetricGroup actionB = new TestMetricGroup();
 
-        setup.setMetricGroup(actionA);
-        FlinkAgentsMetricGroup requestMetricGroup = setup.captureMetricGroup();
-
         setup.setMetricGroup(actionB);
-        setup.recordTokenMetrics(requestMetricGroup, "gpt-4", 100, 50);
+        setup.recordTokenMetrics(actionA, "gpt-4", 100, 50);
 
         TestMetricGroup actionAModelGroup = (TestMetricGroup) actionA.getSubGroup("model", "gpt-4");
         assertEquals(100, actionAModelGroup.counters.get("promptTokens").getCount());
@@ -132,8 +113,6 @@ class BaseChatModelSetupTokenMetricsTest {
     @Test
     @DisplayName("Test token metrics hierarchy: metricGroup -> modelName -> counters")
     void testTokenMetricsHierarchy() {
-        setup.setMetricGroup(mockMetricGroup);
-
         FlinkAgentsMetricGroup mockGpt35Group = mock(FlinkAgentsMetricGroup.class);
         Counter mockGpt35PromptCounter = mock(Counter.class);
         Counter mockGpt35CompletionCounter = mock(Counter.class);
@@ -142,8 +121,8 @@ class BaseChatModelSetupTokenMetricsTest {
         when(mockGpt35Group.getCounter("promptTokens")).thenReturn(mockGpt35PromptCounter);
         when(mockGpt35Group.getCounter("completionTokens")).thenReturn(mockGpt35CompletionCounter);
 
-        setup.recordTokenMetrics("gpt-4", 100, 50);
-        setup.recordTokenMetrics("gpt-3.5-turbo", 200, 100);
+        setup.recordTokenMetrics(mockMetricGroup, "gpt-4", 100, 50);
+        setup.recordTokenMetrics(mockMetricGroup, "gpt-3.5-turbo", 200, 100);
 
         verify(mockMetricGroup).getSubGroup("model", "gpt-4");
         verify(mockMetricGroup).getSubGroup("model", "gpt-3.5-turbo");
@@ -212,9 +191,8 @@ class BaseChatModelSetupTokenMetricsTest {
     @DisplayName("Value-based: token counters are accessible under model key-value group")
     void testTokenMetricsUnderModelKeyValueGroup() {
         TestMetricGroup root = new TestMetricGroup();
-        setup.setMetricGroup(root);
 
-        setup.recordTokenMetrics("gpt-4", 100, 50);
+        setup.recordTokenMetrics(root, "gpt-4", 100, 50);
 
         TestMetricGroup modelGroup = (TestMetricGroup) root.getSubGroup("model", "gpt-4");
         assertEquals(100, modelGroup.counters.get("promptTokens").getCount());
@@ -225,10 +203,9 @@ class BaseChatModelSetupTokenMetricsTest {
     @DisplayName("Value-based: different models have independent counters")
     void testDifferentModelsHaveIndependentCounters() {
         TestMetricGroup root = new TestMetricGroup();
-        setup.setMetricGroup(root);
 
-        setup.recordTokenMetrics("gpt-4", 100, 50);
-        setup.recordTokenMetrics("gpt-3.5-turbo", 200, 80);
+        setup.recordTokenMetrics(root, "gpt-4", 100, 50);
+        setup.recordTokenMetrics(root, "gpt-3.5-turbo", 200, 80);
 
         TestMetricGroup gpt4 = (TestMetricGroup) root.getSubGroup("model", "gpt-4");
         TestMetricGroup gpt35 = (TestMetricGroup) root.getSubGroup("model", "gpt-3.5-turbo");
@@ -243,10 +220,9 @@ class BaseChatModelSetupTokenMetricsTest {
     @DisplayName("Value-based: counters accumulate across multiple calls")
     void testCountersAccumulate() {
         TestMetricGroup root = new TestMetricGroup();
-        setup.setMetricGroup(root);
 
-        setup.recordTokenMetrics("gpt-4", 100, 50);
-        setup.recordTokenMetrics("gpt-4", 150, 75);
+        setup.recordTokenMetrics(root, "gpt-4", 100, 50);
+        setup.recordTokenMetrics(root, "gpt-4", 150, 75);
 
         TestMetricGroup modelGroup = (TestMetricGroup) root.getSubGroup("model", "gpt-4");
         assertEquals(250, modelGroup.counters.get("promptTokens").getCount());

--- a/plan/src/main/java/org/apache/flink/agents/plan/actions/ChatModelAction.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/actions/ChatModelAction.java
@@ -185,7 +185,10 @@ public class ChatModelAction {
     static void recordChatTokenMetrics(
             BaseChatModelSetup chatModel,
             ChatMessage response,
-            FlinkAgentsMetricGroup requestMetricGroup) {
+            @Nullable FlinkAgentsMetricGroup requestMetricGroup) {
+        if (requestMetricGroup == null) {
+            return;
+        }
         Map<String, Object> extraArgs = response.getExtraArgs();
         Object modelName = extraArgs.get("model_name");
         Object promptTokens = extraArgs.get("promptTokens");

--- a/plan/src/main/java/org/apache/flink/agents/plan/actions/ChatModelAction.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/actions/ChatModelAction.java
@@ -182,7 +182,10 @@ public class ChatModelAction {
         }
     }
 
-    static void recordChatTokenMetrics(BaseChatModelSetup chatModel, ChatMessage response) {
+    static void recordChatTokenMetrics(
+            BaseChatModelSetup chatModel,
+            ChatMessage response,
+            FlinkAgentsMetricGroup requestMetricGroup) {
         Map<String, Object> extraArgs = response.getExtraArgs();
         Object modelName = extraArgs.get("model_name");
         Object promptTokens = extraArgs.get("promptTokens");
@@ -194,7 +197,8 @@ public class ChatModelAction {
             long prompt = ((Number) promptTokens).longValue();
             long completion = ((Number) completionTokens).longValue();
             if (prompt > 0 && completion > 0) {
-                chatModel.recordTokenMetrics(modelName.toString(), prompt, completion);
+                chatModel.recordTokenMetrics(
+                        requestMetricGroup, modelName.toString(), prompt, completion);
             }
         }
     }
@@ -322,6 +326,7 @@ public class ChatModelAction {
             throws Exception {
         BaseChatModelSetup chatModel =
                 (BaseChatModelSetup) ctx.getResource(model, ResourceType.CHAT_MODEL);
+        FlinkAgentsMetricGroup requestMetricGroup = ctx.getActionMetricGroup();
 
         boolean chatAsync = ctx.getConfig().get(AgentExecutionOptions.CHAT_ASYNC);
 
@@ -372,7 +377,7 @@ public class ChatModelAction {
                         chatAsync
                                 ? ctx.durableExecuteAsync(callable)
                                 : ctx.durableExecute(callable);
-                recordChatTokenMetrics(chatModel, response);
+                recordChatTokenMetrics(chatModel, response, requestMetricGroup);
                 // only generate structured output for final response.
                 if (outputSchema != null && response.getToolCalls().isEmpty()) {
                     response = generateStructuredOutput(response, outputSchema);

--- a/plan/src/test/java/org/apache/flink/agents/plan/actions/ChatModelActionRetryTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/actions/ChatModelActionRetryTest.java
@@ -128,6 +128,35 @@ class ChatModelActionRetryTest {
     }
 
     @Test
+    void chatRecordsTokenMetricsWithRequestScopedMetricGroup() throws Exception {
+        configureRetryStrategy(0, 0);
+        FlinkAgentsMetricGroup actionA = mock(FlinkAgentsMetricGroup.class);
+        FlinkAgentsMetricGroup actionB = mock(FlinkAgentsMetricGroup.class);
+        when(mockCtx.getActionMetricGroup()).thenReturn(actionA, actionB);
+
+        ChatMessage response =
+                new ChatMessage(
+                        MessageRole.ASSISTANT,
+                        "hello",
+                        Map.of(
+                                "model_name", "provider-model",
+                                "promptTokens", 100L,
+                                "completionTokens", 50L));
+        when(mockChatModel.chat(any(), any(), any())).thenReturn(response);
+
+        ChatModelAction.chat(
+                UUID.randomUUID(),
+                "test-model",
+                List.of(new ChatMessage(MessageRole.USER, "hi")),
+                Map.of(),
+                null,
+                mockCtx);
+
+        verify(mockChatModel).recordTokenMetrics(actionA, "provider-model", 100L, 50L);
+        verify(mockChatModel, never()).recordTokenMetrics(actionB, "provider-model", 100L, 50L);
+    }
+
+    @Test
     void chatRetriesWithExponentialBackoff() throws Exception {
         // 1 second base interval; fail once then succeed -> wait 1s (1 * 2^0)
         configureRetryStrategy(3, 1);

--- a/plan/src/test/java/org/apache/flink/agents/plan/actions/ChatModelActionTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/actions/ChatModelActionTest.java
@@ -33,6 +33,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /** Tests for {@link ChatModelAction}. */
 class ChatModelActionTest {
@@ -67,6 +68,19 @@ class ChatModelActionTest {
         ChatModelAction.recordChatTokenMetrics(setup, responseWith(extraArgs), requestMetricGroup);
 
         verify(setup).recordTokenMetrics(requestMetricGroup, "m", 100L, 50L);
+    }
+
+    @Test
+    void testRecordChatTokenMetricsSkipsWhenMetricGroupMissing() {
+        BaseChatModelSetup setup = mock(BaseChatModelSetup.class);
+        Map<String, Object> extraArgs = new HashMap<>();
+        extraArgs.put("model_name", "m");
+        extraArgs.put("promptTokens", 100L);
+        extraArgs.put("completionTokens", 50L);
+
+        ChatModelAction.recordChatTokenMetrics(setup, responseWith(extraArgs), null);
+
+        verifyNoInteractions(setup);
     }
 
     @Test

--- a/plan/src/test/java/org/apache/flink/agents/plan/actions/ChatModelActionTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/actions/ChatModelActionTest.java
@@ -20,12 +20,14 @@ package org.apache.flink.agents.plan.actions;
 import org.apache.flink.agents.api.chat.messages.ChatMessage;
 import org.apache.flink.agents.api.chat.messages.MessageRole;
 import org.apache.flink.agents.api.chat.model.BaseChatModelSetup;
+import org.apache.flink.agents.api.metrics.FlinkAgentsMetricGroup;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -42,71 +44,82 @@ class ChatModelActionTest {
     @Test
     void testRecordChatTokenMetricsRecordsWhenAllKeysPresent() {
         BaseChatModelSetup setup = mock(BaseChatModelSetup.class);
+        FlinkAgentsMetricGroup requestMetricGroup = mock(FlinkAgentsMetricGroup.class);
         Map<String, Object> extraArgs = new HashMap<>();
         extraArgs.put("model_name", "m");
         extraArgs.put("promptTokens", 100L);
         extraArgs.put("completionTokens", 50L);
 
-        ChatModelAction.recordChatTokenMetrics(setup, responseWith(extraArgs));
+        ChatModelAction.recordChatTokenMetrics(setup, responseWith(extraArgs), requestMetricGroup);
 
-        verify(setup).recordTokenMetrics("m", 100L, 50L);
+        verify(setup).recordTokenMetrics(requestMetricGroup, "m", 100L, 50L);
     }
 
     @Test
     void testRecordChatTokenMetricsHandlesIntegerTokenValues() {
         BaseChatModelSetup setup = mock(BaseChatModelSetup.class);
+        FlinkAgentsMetricGroup requestMetricGroup = mock(FlinkAgentsMetricGroup.class);
         Map<String, Object> extraArgs = new HashMap<>();
         extraArgs.put("model_name", "m");
         extraArgs.put("promptTokens", 100);
         extraArgs.put("completionTokens", 50);
 
-        ChatModelAction.recordChatTokenMetrics(setup, responseWith(extraArgs));
+        ChatModelAction.recordChatTokenMetrics(setup, responseWith(extraArgs), requestMetricGroup);
 
-        verify(setup).recordTokenMetrics("m", 100L, 50L);
+        verify(setup).recordTokenMetrics(requestMetricGroup, "m", 100L, 50L);
     }
 
     @Test
     void testRecordChatTokenMetricsSkipsWhenTokenValueNonNumeric() {
         BaseChatModelSetup setup = mock(BaseChatModelSetup.class);
+        FlinkAgentsMetricGroup requestMetricGroup = mock(FlinkAgentsMetricGroup.class);
         Map<String, Object> extraArgs = new HashMap<>();
         extraArgs.put("model_name", "m");
         extraArgs.put("promptTokens", "100");
         extraArgs.put("completionTokens", 50L);
 
-        ChatModelAction.recordChatTokenMetrics(setup, responseWith(extraArgs));
+        ChatModelAction.recordChatTokenMetrics(setup, responseWith(extraArgs), requestMetricGroup);
 
-        verify(setup, never()).recordTokenMetrics(anyString(), anyLong(), anyLong());
+        verify(setup, never())
+                .recordTokenMetrics(
+                        any(FlinkAgentsMetricGroup.class), anyString(), anyLong(), anyLong());
     }
 
     @Test
     void testRecordChatTokenMetricsSkipsWhenKeyMissing() {
         BaseChatModelSetup setup = mock(BaseChatModelSetup.class);
+        FlinkAgentsMetricGroup requestMetricGroup = mock(FlinkAgentsMetricGroup.class);
         Map<String, Object> extraArgs = new HashMap<>();
         extraArgs.put("model_name", "m");
         extraArgs.put("completionTokens", 50L);
 
-        ChatModelAction.recordChatTokenMetrics(setup, responseWith(extraArgs));
+        ChatModelAction.recordChatTokenMetrics(setup, responseWith(extraArgs), requestMetricGroup);
 
-        verify(setup, never()).recordTokenMetrics(anyString(), anyLong(), anyLong());
+        verify(setup, never())
+                .recordTokenMetrics(
+                        any(FlinkAgentsMetricGroup.class), anyString(), anyLong(), anyLong());
     }
 
     @Test
     void testRecordChatTokenMetricsSkipsZeroTokensOrEmptyModel() {
         BaseChatModelSetup setup = mock(BaseChatModelSetup.class);
+        FlinkAgentsMetricGroup requestMetricGroup = mock(FlinkAgentsMetricGroup.class);
 
         Map<String, Object> zeroPrompt = new HashMap<>();
         zeroPrompt.put("model_name", "m");
         zeroPrompt.put("promptTokens", 0L);
         zeroPrompt.put("completionTokens", 50L);
-        ChatModelAction.recordChatTokenMetrics(setup, responseWith(zeroPrompt));
+        ChatModelAction.recordChatTokenMetrics(setup, responseWith(zeroPrompt), requestMetricGroup);
 
         Map<String, Object> emptyModel = new HashMap<>();
         emptyModel.put("model_name", "");
         emptyModel.put("promptTokens", 100L);
         emptyModel.put("completionTokens", 50L);
-        ChatModelAction.recordChatTokenMetrics(setup, responseWith(emptyModel));
+        ChatModelAction.recordChatTokenMetrics(setup, responseWith(emptyModel), requestMetricGroup);
 
-        verify(setup, never()).recordTokenMetrics(anyString(), anyLong(), anyLong());
+        verify(setup, never())
+                .recordTokenMetrics(
+                        any(FlinkAgentsMetricGroup.class), anyString(), anyLong(), anyLong());
     }
 
     @Test

--- a/python/flink_agents/api/chat_models/chat_model.py
+++ b/python/flink_agents/api/chat_models/chat_model.py
@@ -27,6 +27,7 @@ from flink_agents.api.chat_message import (
     MessageRole,
     find_first_system_message,
 )
+from flink_agents.api.metric_group import MetricGroup
 from flink_agents.api.prompts.prompt import Prompt
 from flink_agents.api.resource import Resource, ResourceType
 from flink_agents.api.skills import BASH_TOOL, LOAD_SKILL_TOOL
@@ -261,7 +262,11 @@ class BaseChatModelSetup(Resource):
         )
 
     def _record_token_metrics(
-        self, model_name: str, prompt_tokens: int, completion_tokens: int
+        self,
+        model_name: str,
+        prompt_tokens: int,
+        completion_tokens: int,
+        metric_group: MetricGroup | None = None,
     ) -> None:
         """Record token usage metrics for the given model.
 
@@ -273,8 +278,12 @@ class BaseChatModelSetup(Resource):
             The number of prompt tokens
         completion_tokens : int
             The number of completion tokens
+        metric_group : MetricGroup | None
+            The metric group captured when the request was initiated. If not provided,
+            this resource's currently bound metric group is used.
         """
-        metric_group = self.metric_group
+        if metric_group is None:
+            metric_group = self.metric_group
         if metric_group is None:
             return
 

--- a/python/flink_agents/api/chat_models/chat_model.py
+++ b/python/flink_agents/api/chat_models/chat_model.py
@@ -266,7 +266,7 @@ class BaseChatModelSetup(Resource):
         model_name: str,
         prompt_tokens: int,
         completion_tokens: int,
-        metric_group: MetricGroup | None = None,
+        metric_group: MetricGroup | None,
     ) -> None:
         """Record token usage metrics for the given model.
 
@@ -279,11 +279,9 @@ class BaseChatModelSetup(Resource):
         completion_tokens : int
             The number of completion tokens
         metric_group : MetricGroup | None
-            The metric group captured when the request was initiated. If not provided,
-            this resource's currently bound metric group is used.
+            The metric group captured when the request was initiated. If None, token
+            metrics are skipped.
         """
-        if metric_group is None:
-            metric_group = self.metric_group
         if metric_group is None:
             return
 

--- a/python/flink_agents/api/chat_models/tests/test_token_metrics.py
+++ b/python/flink_agents/api/chat_models/tests/test_token_metrics.py
@@ -50,7 +50,7 @@ class TestChatModelSetup(BaseChatModelSetup):
         model_name: str,
         prompt_tokens: int,
         completion_tokens: int,
-        metric_group: MetricGroup | None = None,
+        metric_group: MetricGroup | None,
     ) -> None:
         """Expose protected method for testing."""
         self._record_token_metrics(
@@ -110,25 +110,25 @@ class TestBaseChatModelTokenMetrics:
         chat_model = TestChatModelSetup(connection="mock", model="mock-model")
         mock_metric_group = _MockMetricGroup()
 
-        # Set the metric group
-        chat_model.set_metric_group(mock_metric_group)
-
         # Record token metrics
-        chat_model.test_record_token_metrics("gpt-4", 100, 50)
+        chat_model.test_record_token_metrics("gpt-4", 100, 50, mock_metric_group)
 
         # Verify the metrics were recorded
         model_group = mock_metric_group.get_sub_group("model", "gpt-4")
         assert model_group.get_counter("promptTokens").get_count() == 100
         assert model_group.get_counter("completionTokens").get_count() == 50
 
-    def test_record_token_metrics_without_metric_group(self) -> None:
-        """Test token metrics are not recorded when metric group is null."""
+    def test_record_token_metrics_skips_when_metric_group_missing(self) -> None:
+        """Test token metrics are not recorded when metric group is missing."""
         chat_model = TestChatModelSetup(connection="mock", model="mock-model")
+        bound_metric_group = _MockMetricGroup()
+        chat_model.set_metric_group(bound_metric_group)
 
-        # Do not set metric group (should be None by default)
-        # Record token metrics - should not throw
-        chat_model.test_record_token_metrics("gpt-4", 100, 50)
-        # No exception should be raised
+        chat_model.test_record_token_metrics("gpt-4", 100, 50, None)
+
+        model_group = bound_metric_group.get_sub_group("model", "gpt-4")
+        assert model_group.get_counter("promptTokens").get_count() == 0
+        assert model_group.get_counter("completionTokens").get_count() == 0
 
     def test_record_token_metrics_with_request_scoped_metric_group(self) -> None:
         """Token metrics use the metric group captured when the request started."""
@@ -157,14 +157,13 @@ class TestBaseChatModelTokenMetrics:
         chat_model = TestChatModelSetup(connection="mock", model="mock-model")
         mock_metric_group = _MockMetricGroup()
 
-        # Set the metric group
-        chat_model.set_metric_group(mock_metric_group)
-
         # Record for gpt-4
-        chat_model.test_record_token_metrics("gpt-4", 100, 50)
+        chat_model.test_record_token_metrics("gpt-4", 100, 50, mock_metric_group)
 
         # Record for gpt-3.5-turbo
-        chat_model.test_record_token_metrics("gpt-3.5-turbo", 200, 100)
+        chat_model.test_record_token_metrics(
+            "gpt-3.5-turbo", 200, 100, mock_metric_group
+        )
 
         # Verify each model has its own counters
         gpt4_group = mock_metric_group.get_sub_group("model", "gpt-4")
@@ -180,12 +179,9 @@ class TestBaseChatModelTokenMetrics:
         chat_model = TestChatModelSetup(connection="mock", model="mock-model")
         mock_metric_group = _MockMetricGroup()
 
-        # Set the metric group
-        chat_model.set_metric_group(mock_metric_group)
-
         # Record multiple times for the same model
-        chat_model.test_record_token_metrics("gpt-4", 100, 50)
-        chat_model.test_record_token_metrics("gpt-4", 150, 75)
+        chat_model.test_record_token_metrics("gpt-4", 100, 50, mock_metric_group)
+        chat_model.test_record_token_metrics("gpt-4", 150, 75, mock_metric_group)
 
         # Verify the metrics accumulated
         model_group = mock_metric_group.get_sub_group("model", "gpt-4")

--- a/python/flink_agents/api/chat_models/tests/test_token_metrics.py
+++ b/python/flink_agents/api/chat_models/tests/test_token_metrics.py
@@ -46,10 +46,16 @@ class TestChatModelSetup(BaseChatModelSetup):
         return ChatMessage(role=MessageRole.ASSISTANT, content="Test response")
 
     def test_record_token_metrics(
-        self, model_name: str, prompt_tokens: int, completion_tokens: int
+        self,
+        model_name: str,
+        prompt_tokens: int,
+        completion_tokens: int,
+        metric_group: MetricGroup | None = None,
     ) -> None:
         """Expose protected method for testing."""
-        self._record_token_metrics(model_name, prompt_tokens, completion_tokens)
+        self._record_token_metrics(
+            model_name, prompt_tokens, completion_tokens, metric_group
+        )
 
 
 class _MockCounter(Counter):
@@ -123,6 +129,28 @@ class TestBaseChatModelTokenMetrics:
         # Record token metrics - should not throw
         chat_model.test_record_token_metrics("gpt-4", 100, 50)
         # No exception should be raised
+
+    def test_record_token_metrics_with_request_scoped_metric_group(self) -> None:
+        """Token metrics use the metric group captured when the request started."""
+        chat_model = TestChatModelSetup(connection="mock", model="mock-model")
+        action_a_metric_group = _MockMetricGroup()
+        action_b_metric_group = _MockMetricGroup()
+
+        chat_model.set_metric_group(action_a_metric_group)
+        request_metric_group = chat_model.metric_group
+
+        chat_model.set_metric_group(action_b_metric_group)
+        chat_model.test_record_token_metrics(
+            "gpt-4", 100, 50, metric_group=request_metric_group
+        )
+
+        action_a_model_group = action_a_metric_group.get_sub_group("model", "gpt-4")
+        assert action_a_model_group.get_counter("promptTokens").get_count() == 100
+        assert action_a_model_group.get_counter("completionTokens").get_count() == 50
+
+        action_b_model_group = action_b_metric_group.get_sub_group("model", "gpt-4")
+        assert action_b_model_group.get_counter("promptTokens").get_count() == 0
+        assert action_b_model_group.get_counter("completionTokens").get_count() == 0
 
     def test_token_metrics_hierarchy(self) -> None:
         """Test token metrics hierarchy: actionMetricGroup -> modelName -> counters."""

--- a/python/flink_agents/plan/actions/chat_model_action.py
+++ b/python/flink_agents/plan/actions/chat_model_action.py
@@ -327,7 +327,8 @@ async def chat(
                 )
 
             if (
-                response.extra_args.get("model_name")
+                request_metric_group is not None
+                and response.extra_args.get("model_name")
                 and response.extra_args.get("promptTokens")
                 and response.extra_args.get("completionTokens")
             ):

--- a/python/flink_agents/plan/actions/chat_model_action.py
+++ b/python/flink_agents/plan/actions/chat_model_action.py
@@ -290,6 +290,7 @@ async def chat(
     chat_model = cast(
         "BaseChatModelSetup", ctx.get_resource(model, ResourceType.CHAT_MODEL)
     )
+    request_metric_group = ctx.action_metric_group
 
     chat_async = ctx.config.get(AgentExecutionOptions.CHAT_ASYNC)
 
@@ -334,6 +335,7 @@ async def chat(
                     response.extra_args["model_name"],
                     response.extra_args["promptTokens"],
                     response.extra_args["completionTokens"],
+                    request_metric_group,
                 )
             if output_schema is not None and len(response.tool_calls) == 0:
                 response = _generate_structured_output(response, output_schema)


### PR DESCRIPTION
## What
- Capture the current action metric group when a chat request is initiated.
- Record delayed chat token metrics against that captured group instead of the mutable metric group on cached chat model resources.
- Add Java and Python regression coverage for resource metric-group rebinding.

## Why
Cached resources can be rebound when another action retrieves the same resource before the original request records token usage. The delayed token metrics should stay under the action that initiated the request.

Closes #859.

## Tests
- mvn -pl api -DskipITs -Dspotless.check.skip=true -Dcheckstyle.skip=true -Dtest=BaseChatModelSetupTokenMetricsTest test
- mvn -pl plan -am -DskipITs -Dspotless.check.skip=true -Dcheckstyle.skip=true -Dsurefire.failIfNoSpecifiedTests=false -Dtest=ChatModelActionTest,ChatModelActionRetryTest test
- bash -lc 'export PATH="$HOME/.local/bin:$PATH"; cd python && uv run --no-sync pytest flink_agents/api/chat_models/tests/test_token_metrics.py -q'
- bash -lc 'export PATH="$HOME/.local/bin:$PATH"; cd python && uv run --no-sync ruff format --check flink_agents/api/chat_models/chat_model.py flink_agents/api/chat_models/tests/test_token_metrics.py flink_agents/plan/actions/chat_model_action.py && uv run --no-sync ruff check flink_agents/api/chat_models/chat_model.py flink_agents/api/chat_models/tests/test_token_metrics.py flink_agents/plan/actions/chat_model_action.py'
- bash -lc 'export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64; export PATH="$JAVA_HOME/bin:$PATH"; mvn -pl api,plan -am spotless:check -Dspotless.skip=false -DskipTests -DskipITs -Dcheckstyle.skip=true'