### PR TITLE
[ci] Bound the runtime of the integration-test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,7 @@ jobs:
   python_it_tests:
     name: it-python [${{ matrix.os }}] [java-17] [python-${{ matrix.python-version}}] [flink-${{ matrix.flink-version}}]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     env:
       SKIP_SPOTLESS_CHECK: true
     strategy:
@@ -201,6 +202,7 @@ jobs:
   java_it_tests:
     name: it-java [${{ matrix.os }}] [java-${{ matrix.java-version}}] [flink-${{ matrix.flink-version}}]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
     env:
       SKIP_SPOTLESS_CHECK: true
     strategy:
@@ -241,6 +243,7 @@ jobs:
   cross_language_tests:
     name: cross-language [${{ matrix.os }}] [python-${{ matrix.python-version}}] [java-${{ matrix.java-version}}]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     env:
       SKIP_SPOTLESS_CHECK: true
     strategy:


### PR DESCRIPTION
Linked issue: #889

### Purpose of change

None of the jobs in `ci.yml` set `timeout-minutes`, so a hung test runs until GitHub's six-hour per-job ceiling before it is killed. A recent run consumed `6h0m16s` on a stalled `it-python` job — the local `llama-server` segfaulted mid-run, pytest hung, and the job burned shared Apache runner capacity for a result that was knowable in minutes.

This bounds the three jobs that install and exercise a local Ollama server (`it-python`, `it-java`, `cross-language`), which are the ones exposed to that hang. Each limit is roughly two to three times the job's slowest observed run over recent green builds on `main`:

| job | slowest observed (p100, 6 green `main` runs) | `timeout-minutes` |
|-----|-----|-----|
| `it-python` | 26.2m | 60 |
| `cross-language` | 24.8m | 60 |
| `it-java` | 14.0m | 40 |

The segfault itself is a separate question tracked in #889; this change only ensures such a hang fails fast instead of running to the six-hour ceiling.

### Tests

No test changes. Verified that the workflow YAML still parses and that the three `timeout-minutes` keys attach at job level to `python_it_tests`, `java_it_tests`, and `cross_language_tests`. The behavior — a job aborting once it exceeds its limit — is a GitHub Actions primitive.

### API

No public API changes.

### Documentation

- [x] `doc-not-needed`
