### PR TITLE
[api][runtime][test] Add @JsonCreator to built-in event subclasses for ActionStateSerde durable recovery

### DIFF
--- a/api/src/main/java/org/apache/flink/agents/api/event/ChatRequestEvent.java
+++ b/api/src/main/java/org/apache/flink/agents/api/event/ChatRequestEvent.java
@@ -68,19 +68,13 @@ public class ChatRequestEvent extends Event {
     public ChatRequestEvent(
             @JsonProperty("id") UUID id,
             @JsonProperty("attributes") Map<String, Object> attributes) {
-        super(id, EVENT_TYPE, attributes);
+        super(id, EVENT_TYPE, normalizeAttributes(attributes));
     }
 
-    /**
-     * Reconstructs a typed ChatRequestEvent from a base Event, deserializing nested types.
-     *
-     * @param event the base event containing chat request data in attributes
-     * @return a typed ChatRequestEvent
-     */
+    /** Converts nested attributes back to their typed forms. */
     @SuppressWarnings("unchecked")
-    public static ChatRequestEvent fromEvent(Event event) {
-        Map<String, Object> attrs = new HashMap<>(event.getAttributes());
-        List<?> rawMessages = (List<?>) attrs.get("messages");
+    private static Map<String, Object> normalizeAttributes(Map<String, Object> attributes) {
+        List<?> rawMessages = (List<?>) attributes.get("messages");
         if (rawMessages != null) {
             List<ChatMessage> messages = new ArrayList<>();
             for (Object m : rawMessages) {
@@ -90,9 +84,20 @@ public class ChatRequestEvent extends Event {
                     messages.add(MAPPER.convertValue(m, ChatMessage.class));
                 }
             }
-            attrs.put("messages", messages);
+            attributes.put("messages", messages);
         }
-        ChatRequestEvent result = new ChatRequestEvent(event.getId(), attrs);
+        return attributes;
+    }
+
+    /**
+     * Reconstructs a typed ChatRequestEvent from a base Event, deserializing nested types.
+     *
+     * @param event the base event containing chat request data in attributes
+     * @return a typed ChatRequestEvent
+     */
+    public static ChatRequestEvent fromEvent(Event event) {
+        ChatRequestEvent result =
+                new ChatRequestEvent(event.getId(), new HashMap<>(event.getAttributes()));
         if (event.hasSourceTimestamp()) {
             result.setSourceTimestamp(event.getSourceTimestamp());
         }

--- a/api/src/main/java/org/apache/flink/agents/api/event/ChatRequestEvent.java
+++ b/api/src/main/java/org/apache/flink/agents/api/event/ChatRequestEvent.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.agents.api.event;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.api.chat.messages.ChatMessage;
@@ -62,7 +64,10 @@ public class ChatRequestEvent extends Event {
         this(model, messages, null, null);
     }
 
-    public ChatRequestEvent(UUID id, Map<String, Object> attributes) {
+    @JsonCreator
+    public ChatRequestEvent(
+            @JsonProperty("id") UUID id,
+            @JsonProperty("attributes") Map<String, Object> attributes) {
         super(id, EVENT_TYPE, attributes);
     }
 

--- a/api/src/main/java/org/apache/flink/agents/api/event/ChatResponseEvent.java
+++ b/api/src/main/java/org/apache/flink/agents/api/event/ChatResponseEvent.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.agents.api.event;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.api.chat.messages.ChatMessage;
@@ -46,7 +48,10 @@ public class ChatResponseEvent extends Event {
         setAttr("total_retry_wait_sec", totalRetryWaitSec);
     }
 
-    public ChatResponseEvent(UUID id, Map<String, Object> attributes) {
+    @JsonCreator
+    public ChatResponseEvent(
+            @JsonProperty("id") UUID id,
+            @JsonProperty("attributes") Map<String, Object> attributes) {
         super(id, EVENT_TYPE, attributes);
     }
 

--- a/api/src/main/java/org/apache/flink/agents/api/event/ChatResponseEvent.java
+++ b/api/src/main/java/org/apache/flink/agents/api/event/ChatResponseEvent.java
@@ -52,7 +52,20 @@ public class ChatResponseEvent extends Event {
     public ChatResponseEvent(
             @JsonProperty("id") UUID id,
             @JsonProperty("attributes") Map<String, Object> attributes) {
-        super(id, EVENT_TYPE, attributes);
+        super(id, EVENT_TYPE, normalizeAttributes(attributes));
+    }
+
+    /** Converts nested attributes back to their typed forms. */
+    private static Map<String, Object> normalizeAttributes(Map<String, Object> attributes) {
+        Object rawId = attributes.get("request_id");
+        if (rawId instanceof String) {
+            attributes.put("request_id", UUID.fromString((String) rawId));
+        }
+        Object rawResponse = attributes.get("response");
+        if (rawResponse instanceof Map) {
+            attributes.put("response", MAPPER.convertValue(rawResponse, ChatMessage.class));
+        }
+        return attributes;
     }
 
     /**
@@ -61,18 +74,9 @@ public class ChatResponseEvent extends Event {
      * @param event the base event containing chat response data in attributes
      * @return a typed ChatResponseEvent
      */
-    @SuppressWarnings("unchecked")
     public static ChatResponseEvent fromEvent(Event event) {
-        Map<String, Object> attrs = new HashMap<>(event.getAttributes());
-        Object rawId = attrs.get("request_id");
-        if (rawId instanceof String) {
-            attrs.put("request_id", UUID.fromString((String) rawId));
-        }
-        Object rawResponse = attrs.get("response");
-        if (rawResponse instanceof Map) {
-            attrs.put("response", MAPPER.convertValue(rawResponse, ChatMessage.class));
-        }
-        ChatResponseEvent result = new ChatResponseEvent(event.getId(), attrs);
+        ChatResponseEvent result =
+                new ChatResponseEvent(event.getId(), new HashMap<>(event.getAttributes()));
         if (event.hasSourceTimestamp()) {
             result.setSourceTimestamp(event.getSourceTimestamp());
         }

--- a/api/src/main/java/org/apache/flink/agents/api/event/ContextRetrievalRequestEvent.java
+++ b/api/src/main/java/org/apache/flink/agents/api/event/ContextRetrievalRequestEvent.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.agents.api.event;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.agents.api.Event;
 
 import java.util.HashMap;
@@ -43,7 +45,10 @@ public class ContextRetrievalRequestEvent extends Event {
         setAttr("max_results", maxResults);
     }
 
-    public ContextRetrievalRequestEvent(UUID id, Map<String, Object> attributes) {
+    @JsonCreator
+    public ContextRetrievalRequestEvent(
+            @JsonProperty("id") UUID id,
+            @JsonProperty("attributes") Map<String, Object> attributes) {
         super(id, EVENT_TYPE, attributes);
     }
 

--- a/api/src/main/java/org/apache/flink/agents/api/event/ContextRetrievalResponseEvent.java
+++ b/api/src/main/java/org/apache/flink/agents/api/event/ContextRetrievalResponseEvent.java
@@ -49,24 +49,17 @@ public class ContextRetrievalResponseEvent extends Event {
     public ContextRetrievalResponseEvent(
             @JsonProperty("id") UUID id,
             @JsonProperty("attributes") Map<String, Object> attributes) {
-        super(id, EVENT_TYPE, attributes);
+        super(id, EVENT_TYPE, normalizeAttributes(attributes));
     }
 
-    /**
-     * Reconstructs a typed ContextRetrievalResponseEvent from a base Event, deserializing nested
-     * types.
-     *
-     * @param event the base event containing context retrieval response data in attributes
-     * @return a typed ContextRetrievalResponseEvent
-     */
+    /** Converts nested attributes back to their typed forms. */
     @SuppressWarnings("unchecked")
-    public static ContextRetrievalResponseEvent fromEvent(Event event) {
-        Map<String, Object> attrs = new HashMap<>(event.getAttributes());
-        Object rawId = attrs.get("request_id");
+    private static Map<String, Object> normalizeAttributes(Map<String, Object> attributes) {
+        Object rawId = attributes.get("request_id");
         if (rawId instanceof String) {
-            attrs.put("request_id", UUID.fromString((String) rawId));
+            attributes.put("request_id", UUID.fromString((String) rawId));
         }
-        List<?> rawDocs = (List<?>) attrs.get("documents");
+        List<?> rawDocs = (List<?>) attributes.get("documents");
         if (rawDocs != null) {
             List<Document> documents = new ArrayList<>();
             for (Object d : rawDocs) {
@@ -76,10 +69,22 @@ public class ContextRetrievalResponseEvent extends Event {
                     documents.add(MAPPER.convertValue(d, Document.class));
                 }
             }
-            attrs.put("documents", documents);
+            attributes.put("documents", documents);
         }
+        return attributes;
+    }
+
+    /**
+     * Reconstructs a typed ContextRetrievalResponseEvent from a base Event, deserializing nested
+     * types.
+     *
+     * @param event the base event containing context retrieval response data in attributes
+     * @return a typed ContextRetrievalResponseEvent
+     */
+    public static ContextRetrievalResponseEvent fromEvent(Event event) {
         ContextRetrievalResponseEvent result =
-                new ContextRetrievalResponseEvent(event.getId(), attrs);
+                new ContextRetrievalResponseEvent(
+                        event.getId(), new HashMap<>(event.getAttributes()));
         if (event.hasSourceTimestamp()) {
             result.setSourceTimestamp(event.getSourceTimestamp());
         }

--- a/api/src/main/java/org/apache/flink/agents/api/event/ContextRetrievalResponseEvent.java
+++ b/api/src/main/java/org/apache/flink/agents/api/event/ContextRetrievalResponseEvent.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.agents.api.event;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.api.vectorstores.Document;
@@ -43,7 +45,10 @@ public class ContextRetrievalResponseEvent extends Event {
         setAttr("documents", new ArrayList<>(documents));
     }
 
-    public ContextRetrievalResponseEvent(UUID id, Map<String, Object> attributes) {
+    @JsonCreator
+    public ContextRetrievalResponseEvent(
+            @JsonProperty("id") UUID id,
+            @JsonProperty("attributes") Map<String, Object> attributes) {
         super(id, EVENT_TYPE, attributes);
     }
 

--- a/api/src/main/java/org/apache/flink/agents/api/event/ToolRequestEvent.java
+++ b/api/src/main/java/org/apache/flink/agents/api/event/ToolRequestEvent.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.agents.api.event;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.agents.api.Event;
 
 import java.util.HashMap;
@@ -37,7 +39,10 @@ public class ToolRequestEvent extends Event {
         setAttr("tool_calls", toolCalls);
     }
 
-    public ToolRequestEvent(UUID id, Map<String, Object> attributes) {
+    @JsonCreator
+    public ToolRequestEvent(
+            @JsonProperty("id") UUID id,
+            @JsonProperty("attributes") Map<String, Object> attributes) {
         super(id, EVENT_TYPE, attributes);
     }
 

--- a/api/src/main/java/org/apache/flink/agents/api/event/ToolResponseEvent.java
+++ b/api/src/main/java/org/apache/flink/agents/api/event/ToolResponseEvent.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.agents.api.event;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.api.tools.ToolResponse;
@@ -57,7 +59,10 @@ public class ToolResponseEvent extends Event {
         this(requestId, responses, success, error, Map.of());
     }
 
-    public ToolResponseEvent(UUID id, Map<String, Object> attributes) {
+    @JsonCreator
+    public ToolResponseEvent(
+            @JsonProperty("id") UUID id,
+            @JsonProperty("attributes") Map<String, Object> attributes) {
         super(id, EVENT_TYPE, attributes);
     }
 

--- a/api/src/main/java/org/apache/flink/agents/api/event/ToolResponseEvent.java
+++ b/api/src/main/java/org/apache/flink/agents/api/event/ToolResponseEvent.java
@@ -63,23 +63,17 @@ public class ToolResponseEvent extends Event {
     public ToolResponseEvent(
             @JsonProperty("id") UUID id,
             @JsonProperty("attributes") Map<String, Object> attributes) {
-        super(id, EVENT_TYPE, attributes);
+        super(id, EVENT_TYPE, normalizeAttributes(attributes));
     }
 
-    /**
-     * Reconstructs a typed ToolResponseEvent from a base Event, deserializing nested types.
-     *
-     * @param event the base event containing tool response data in attributes
-     * @return a typed ToolResponseEvent
-     */
+    /** Converts nested attributes back to their typed forms. */
     @SuppressWarnings("unchecked")
-    public static ToolResponseEvent fromEvent(Event event) {
-        Map<String, Object> attrs = new HashMap<>(event.getAttributes());
-        Object rawId = attrs.get("request_id");
+    private static Map<String, Object> normalizeAttributes(Map<String, Object> attributes) {
+        Object rawId = attributes.get("request_id");
         if (rawId instanceof String) {
-            attrs.put("request_id", UUID.fromString((String) rawId));
+            attributes.put("request_id", UUID.fromString((String) rawId));
         }
-        Map<String, ?> rawResponses = (Map<String, ?>) attrs.get("responses");
+        Map<String, ?> rawResponses = (Map<String, ?>) attributes.get("responses");
         if (rawResponses != null) {
             Map<String, ToolResponse> responses = new HashMap<>();
             for (Map.Entry<String, ?> entry : rawResponses.entrySet()) {
@@ -92,9 +86,20 @@ public class ToolResponseEvent extends Event {
                     responses.put(entry.getKey(), ToolResponse.success(v));
                 }
             }
-            attrs.put("responses", responses);
+            attributes.put("responses", responses);
         }
-        ToolResponseEvent result = new ToolResponseEvent(event.getId(), attrs);
+        return attributes;
+    }
+
+    /**
+     * Reconstructs a typed ToolResponseEvent from a base Event, deserializing nested types.
+     *
+     * @param event the base event containing tool response data in attributes
+     * @return a typed ToolResponseEvent
+     */
+    public static ToolResponseEvent fromEvent(Event event) {
+        ToolResponseEvent result =
+                new ToolResponseEvent(event.getId(), new HashMap<>(event.getAttributes()));
         if (event.hasSourceTimestamp()) {
             result.setSourceTimestamp(event.getSourceTimestamp());
         }

--- a/docs/content/docs/development/workflow_agent.md
+++ b/docs/content/docs/development/workflow_agent.md
@@ -723,6 +723,10 @@ built-in events:
 All attribute values must be JSON-serializable. In Python, this means `BaseModel`-serializable or primitive types. In Java, values must be Jackson-serializable.
 {{< /hint >}}
 
+{{< hint warning >}}
+When defining a custom `Event` subclass in Java, annotate its `(UUID id, Map<String, Object> attributes)` constructor with `@JsonCreator`, and annotate both parameters with `@JsonProperty`. Durable execution stores events in `ActionState` and uses Jackson to restore concrete event subclasses during recovery. Without these annotations, recovery deserialization fails because the base `Event` constructor's `@JsonCreator` is not inherited by subclasses.
+{{< /hint >}}
+
 ## Built-in Events and Actions
 
 There are several built-in `Event` and `Action` in Flink-Agents:

--- a/docs/content/docs/development/workflow_agent.md
+++ b/docs/content/docs/development/workflow_agent.md
@@ -725,6 +725,30 @@ All attribute values must be JSON-serializable. In Python, this means `BaseModel
 
 {{< hint warning >}}
 When defining a custom `Event` subclass in Java, annotate its `(UUID id, Map<String, Object> attributes)` constructor with `@JsonCreator`, and annotate both parameters with `@JsonProperty`. Durable execution stores events in `ActionState` and uses Jackson to restore concrete event subclasses during recovery. Without these annotations, recovery deserialization fails because the base `Event` constructor's `@JsonCreator` is not inherited by subclasses.
+
+If the subclass stores typed objects in `attributes`, convert them back to their typed forms inside this constructor too, as the built-in events do. For example, `ChatResponseEvent` restores its typed attributes like this:
+
+```java
+@JsonCreator
+public ChatResponseEvent(
+        @JsonProperty("id") UUID id,
+        @JsonProperty("attributes") Map<String, Object> attributes) {
+    super(id, EVENT_TYPE, normalizeAttributes(attributes));
+}
+
+/** Converts nested attributes back to their typed forms. */
+private static Map<String, Object> normalizeAttributes(Map<String, Object> attributes) {
+    Object rawId = attributes.get("request_id");
+    if (rawId instanceof String) {
+        attributes.put("request_id", UUID.fromString((String) rawId));
+    }
+    Object rawResponse = attributes.get("response");
+    if (rawResponse instanceof Map) {
+        attributes.put("response", MAPPER.convertValue(rawResponse, ChatMessage.class));
+    }
+    return attributes;
+}
+```
 {{< /hint >}}
 
 ## Built-in Events and Actions

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateSerde.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateSerde.java
@@ -24,8 +24,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.flink.agents.api.Event;
-import org.apache.flink.agents.api.InputEvent;
-import org.apache.flink.agents.api.OutputEvent;
 import org.apache.flink.agents.runtime.operator.ActionTask;
 
 import java.io.IOException;
@@ -66,8 +64,6 @@ public final class ActionStateSerde {
 
         // Add type information for polymorphic Event deserialization
         mapper.addMixIn(Event.class, EventTypeInfoMixin.class);
-        mapper.addMixIn(InputEvent.class, EventTypeInfoMixin.class);
-        mapper.addMixIn(OutputEvent.class, EventTypeInfoMixin.class);
 
         // Custom serializer for ActionTask - always serialize as null
         SimpleModule module = new SimpleModule();

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateSerdeTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateSerdeTest.java
@@ -381,24 +381,21 @@ public class ActionStateSerdeTest {
         assertEquals(ContextRetrievalRequestEvent.class, outputEvents.get(4).getClass());
         assertEquals(ContextRetrievalResponseEvent.class, outputEvents.get(5).getClass());
 
-        // Replayed events are consumed through fromEvent() (see ChatModelAction,
-        // ToolCallAction, ContextRetrievalAction), which must restore nested
-        // attributes degraded to raw maps by the JSON round-trip back to their
-        // typed forms.
-        ChatRequestEvent chatRequest = ChatRequestEvent.fromEvent(outputEvents.get(0));
+        // Typed getters must return typed values directly on the deserialized events.
+        ChatRequestEvent chatRequest = (ChatRequestEvent) outputEvents.get(0);
         assertEquals("hello", chatRequest.getMessages().get(0).getContent());
         assertEquals(MessageRole.USER, chatRequest.getMessages().get(0).getRole());
 
-        ChatResponseEvent chatResponse = ChatResponseEvent.fromEvent(outputEvents.get(1));
+        ChatResponseEvent chatResponse = (ChatResponseEvent) outputEvents.get(1);
         assertEquals(requestId, chatResponse.getRequestId());
         assertEquals("hello", chatResponse.getResponse().getContent());
 
-        ToolResponseEvent toolResponse = ToolResponseEvent.fromEvent(outputEvents.get(3));
+        ToolResponseEvent toolResponse = (ToolResponseEvent) outputEvents.get(3);
         assertEquals(requestId, toolResponse.getRequestId());
         assertEquals("result", toolResponse.getResponses().get("call-1").getResult());
 
         ContextRetrievalResponseEvent retrievalResponse =
-                ContextRetrievalResponseEvent.fromEvent(outputEvents.get(5));
+                (ContextRetrievalResponseEvent) outputEvents.get(5);
         assertEquals(requestId, retrievalResponse.getRequestId());
         assertEquals("doc content", retrievalResponse.getDocuments().get(0).getContent());
         assertEquals("doc-1", retrievalResponse.getDocuments().get(0).getId());

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateSerdeTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateSerdeTest.java
@@ -20,7 +20,17 @@ package org.apache.flink.agents.runtime.actionstate;
 import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.api.InputEvent;
 import org.apache.flink.agents.api.OutputEvent;
+import org.apache.flink.agents.api.chat.messages.ChatMessage;
+import org.apache.flink.agents.api.chat.messages.MessageRole;
 import org.apache.flink.agents.api.context.MemoryUpdate;
+import org.apache.flink.agents.api.event.ChatRequestEvent;
+import org.apache.flink.agents.api.event.ChatResponseEvent;
+import org.apache.flink.agents.api.event.ContextRetrievalRequestEvent;
+import org.apache.flink.agents.api.event.ContextRetrievalResponseEvent;
+import org.apache.flink.agents.api.event.ToolRequestEvent;
+import org.apache.flink.agents.api.event.ToolResponseEvent;
+import org.apache.flink.agents.api.tools.ToolResponse;
+import org.apache.flink.agents.api.vectorstores.Document;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -29,6 +39,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -332,5 +343,64 @@ public class ActionStateSerdeTest {
         // Kafka seder should handle nulls
         assertNull(kafkaSeder.serialize("test-topic", null));
         assertNull(kafkaSeder.deserialize("test-topic", null));
+    }
+
+    @Test
+    public void testBuiltInEventSerDeRoundTrip() throws Exception {
+        ChatMessage msg = new ChatMessage(MessageRole.USER, "hello");
+        UUID requestId = UUID.randomUUID();
+        Document doc = new Document("doc content", Map.of("source", "unit-test"), "doc-1");
+
+        // Built-in events are persisted both as the triggering taskEvent and as
+        // outputEvents; cover both paths.
+        ActionState originalState = new ActionState(new ChatRequestEvent("myModel", List.of(msg)));
+        originalState.addEvent(new ChatRequestEvent("myModel", List.of(msg)));
+        originalState.addEvent(new ChatResponseEvent(requestId, msg));
+        originalState.addEvent(new ToolRequestEvent("myModel", List.of(Map.of("name", "myTool"))));
+        originalState.addEvent(
+                new ToolResponseEvent(
+                        requestId,
+                        Map.of("call-1", ToolResponse.success("result")),
+                        Map.of("call-1", true),
+                        Map.of()));
+        originalState.addEvent(new ContextRetrievalRequestEvent("query text", "myVectorStore", 5));
+        originalState.addEvent(
+                new ContextRetrievalResponseEvent(requestId, "query text", List.of(doc)));
+
+        byte[] serialized = ActionStateSerde.serialize(originalState);
+        ActionState deserializedState = ActionStateSerde.deserialize(serialized);
+
+        assertEquals(ChatRequestEvent.class, deserializedState.getTaskEvent().getClass());
+
+        List<Event> outputEvents = deserializedState.getOutputEvents();
+        assertEquals(6, outputEvents.size());
+        assertEquals(ChatRequestEvent.class, outputEvents.get(0).getClass());
+        assertEquals(ChatResponseEvent.class, outputEvents.get(1).getClass());
+        assertEquals(ToolRequestEvent.class, outputEvents.get(2).getClass());
+        assertEquals(ToolResponseEvent.class, outputEvents.get(3).getClass());
+        assertEquals(ContextRetrievalRequestEvent.class, outputEvents.get(4).getClass());
+        assertEquals(ContextRetrievalResponseEvent.class, outputEvents.get(5).getClass());
+
+        // Replayed events are consumed through fromEvent() (see ChatModelAction,
+        // ToolCallAction, ContextRetrievalAction), which must restore nested
+        // attributes degraded to raw maps by the JSON round-trip back to their
+        // typed forms.
+        ChatRequestEvent chatRequest = ChatRequestEvent.fromEvent(outputEvents.get(0));
+        assertEquals("hello", chatRequest.getMessages().get(0).getContent());
+        assertEquals(MessageRole.USER, chatRequest.getMessages().get(0).getRole());
+
+        ChatResponseEvent chatResponse = ChatResponseEvent.fromEvent(outputEvents.get(1));
+        assertEquals(requestId, chatResponse.getRequestId());
+        assertEquals("hello", chatResponse.getResponse().getContent());
+
+        ToolResponseEvent toolResponse = ToolResponseEvent.fromEvent(outputEvents.get(3));
+        assertEquals(requestId, toolResponse.getRequestId());
+        assertEquals("result", toolResponse.getResponses().get("call-1").getResult());
+
+        ContextRetrievalResponseEvent retrievalResponse =
+                ContextRetrievalResponseEvent.fromEvent(outputEvents.get(5));
+        assertEquals(requestId, retrievalResponse.getRequestId());
+        assertEquals("doc content", retrievalResponse.getDocuments().get(0).getContent());
+        assertEquals("doc-1", retrievalResponse.getDocuments().get(0).getId());
     }
 }


### PR DESCRIPTION
Linked issue: #868

### Purpose of change

`ActionStateSerde` uses Jackson polymorphic deserialization (`@JsonTypeInfo(Id.CLASS)`) to restore the concrete `Event` subclasses persisted in `ActionState` (`taskEvent` / `outputEvents`) for durable execution recovery. Jackson requires each concrete subclass to declare its own creator — the `@JsonCreator` on the base `Event` constructor is not inherited.

Only `InputEvent`/`OutputEvent` annotate their `(UUID, Map<String, Object>)` constructors with `@JsonCreator/@JsonProperty`. The six built-in event subclasses under `org.apache.flink.agents.api.event.*` (`ChatRequestEvent`, `ChatResponseEvent`, `ToolRequestEvent`, `ToolResponseEvent`, `ContextRetrievalRequestEvent`, `ContextRetrievalResponseEvent`) have the same constructors but lack the annotations, so deserializing any of them from a persisted `ActionState` fails with:

```
InvalidDefinitionException: Cannot construct instance of `...ChatRequestEvent`
(no Creators, like default constructor, exist)
```

This PR annotates the `(UUID, Map<String, Object>)` constructor of all six classes, consistent with `InputEvent`/`OutputEvent`.

### Tests

Added `ActionStateSerdeTest#testBuiltinChatToolAndContextEventsRoundTripThroughOutputEvents`, which:

- round-trips all six built-in events through `ActionStateSerde` both as `taskEvent` and inside `outputEvents`, asserting the concrete class is restored (fails with the exception above without the fix);
- additionally asserts that nested attributes come back as their expected types via the `fromEvent()` consumption path used by the built-in actions (`ChatMessage`, `ToolResponse`, `Document`, and `UUID` request ids), not raw maps.

Verified with `mvn -pl runtime test -Dtest=ActionStateSerdeTest` (11/11 pass) and the full `api` module test suite.

### API

No signature changes. Adds Jackson annotations to existing public constructors of the six built-in event classes; serialized JSON format is unchanged.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`
