### PR TITLE
[ci] Use maintained 'temurin' distribution for setup-java

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -59,7 +59,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Run Java Tests
         run: tools/ut.sh -j
 
@@ -77,7 +77,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Install python
         uses: actions/setup-python@v4
         with:
@@ -105,7 +105,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Install python
         uses: actions/setup-python@v4
         with:
@@ -134,7 +134,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Install python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -100,7 +100,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Install python
         uses: actions/setup-python@v4
         with:
@@ -136,7 +136,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Install python
         uses: actions/setup-python@v4
         with:
@@ -180,7 +180,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Install python
         uses: actions/setup-python@v4
         with:
@@ -228,7 +228,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Install flink-agents Java
         run: bash tools/build.sh -j
       - name: Install ollama
@@ -266,7 +266,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Install python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
<!-- Hotfix — no linked issue. -->

### Purpose of change

All `actions/setup-java@v4` steps in `ci.yml` and `build_wheel.yml` use `distribution: 'adopt'`, the deprecated AdoptOpenJDK identifier. This switches all 11 occurrences to the maintained `'temurin'` (Eclipse Temurin) distribution — its supported successor and the same underlying binaries.

Why `temurin` is the correct target (per the `actions/setup-java` maintainers, not a preference):

- The [`actions/setup-java` README](https://github.com/actions/setup-java#supported-distributions) states: "AdoptOpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from `adopt` and `adopt-openj9`, to `temurin` and `semeru` respectively, to keep receiving software and security updates."
- Its supported-distributions table maps `temurin` → Eclipse Temurin (adoptium.net, actively maintained) and `adopt` → AdoptOpenJDK (adoptopenjdk.net, the retired project). Background: [Goodbye AdoptOpenJDK, Hello Adoptium (Aug 2021)](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).
- Eclipse Temurin is also the JDK distribution pre-installed on GitHub-hosted runners, so this aligns the configured distribution with the runners' own.

Motivation: a recent CI run hit a transient JDK-download failure in the `Install java` step, before any test ran:

```
Downloading Java 17.0.19+10 (Adopt-Hotspot) from
  https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_x64_linux_hotspot_17.0.19_10.tar.gz ...
##[error]Unexpected HTTP response: 403
```

To be clear, this is not a guaranteed fix for that transient — the binaries still come from the same Adoptium release assets, so a re-run remains the remedy for a one-off download failure. This change is a maintenance cleanup to the supported distribution name.

### Tests

No test changes. This only affects how the CI JDK is provisioned; the full CI matrix on this PR exercises the change end-to-end (Java 11/17/21, Flink 1.20/2.0/2.1/2.2/2.3).

### API

No public API changes.

### Documentation

- [x] `doc-not-needed`
