### PR TITLE
[runtime] stale branch

### DIFF
--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStore.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStore.java
@@ -282,30 +282,49 @@ public class KafkaActionStateStore implements ActionStateStore {
     public void pruneState(Object key, long seqNum) {
         LOG.debug("Pruning state for key: {} up to sequence number: {}", key, seqNum);
 
-        // Remove states from in-memory cache for this key up to the specified sequence
-        // number
-        actionStates
-                .entrySet()
-                .removeIf(
-                        entry -> {
-                            String stateKey = entry.getKey();
-                            // Extract key and sequence number from the state key
-                            // State key format: "key_seqNum_action_event"
-                            if (stateKey.startsWith(key.toString() + "_")) {
-                                try {
-                                    List<String> parts = ActionStateUtil.parseKey(stateKey);
-                                    if (parts.size() >= 2) {
-                                        long stateSeqNum = Long.parseLong(parts.get(1));
-                                        return stateSeqNum <= seqNum;
-                                    }
-                                } catch (NumberFormatException e) {
-                                    LOG.warn(
-                                            "Failed to parse sequence number from state key: {}",
-                                            stateKey);
-                                }
-                            }
-                            return false;
-                        });
+        // collect keys that match the prune predicate
+        List<String> keysToPrune = new ArrayList<>();
+        for (Map.Entry<String, ActionState> entry : actionStates.entrySet()) {
+            String stateKey = entry.getKey();
+            if (stateKey.startsWith(key.toString() + "_")) {
+                try {
+                    List<String> parts = ActionStateUtil.parseKey(stateKey);
+                    if (parts.size() >= 2) {
+                        long stateSeqNum = Long.parseLong(parts.get(1));
+                        if (stateSeqNum <= seqNum) {
+                            keysToPrune.add(stateKey);
+                        }
+                    }
+                } catch (Exception e) {
+                    LOG.warn("Failed to parse state key: {}", stateKey, e);
+                }
+            }
+        }
+
+        // send tombstones to kafka so log compaction can reclaim storage
+        if (producer != null && !keysToPrune.isEmpty()) {
+            try {
+                for (String stateKey : keysToPrune) {
+                    producer.send(new ProducerRecord<>(topic, stateKey, null));
+                }
+                producer.flush();
+                LOG.debug(
+                        "Sent {} tombstone records to Kafka for key: {}",
+                        keysToPrune.size(),
+                        key);
+            } catch (Exception e) {
+                LOG.warn(
+                        "Failed to send tombstone records to Kafka for key: {}. "
+                                + "Records will persist in the topic until manual cleanup.",
+                        key,
+                        e);
+            }
+        }
+
+        // remove from in-memory cache (always, regardless of tombstone success)
+        for (String stateKey : keysToPrune) {
+            actionStates.remove(stateKey);
+        }
 
         LOG.debug("Pruned state for key: {} up to sequence number: {}", key, seqNum);
     }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStore.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStore.java
@@ -254,11 +254,17 @@ public class KafkaActionStateStore implements ActionStateStore {
 
                 for (ConsumerRecord<String, ActionState> record : records) {
                     try {
-                        actionStates.put(record.key(), record.value());
+                        if (record.value() == null) {
+                            // tombstone record — remove the key from cache
+                            actionStates.remove(record.key());
+                        } else {
+                            actionStates.put(record.key(), record.value());
+                        }
                     } catch (Exception e) {
                         LOG.warn(
-                                "Failed to deserialize action state record: {}",
-                                record.value().toString(),
+                                "Failed to deserialize action state record: key={}, value={}",
+                                record.key(),
+                                record.value(),
                                 e);
                     }
                 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStoreTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStoreTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy.EARLIEST;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -196,6 +197,78 @@ public class KafkaActionStateStoreTest {
         assertNull(
                 actionStates.get(ActionStateUtil.generateKey(TEST_KEY, 2L, testAction, testEvent)));
         assertNotNull(actionStateStore.get(TEST_KEY, 3L, testAction, testEvent));
+
+        // Assert - tombstones should have been sent to Kafka
+        var history = mockProducer.history();
+        assertThat(history).hasSize(2);
+        for (ProducerRecord<String, ActionState> record : history) {
+            assertThat(record.topic()).isEqualTo(TEST_TOPIC);
+            assertThat(record.key()).startsWith(TEST_KEY + "_");
+            assertThat(record.value()).isNull();
+        }
+    }
+
+    @Test
+    void testPruneStateSendsTombstonesWithCorrectKeys() throws Exception {
+        // Arrange
+        String key1 = ActionStateUtil.generateKey(TEST_KEY, 1L, testAction, testEvent);
+        String key2 = ActionStateUtil.generateKey(TEST_KEY, 2L, testAction, testEvent);
+        String key3 = ActionStateUtil.generateKey(TEST_KEY, 3L, testAction, testEvent);
+        actionStates.put(key1, testActionState);
+        actionStates.put(key2, testActionState);
+        actionStates.put(key3, testActionState);
+
+        // Act
+        actionStateStore.pruneState(TEST_KEY, 2L);
+
+        // Assert - exactly keys for seqNum 1 and 2 appear as tombstones
+        var history = mockProducer.history();
+        assertThat(history).hasSize(2);
+        List<String> tombstoneKeys =
+                history.stream()
+                        .map(ProducerRecord::key)
+                        .sorted()
+                        .collect(Collectors.toList());
+        List<String> expectedKeys =
+                List.of(key1, key2).stream().sorted().collect(Collectors.toList());
+        assertThat(tombstoneKeys).isEqualTo(expectedKeys);
+        assertThat(history).allMatch(r -> r.value() == null);
+    }
+
+    @Test
+    void testPruneStateNoMatchingKeys() throws Exception {
+        // Arrange - add states for a different key
+        actionStates.put(
+                ActionStateUtil.generateKey("other-key", 1L, testAction, testEvent),
+                testActionState);
+
+        // Act
+        actionStateStore.pruneState(TEST_KEY, 2L);
+
+        // Assert - no tombstones sent, other key's state remains
+        assertThat(mockProducer.history()).isEmpty();
+        assertThat(actionStates).hasSize(1);
+    }
+
+    @Test
+    void testPruneStateWithNullProducer() throws Exception {
+        // Arrange - store with null producer
+        Map<String, ActionState> localStates = new HashMap<>();
+        KafkaActionStateStore nullProducerStore =
+                new KafkaActionStateStore(
+                        localStates,
+                        new AgentConfiguration(),
+                        null,
+                        mockConsumer,
+                        TEST_TOPIC);
+        localStates.put(
+                ActionStateUtil.generateKey(TEST_KEY, 1L, testAction, testEvent), testActionState);
+
+        // Act - should not throw
+        nullProducerStore.pruneState(TEST_KEY, 1L);
+
+        // Assert - in-memory removal still works
+        assertThat(localStates).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Addresses #691

### Purpose of change

`KafkaActionStateStore.pruneState()` only removed entries from the in-memory cache. the underlying Kafka topic was never updated, so:

1. the topic grew unbounded, meaning Kafka log compaction had no tombstones to trigger key deletion
2. after a restart, `rebuildState()` replayed pruned records back into memory, resurrecting state that should have been discarded

This PR sends `null`-valued records to the state topic during pruning, and updates `rebuildState()` to skip tombstoned keys during replay instead of inserting them into the cache. Also fixes an NPE in the error-logging path that called `record.value().toString()` on a null value.

### Tests
`mvn --batch-mode --no-transfer-progress -pl runtime -am -Dtest=KafkaActionStateStoreTest test`

- `testPruneState` verifies tombstones are produced and in-memory entries are evicted
- `testPruneStateSendsTombstonesWithCorrectKeys` asserts exact composite keys on produced tombstones
- `testPruneStateNoMatchingKeys` verifies no tombstones sent when no keys match
- `testPruneStateWithNullProducer` verifies graceful degradation when producer is null

### API

No public API changes.

### Documentation

- [x] `doc-not-needed`