### PR TITLE
[runtime] Binary serde for MemoryUpdate values via versioned Kryo envelope

### DIFF
--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateSerde.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateSerde.java
@@ -19,14 +19,29 @@ package org.apache.flink.agents.runtime.actionstate;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.flink.agents.api.Event;
+import org.apache.flink.agents.api.context.MemoryUpdate;
 import org.apache.flink.agents.runtime.operator.ActionTask;
+import org.apache.flink.api.common.serialization.SerializerConfigImpl;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Base64;
 
 /**
  * Backend-agnostic serializer/deserializer for {@link ActionState}.
@@ -36,6 +51,37 @@ import java.io.IOException;
  * ActionStateStore backends delegate to this class for consistent serialization format.
  */
 public final class ActionStateSerde {
+
+    /**
+     * Recovery-compat contract for the {@link MemoryUpdate#getValue() MemoryUpdate.value} envelope.
+     *
+     * <p>A non-null value is written on disk as {@code
+     * {"serde":"kryo","version":1,"payload":<b64>}} where {@code payload} is the base64 of the
+     * Flink-native (Kryo) binary of the untyped value. That binary is only guaranteed readable by
+     * the same code and same Flink version that wrote it — which is all that ever happens, because
+     * the durable-execution journal is checkpoint-scoped and never survives a code or Flink
+     * upgrade. Bump {@code version} if the payload encoding ever changes; Kryo is pinned within a
+     * Flink major release (supplied by the cluster).
+     */
+    private static final String MEMORY_UPDATE_SERDE = "kryo";
+
+    private static final int MEMORY_UPDATE_VERSION = 1;
+    private static final String ENVELOPE_SERDE_FIELD = "serde";
+    private static final String ENVELOPE_VERSION_FIELD = "version";
+    private static final String ENVELOPE_PAYLOAD_FIELD = "payload";
+
+    // The Flink-native serializer for an untyped Object resolves to Kryo
+    // (GenericTypeInfo<Object> -> KryoSerializer).
+    private static final TypeSerializer<Object> VALUE_SERIALIZER_TEMPLATE =
+            TypeInformation.of(Object.class).createSerializer(new SerializerConfigImpl());
+
+    // KryoSerializer is not thread-safe; only duplicate() (which is safe) is ever called on the
+    // shared template, giving each thread an independent copy for serialize/deserialize. Because
+    // this ThreadLocal is static, a thread's copy can retain (pin) the classes of the values it has
+    // serialized for that thread's lifetime — an accepted tradeoff over rebuilding a heavy Kryo
+    // instance on every call.
+    private static final ThreadLocal<TypeSerializer<Object>> VALUE_SERIALIZER =
+            ThreadLocal.withInitial(VALUE_SERIALIZER_TEMPLATE::duplicate);
 
     private static final ObjectMapper OBJECT_MAPPER = createObjectMapper();
 
@@ -70,7 +116,23 @@ public final class ActionStateSerde {
         module.addSerializer(ActionTask.class, new ActionTaskSerializer());
         mapper.registerModule(module);
 
+        // Preserve the concrete runtime type of the untyped MemoryUpdate.value across durable
+        // recovery by wrapping it in a versioned Kryo envelope.
+        mapper.addMixIn(MemoryUpdate.class, MemoryUpdateValueMixin.class);
+
         return mapper;
+    }
+
+    private static byte[] kryoSerialize(Object value) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        VALUE_SERIALIZER.get().serialize(value, new DataOutputViewStreamWrapper(baos));
+        return baos.toByteArray();
+    }
+
+    private static Object kryoDeserialize(byte[] bytes) throws IOException {
+        return VALUE_SERIALIZER
+                .get()
+                .deserialize(new DataInputViewStreamWrapper(new ByteArrayInputStream(bytes)));
     }
 
     /** Mixin to add type information for Event hierarchy. */
@@ -86,6 +148,64 @@ public final class ActionStateSerde {
         public void serialize(ActionTask value, JsonGenerator gen, SerializerProvider serializers)
                 throws IOException {
             gen.writeNull();
+        }
+    }
+
+    /**
+     * Binds the Kryo envelope (de)serializer to the {@code value} property of {@link MemoryUpdate}.
+     */
+    abstract static class MemoryUpdateValueMixin {
+        @JsonSerialize(using = MemoryUpdateValueSerializer.class)
+        @JsonDeserialize(using = MemoryUpdateValueDeserializer.class)
+        Object value;
+    }
+
+    /**
+     * Writes a non-null {@link MemoryUpdate} value as the {@code {serde,version,payload}} envelope.
+     */
+    static class MemoryUpdateValueSerializer extends JsonSerializer<Object> {
+        @Override
+        public void serialize(Object value, JsonGenerator gen, SerializerProvider provider)
+                throws IOException {
+            gen.writeStartObject();
+            gen.writeStringField(ENVELOPE_SERDE_FIELD, MEMORY_UPDATE_SERDE);
+            gen.writeNumberField(ENVELOPE_VERSION_FIELD, MEMORY_UPDATE_VERSION);
+            gen.writeStringField(
+                    ENVELOPE_PAYLOAD_FIELD,
+                    Base64.getEncoder().encodeToString(kryoSerialize(value)));
+            gen.writeEndObject();
+        }
+    }
+
+    /**
+     * Reads the Kryo envelope back to the concrete value; version-checks; falls back for a
+     * non-envelope node.
+     */
+    static class MemoryUpdateValueDeserializer extends JsonDeserializer<Object> {
+        @Override
+        public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            JsonNode node = ctxt.readTree(p);
+            if (isEnvelope(node)) {
+                int version = node.get(ENVELOPE_VERSION_FIELD).asInt();
+                if (version != MEMORY_UPDATE_VERSION) {
+                    throw new IOException(
+                            "Unsupported MemoryUpdate value envelope version: " + version);
+                }
+                return kryoDeserialize(
+                        Base64.getDecoder().decode(node.get(ENVELOPE_PAYLOAD_FIELD).asText()));
+            }
+            // Not a recognized envelope: fall back to stock untyped-Object binding. This dispatches
+            // to the UntypedObjectDeserializer, not back into this deserializer, because the
+            // binding
+            // is per-property (MemoryUpdate.value), not on the Object type.
+            return ctxt.readTreeAsValue(node, Object.class);
+        }
+
+        private static boolean isEnvelope(JsonNode n) {
+            return n.isObject()
+                    && MEMORY_UPDATE_SERDE.equals(n.path(ENVELOPE_SERDE_FIELD).asText())
+                    && n.has(ENVELOPE_VERSION_FIELD)
+                    && n.path(ENVELOPE_PAYLOAD_FIELD).isTextual();
         }
     }
 }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateSerde.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateSerde.java
@@ -177,28 +177,27 @@ public final class ActionStateSerde {
         }
     }
 
-    /**
-     * Reads the Kryo envelope back to the concrete value; version-checks; falls back for a
-     * non-envelope node.
-     */
+    /** Reads the Kryo envelope back to the concrete value and version-checks it. */
     static class MemoryUpdateValueDeserializer extends JsonDeserializer<Object> {
         @Override
         public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
             JsonNode node = ctxt.readTree(p);
-            if (isEnvelope(node)) {
-                int version = node.get(ENVELOPE_VERSION_FIELD).asInt();
-                if (version != MEMORY_UPDATE_VERSION) {
-                    throw new IOException(
-                            "Unsupported MemoryUpdate value envelope version: " + version);
-                }
-                return kryoDeserialize(
-                        Base64.getDecoder().decode(node.get(ENVELOPE_PAYLOAD_FIELD).asText()));
+            // Every non-null value this serializer writes is an envelope, and the durable journal
+            // never outlives the code that wrote it (see the recovery-compat contract above), so a
+            // non-envelope node is an unsupported cross-version restore rather than legacy data to
+            // tolerate. Reject it instead of silently binding it to a wrong-typed stock value.
+            if (!isEnvelope(node)) {
+                throw new IOException(
+                        "Expected a Kryo-envelope MemoryUpdate value but found: "
+                                + node.getNodeType());
             }
-            // Not a recognized envelope: fall back to stock untyped-Object binding. This dispatches
-            // to the UntypedObjectDeserializer, not back into this deserializer, because the
-            // binding
-            // is per-property (MemoryUpdate.value), not on the Object type.
-            return ctxt.readTreeAsValue(node, Object.class);
+            int version = node.get(ENVELOPE_VERSION_FIELD).asInt();
+            if (version != MEMORY_UPDATE_VERSION) {
+                throw new IOException(
+                        "Unsupported MemoryUpdate value envelope version: " + version);
+            }
+            return kryoDeserialize(
+                    Base64.getDecoder().decode(node.get(ENVELOPE_PAYLOAD_FIELD).asText()));
         }
 
         private static boolean isEnvelope(JsonNode n) {

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateSerdeTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateSerdeTest.java
@@ -321,6 +321,113 @@ public class ActionStateSerdeTest {
     }
 
     @Test
+    public void testByteArrayMemoryValuePreserved() throws Exception {
+        byte[] value = new byte[] {1, 2, 3, 4, 5};
+        ActionState originalState = new ActionState(new InputEvent("in"));
+        originalState.addShortTermMemoryUpdate(new MemoryUpdate("stm.bytes", value));
+
+        ActionState deserializedState =
+                ActionStateSerde.deserialize(ActionStateSerde.serialize(originalState));
+
+        Object recovered = deserializedState.getShortTermMemoryUpdates().get(0).getValue();
+        assertInstanceOf(byte[].class, recovered);
+        assertArrayEquals(value, (byte[]) recovered);
+    }
+
+    @Test
+    public void testLongMemoryValuePreserved() throws Exception {
+        Long value = 42L;
+        ActionState originalState = new ActionState(new InputEvent("in"));
+        originalState.addShortTermMemoryUpdate(new MemoryUpdate("stm.long", value));
+
+        ActionState deserializedState =
+                ActionStateSerde.deserialize(ActionStateSerde.serialize(originalState));
+
+        Object recovered = deserializedState.getShortTermMemoryUpdates().get(0).getValue();
+        assertInstanceOf(Long.class, recovered);
+        assertEquals(42L, recovered);
+    }
+
+    @Test
+    public void testNestedCollectionMemoryValuePreserved() throws Exception {
+        byte[] nestedBytes = new byte[] {9, 8, 7};
+        List<Object> innerList = new ArrayList<>();
+        innerList.add(nestedBytes);
+        innerList.add(7L);
+        Map<String, Object> value = new HashMap<>();
+        value.put("items", innerList);
+
+        ActionState originalState = new ActionState(new InputEvent("in"));
+        originalState.addShortTermMemoryUpdate(new MemoryUpdate("stm.nested", value));
+
+        ActionState deserializedState =
+                ActionStateSerde.deserialize(ActionStateSerde.serialize(originalState));
+
+        Object recovered = deserializedState.getShortTermMemoryUpdates().get(0).getValue();
+        assertInstanceOf(Map.class, recovered);
+        @SuppressWarnings("unchecked")
+        List<Object> recoveredList = (List<Object>) ((Map<String, Object>) recovered).get("items");
+        assertInstanceOf(byte[].class, recoveredList.get(0));
+        assertArrayEquals(nestedBytes, (byte[]) recoveredList.get(0));
+        assertInstanceOf(Long.class, recoveredList.get(1));
+        assertEquals(7L, recoveredList.get(1));
+    }
+
+    @Test
+    public void testPojoMemoryValuePreserved() throws Exception {
+        MemoryValuePojo value = new MemoryValuePojo("hello", 99);
+        ActionState originalState = new ActionState(new InputEvent("in"));
+        originalState.addShortTermMemoryUpdate(new MemoryUpdate("stm.pojo", value));
+
+        ActionState deserializedState =
+                ActionStateSerde.deserialize(ActionStateSerde.serialize(originalState));
+
+        Object recovered = deserializedState.getShortTermMemoryUpdates().get(0).getValue();
+        assertInstanceOf(MemoryValuePojo.class, recovered);
+        assertEquals(value, recovered);
+    }
+
+    @Test
+    public void testUnknownEnvelopeVersionRejected() throws Exception {
+        ActionState originalState = new ActionState(new InputEvent("in"));
+        originalState.addShortTermMemoryUpdate(new MemoryUpdate("stm.version", "some value"));
+
+        byte[] serialized = ActionStateSerde.serialize(originalState);
+        String json = new String(serialized, StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"version\":1"));
+        byte[] patched =
+                json.replace("\"version\":1", "\"version\":2").getBytes(StandardCharsets.UTF_8);
+
+        assertThrows(RuntimeException.class, () -> ActionStateSerde.deserialize(patched));
+    }
+
+    /** Serializable POJO used to verify Kryo preserves user types across durable recovery. */
+    public static class MemoryValuePojo implements java.io.Serializable {
+        private String name;
+        private int count;
+
+        public MemoryValuePojo() {}
+
+        public MemoryValuePojo(String name, int count) {
+            this.name = name;
+            this.count = count;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof MemoryValuePojo)) return false;
+            MemoryValuePojo that = (MemoryValuePojo) o;
+            return count == that.count && java.util.Objects.equals(name, that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(name, count);
+        }
+    }
+
+    @Test
     public void testKafkaSederDelegatesToActionStateSerde() throws Exception {
         InputEvent inputEvent = new InputEvent("test delegation");
         ActionState originalState = new ActionState(inputEvent);

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateSerdeTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateSerdeTest.java
@@ -388,6 +388,36 @@ public class ActionStateSerdeTest {
     }
 
     @Test
+    public void testNullMemoryValuePreserved() throws Exception {
+        ActionState originalState = new ActionState(new InputEvent("in"));
+        originalState.addShortTermMemoryUpdate(new MemoryUpdate("stm.null", null));
+
+        ActionState deserializedState =
+                ActionStateSerde.deserialize(ActionStateSerde.serialize(originalState));
+
+        assertEquals(1, deserializedState.getShortTermMemoryUpdates().size());
+        assertNull(deserializedState.getShortTermMemoryUpdates().get(0).getValue());
+    }
+
+    @Test
+    public void testNonEnvelopeMemoryValueRejected() throws Exception {
+        ActionState originalState = new ActionState(new InputEvent("in"));
+        originalState.addShortTermMemoryUpdate(new MemoryUpdate("stm.raw", "some value"));
+
+        byte[] serialized = ActionStateSerde.serialize(originalState);
+        String json = new String(serialized, StandardCharsets.UTF_8);
+        // Replace the whole envelope object with a bare JSON value, as a legacy pre-envelope
+        // journal would have stored it.
+        int start = json.indexOf("{\"serde\":");
+        int end = json.indexOf('}', start) + 1;
+        byte[] patched =
+                (json.substring(0, start) + "\"some value\"" + json.substring(end))
+                        .getBytes(StandardCharsets.UTF_8);
+
+        assertThrows(RuntimeException.class, () -> ActionStateSerde.deserialize(patched));
+    }
+
+    @Test
     public void testUnknownEnvelopeVersionRejected() throws Exception {
         ActionState originalState = new ActionState(new InputEvent("in"));
         originalState.addShortTermMemoryUpdate(new MemoryUpdate("stm.version", "some value"));


### PR DESCRIPTION
Linked issue: closes #865, closes #872

### Purpose of change

`MemoryUpdate.value` is declared `Object`, and `ActionStateSerde` persisted it through a Jackson `ObjectMapper` that carries no type information for that field. On durable-execution replay the value was rebuilt by Jackson's stock untyped deserializer, so any runtime type that bare JSON cannot reconstruct degraded silently: `byte[]` to base64 `String`, an int-range `Long` to `Integer`, a user POJO to `LinkedHashMap`, and the same losses for those types nested inside a `List` or `Map`. The consumer performs no downcast, so the wrong type flowed into agent memory after any crash or restore. This generalizes #865 / #871, which fixed only a top-level `byte[]`.

The fix binds a field-scoped Jackson (de)serializer to `MemoryUpdate.value` only. It runs the Flink-native serializer — Kryo, for a generic `Object` — and stores the bytes base64-encoded inside a self-describing versioned envelope embedded in the single `ActionState` JSON document: `{ "serde": "kryo", "version": 1, "payload": "<base64>" }`. One mechanism covers every Kryo-serializable type instead of a per-type special case.

Key points:

- Field-scoping is deliberate: the (de)serializer binds to `MemoryUpdate.value` via a mixin, never a global `byte[]` serializer, so `CallResult`'s statically-typed `byte[]` payloads keep round-tripping unchanged.
- Thread-safety: `KryoSerializer` is not thread-safe, so one immutable template is built once and each thread serializes through its own `duplicate()` via a `ThreadLocal`.
- An unknown envelope `version` is rejected rather than silently mis-decoded.
- Safe binary format: the durable-execution journal is checkpoint-scoped (pruned on checkpoint completion, rebuilt on restore), so state is always written and read by the same code and the same Flink version. It never crosses a code or Flink upgrade, so Kryo's cross-version binary incompatibility and schema-evolution brittleness are never exercised. The recovery-compat contract (envelope shape, `version` marker, Kryo pinned within the major release) is documented on the serde.
- The `Event` field stays JSON, preserving the cross-language and event-log contract.

This supersedes #871 (the narrow `__flink_agents_bytes__` byte[] envelope), which is unmerged, so no state is persisted in that format.

### Tests

Extends `ActionStateSerdeTest` with 5 round-trip tests: top-level `byte[]`, an int-range `Long`, a nested `Map` / `List` graph holding both a `byte[]` and a `Long`, a custom POJO (recovered as its class, not a `LinkedHashMap`), and an unknown-version envelope (rejected). The 10 existing tests are unchanged.

`mvn -pl runtime -am test -Dtest=ActionStateSerdeTest` passes 15 tests under the default Flink 2.3.0, which is also the runtime linkage check for the Kryo construction path. `mvn -pl runtime spotless:check` is clean.

### API

No public API change. All new types are package-private members of `ActionStateSerde`. No new dependency, and no `dist/` change — Kryo is provided by the cluster Flink.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`
