### PR TITLE
[ci] Retry Ollama install and propagate download failures

### DIFF
--- a/tools/start_ollama_server.sh
+++ b/tools/start_ollama_server.sh
@@ -17,12 +17,29 @@
 #################################################################################
 
 # only works on linux
-os=$(uname -s)
-echo $os
+set -euo pipefail
 
-curl -fsSL https://ollama.com/install.sh | sh
-ret=$?
-if [ "$ret" != "0" ]
-then
-  exit $ret
-fi
+os=$(uname -s)
+echo "$os"
+
+install_script=$(mktemp)
+trap 'rm -f "$install_script"' EXIT
+
+# The upstream installer probes for the .tar.zst asset with a silent HEAD request, and on
+# any failure of that probe falls back to a .tgz that current releases no longer publish.
+# A single transient network error therefore turns into a hard 404, so retry the install.
+attempts=3
+for attempt in $(seq 1 "$attempts"); do
+  if curl -fsSL https://ollama.com/install.sh -o "$install_script" && sh "$install_script"; then
+    exit 0
+  fi
+
+  if [ "$attempt" -lt "$attempts" ]; then
+    delay=$((attempt * 10))
+    echo "ollama install attempt ${attempt}/${attempts} failed; retrying in ${delay}s" >&2
+    sleep "$delay"
+  fi
+done
+
+echo "ollama install failed after ${attempts} attempts" >&2
+exit 1


### PR DESCRIPTION
Linked issue: #889

### Purpose of change

The `it-java`, `it-python`, and `cross-language` CI jobs install a local Ollama server via `tools/start_ollama_server.sh`, which pipes `https://ollama.com/install.sh` into `sh`. That upstream installer probes for the `ollama-linux-${ARCH}.tar.zst` release asset with a silent `curl --fail --silent --head`, and on any failure of that probe it falls back to a `.tgz` asset that current releases no longer publish (`.tgz` returns `404`). A single transient network error on the probe therefore turns into a hard failure, before any test compiles or runs:

```
>>> Downloading ollama-linux-amd64.tgz
curl: (22) The requested URL returned error: 404

gzip: stdin: unexpected end of file
tar: Child returned status 1
##[error]Process completed with exit code 2.
```

This retries the install up to three times with a linear backoff, so a transient failure recovers instead of failing the job. The underlying `.tar.zst` asset does exist, so a retry is a genuine remedy rather than another roll of the dice.

It also fixes a latent bug in the wrapper. The old script read `ret=$?` after `curl -fsSL ... | sh`, which captures the exit status of `sh`, not `curl`. With no `pipefail`, a failed download left `sh` reading empty stdin and exiting `0`, so the step "succeeded" with no Ollama installed and the failure surfaced later somewhere less obvious. The installer is now downloaded to a file and `curl` is checked directly, under `set -euo pipefail`.

### Tests

Verified locally by exercising both paths against stubbed install targets: the script recovers and exits `0` when a transient failure clears before the retries are exhausted, and it exits `1` after three failed attempts against a persistent `404`. `bash -n` passes; the CI lint job exercises the script's shell checks.

The full CI matrix on this PR exercises the change end-to-end — every `it-java` / `it-python` / `cross-language` job runs this installer.

### API

No public API changes.

### Documentation

- [x] `doc-not-needed`
