### PR TITLE
[Tech Debt] Avoid using reflection to load implementation classes of resources during the compilation phase

### DIFF
--- a/api/src/main/java/org/apache/flink/agents/api/resource/ResourceDescriptor.java
+++ b/api/src/main/java/org/apache/flink/agents/api/resource/ResourceDescriptor.java
@@ -51,15 +51,17 @@ public class ResourceDescriptor {
      *     <ul>
      *       <li><b>For Java resources:</b> The fully qualified Java class name (e.g.,
      *           "com.example.YourJavaClass"). The {@code module} parameter should be empty or null.
-     *       <li><b>For Python resources (when declaring from Java):</b> The Python class name
-     *           (simple name, not module path, e.g., "YourPythonClass"). The Python module path
-     *           must be specified in the {@code module} parameter (e.g., "your_module.submodule").
      *     </ul>
      *
      * @param module The Python module path for cross-platform compatibility. Defaults to empty
      *     string for Java resources. Example: "your_module.submodule"
      * @param initialArguments Additional arguments for resource initialization. Can be null or
      *     empty map if no initial arguments are needed.
+     *     <ul>
+     *       <li><b>For Python resources (when declaring from Java):</b> The Python class name
+     *           (e.g., "your_module.submodule.YourPythonClass"). the initialArguments should put
+     *           ("pythonClazz", "your_module.submodule.YourPythonClass").
+     *     </ul>
      */
     @JsonCreator
     public ResourceDescriptor(

--- a/api/src/main/java/org/apache/flink/agents/api/resource/ResourceDescriptor.java
+++ b/api/src/main/java/org/apache/flink/agents/api/resource/ResourceDescriptor.java
@@ -58,9 +58,10 @@ public class ResourceDescriptor {
      * @param initialArguments Additional arguments for resource initialization. Can be null or
      *     empty map if no initial arguments are needed.
      *     <ul>
-     *       <li><b>For Python resources (when declaring from Java):</b> The Python class name
-     *           (e.g., "your_module.submodule.YourPythonClass"). the initialArguments should put
-     *           ("pythonClazz", "your_module.submodule.YourPythonClass").
+     *       <li><b>For Python resources (when declaring from Java): put the fully-qualified Python
+     *           class under the pythonClazz key in initialArguments (e.g. ("pythonClazz",
+     *           "your_module.submodule.YourPythonClass")). The clazz argument is unused in this
+     *           case.
      *     </ul>
      */
     @JsonCreator

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -34,14 +34,12 @@ under the License.
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-agents-api</artifactId>
             <version>${project.version}</version>
-            <scope>provided</scope>
         </dependency>
         <!-- Flink API -->
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
-            <scope>provided</scope>
         </dependency>
         <!-- Connectors -->
         <dependency>
@@ -55,6 +53,40 @@ under the License.
             <artifactId>flink-json</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- Flink Table API -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java-bridge</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_2.12</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-agents-runtime</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <!-- Flink Agents OpenAI Integration -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-agents-integrations-chat-models-openai</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Dependencies required for running agents in ide. -->

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -34,12 +34,14 @@ under the License.
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-agents-api</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <!-- Flink API -->
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
+            <scope>provided</scope>
         </dependency>
         <!-- Connectors -->
         <dependency>
@@ -53,40 +55,6 @@ under the License.
             <artifactId>flink-json</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
-        </dependency>
-
-        <!-- Flink Table API -->
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-api-java-bridge</artifactId>
-            <version>${flink.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-planner_2.12</artifactId>
-            <version>${flink.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-agents-runtime</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-clients</artifactId>
-            <version>${flink.version}</version>
-        </dependency>
-        <!-- Flink Agents OpenAI Integration -->
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-agents-integrations-chat-models-openai</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- Dependencies required for running agents in ide. -->

--- a/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
@@ -343,9 +343,6 @@ public class AgentPlan implements Serializable {
         if (isPython || isPythonResource(descriptor)) {
             return new PythonResourceProvider(name, type, descriptor);
         }
-        if (descriptor.getModule() != null && !descriptor.getModule().isEmpty() && !descriptor.getInitialArguments().containsKey("java_clazz")) {
-            throw new IllegalArgumentException("python resource needs pythonClazz param or java resource needs java_clazz param");
-        }
         return new JavaResourceProvider(name, type, descriptor);
     }
 

--- a/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
@@ -35,7 +35,6 @@ import org.apache.flink.agents.api.resource.Resource;
 import org.apache.flink.agents.api.resource.ResourceDescriptor;
 import org.apache.flink.agents.api.resource.ResourceType;
 import org.apache.flink.agents.api.resource.SerializableResource;
-import org.apache.flink.agents.api.resource.python.PythonResourceWrapper;
 import org.apache.flink.agents.api.skills.SkillSourceSpec;
 import org.apache.flink.agents.api.skills.Skills;
 import org.apache.flink.agents.api.tools.ToolMetadata;
@@ -316,31 +315,40 @@ public class AgentPlan implements Serializable {
     }
 
     private void extractResource(ResourceType type, Method method) throws Exception {
-        extractResource(type, method, null);
+        extractResource(type, method, null, false);
     }
 
     private void extractResource(
             ResourceType type,
             Method method,
-            Function<ResourceDescriptor, ResourceDescriptor> descriptorDecorator)
+            Function<ResourceDescriptor, ResourceDescriptor> descriptorDecorator,
+            boolean isPython)
             throws Exception {
         String name = method.getName();
-        ResourceProvider provider;
         ResourceDescriptor descriptor = (ResourceDescriptor) method.invoke(null);
 
         descriptor =
                 descriptorDecorator != null ? descriptorDecorator.apply(descriptor) : descriptor;
 
-        if (PythonResourceWrapper.class.isAssignableFrom(
-                Class.forName(
-                        descriptor.getClazz(),
-                        true,
-                        Thread.currentThread().getContextClassLoader()))) {
-            provider = new PythonResourceProvider(name, type, descriptor);
-        } else {
-            provider = new JavaResourceProvider(name, type, descriptor);
+        addResourceProvider(createDescriptorResourceProvider(name, type, descriptor, isPython));
+    }
+
+    private ResourceProvider createDescriptorResourceProvider(
+            String name, ResourceType type, ResourceDescriptor descriptor) {
+        return createDescriptorResourceProvider(name, type, descriptor, false);
+    }
+
+    private ResourceProvider createDescriptorResourceProvider(
+            String name, ResourceType type, ResourceDescriptor descriptor, boolean isPython) {
+        if (isPython || isPythonResource(descriptor)) {
+            return new PythonResourceProvider(name, type, descriptor);
         }
-        addResourceProvider(provider);
+        return new JavaResourceProvider(name, type, descriptor);
+    }
+
+    private boolean isPythonResource(ResourceDescriptor descriptor) {
+        String pythonClazz = descriptor.getArgument("pythonClazz");
+        return pythonClazz != null && !pythonClazz.isEmpty();
     }
 
     private void extractTool(Method method) throws Exception {
@@ -525,7 +533,8 @@ public class AgentPlan implements Serializable {
                                     new ResourceDescriptor(
                                             desc.getModule(),
                                             PythonMCPServer.class.getName(),
-                                            new HashMap<>(desc.getInitialArguments())));
+                                            new HashMap<>(desc.getInitialArguments())),
+                            true);
                 }
             }
         }
@@ -576,17 +585,8 @@ public class AgentPlan implements Serializable {
                 for (Map.Entry<String, Object> kv : entry.getValue().entrySet()) {
                     ResourceDescriptor descriptor =
                             requireResourceDescriptor(kv.getKey(), type, kv.getValue());
-                    ResourceProvider provider;
-                    if (PythonResourceWrapper.class.isAssignableFrom(
-                            Class.forName(
-                                    descriptor.getClazz(),
-                                    true,
-                                    Thread.currentThread().getContextClassLoader()))) {
-                        provider = new PythonResourceProvider(kv.getKey(), type, descriptor);
-                    } else {
-                        provider = new JavaResourceProvider(kv.getKey(), type, descriptor);
-                    }
-                    addResourceProvider(provider);
+                    addResourceProvider(
+                            createDescriptorResourceProvider(kv.getKey(), type, descriptor));
                 }
             }
         }

--- a/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
@@ -343,8 +343,8 @@ public class AgentPlan implements Serializable {
         if (isPython || isPythonResource(descriptor)) {
             return new PythonResourceProvider(name, type, descriptor);
         }
-        if (descriptor.getModule() != null && !descriptor.getModule().isEmpty() && descriptor.getInitialArguments().containsKey("java_clazz")) {
-            throw new IllegalArgumentException("python resource need pythonClazz param");
+        if (descriptor.getModule() != null && !descriptor.getModule().isEmpty() && !descriptor.getInitialArguments().containsKey("java_clazz")) {
+            throw new IllegalArgumentException("python resource needs pythonClazz param or java resource needs java_clazz param");
         }
         return new JavaResourceProvider(name, type, descriptor);
     }

--- a/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/AgentPlan.java
@@ -343,6 +343,9 @@ public class AgentPlan implements Serializable {
         if (isPython || isPythonResource(descriptor)) {
             return new PythonResourceProvider(name, type, descriptor);
         }
+        if (descriptor.getModule() != null && !descriptor.getModule().isEmpty() && descriptor.getInitialArguments().containsKey("java_clazz")) {
+            throw new IllegalArgumentException("python resource need pythonClazz param");
+        }
         return new JavaResourceProvider(name, type, descriptor);
     }
 

--- a/plan/src/test/java/org/apache/flink/agents/plan/AgentPlanTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/AgentPlanTest.java
@@ -24,11 +24,13 @@ import org.apache.flink.agents.api.InputEvent;
 import org.apache.flink.agents.api.OutputEvent;
 import org.apache.flink.agents.api.agents.Agent;
 import org.apache.flink.agents.api.annotation.ChatModelSetup;
+import org.apache.flink.agents.api.annotation.MCPServer;
 import org.apache.flink.agents.api.annotation.Tool;
 import org.apache.flink.agents.api.context.RunnerContext;
 import org.apache.flink.agents.api.resource.Resource;
 import org.apache.flink.agents.api.resource.ResourceContext;
 import org.apache.flink.agents.api.resource.ResourceDescriptor;
+import org.apache.flink.agents.api.resource.ResourceName;
 import org.apache.flink.agents.api.resource.ResourceType;
 import org.apache.flink.agents.api.resource.SerializableResource;
 import org.apache.flink.agents.api.resource.python.PythonResourceAdapter;
@@ -506,6 +508,25 @@ public class AgentPlanTest {
     }
 
     @Test
+    public void testAddResourceDescriptorWithPythonClazzUsesPythonResourceProvider()
+            throws Exception {
+        Agent agent = new Agent();
+        ResourceDescriptor descriptor =
+                ResourceDescriptor.Builder.newBuilder(String.class.getName())
+                        .addInitialArgument("pythonClazz", "test.module.EmbeddingClazz")
+                        .build();
+        agent.addResource("myEmbedding", ResourceType.EMBEDDING_MODEL, descriptor);
+
+        AgentPlan plan = new AgentPlan(agent);
+
+        ResourceProvider provider =
+                plan.getResourceProviders().get(ResourceType.EMBEDDING_MODEL).get("myEmbedding");
+        assertThat(provider).isInstanceOf(PythonResourceProvider.class);
+        assertThat(((PythonResourceProvider) provider).getDescriptor().getClazz())
+                .isEqualTo(String.class.getName());
+    }
+
+    @Test
     public void testAddResourceRegistersVectorStoreJavaProvider() throws Exception {
         Agent agent = new Agent();
         // A non-Python-wrapper class triggers JavaResourceProvider — String is fine for this
@@ -533,6 +554,49 @@ public class AgentPlanTest {
                 new TestSerializableChatModel("badEmbedding"));
 
         Assertions.assertThrows(IllegalStateException.class, () -> new AgentPlan(agent));
+    }
+
+    /** Test agent with descriptor-based Python resource. */
+    public static class TestAgentWithDescriptorPythonResource extends Agent {
+        @ChatModelSetup
+        public static ResourceDescriptor pythonChatModelByDescriptor() {
+            return ResourceDescriptor.Builder.newBuilder(String.class.getName())
+                    .addInitialArgument("pythonClazz", "test.module.TestClazz")
+                    .build();
+        }
+    }
+
+    @Test
+    public void testDescriptorWithPythonClazzUsesPythonResourceProvider() throws Exception {
+        AgentPlan plan = new AgentPlan(new TestAgentWithDescriptorPythonResource());
+
+        ResourceProvider provider =
+                plan.getResourceProviders()
+                        .get(ResourceType.CHAT_MODEL)
+                        .get("pythonChatModelByDescriptor");
+        assertThat(provider).isInstanceOf(PythonResourceProvider.class);
+        assertThat(((PythonResourceProvider) provider).getDescriptor().getClazz())
+                .isEqualTo(String.class.getName());
+    }
+
+    /** Test agent with explicit Python MCP server declaration. */
+    public static class TestAgentWithPythonMCPServer extends Agent {
+        @MCPServer(lang = "python")
+        public static ResourceDescriptor testMcpServer() {
+            return ResourceDescriptor.Builder.newBuilder(ResourceName.MCP_SERVER)
+                    .addInitialArgument("endpoint", "http://127.0.0.1:8000/mcp")
+                    .addInitialArgument("timeout", 30)
+                    .build();
+        }
+    }
+
+    @Test
+    public void testPythonMCPServerUsesPythonResourceProviderAtCompileTime() throws Exception {
+        AgentPlan plan = new AgentPlan(new TestAgentWithPythonMCPServer());
+
+        ResourceProvider provider =
+                plan.getResourceProviders().get(ResourceType.MCP_SERVER).get("testMcpServer");
+        assertThat(provider).isInstanceOf(PythonResourceProvider.class);
     }
 
     @Test


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: https://github.com/apache/flink-agents/issues/864

### Purpose of change

<!-- What is the purpose of this change? -->
Avoid using reflection to load implementation classes of resources during the compilation phase

### Tests
ut test

<!-- How is this change verified? -->

### API

<!-- Does this change touches any public APIs? -->
no API

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
