### PR TITLE
[ci] Auto-rerun flaky integration-test jobs on a fresh runner

### DIFF
--- a/.github/workflows/rerun-flaky-it.yml
+++ b/.github/workflows/rerun-flaky-it.yml
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# The integration-test jobs depend on a live local Ollama server whose llama-server
+# runner intermittently segfaults (~20% per job), and on a PyFlink py4j gateway that
+# occasionally dies on flink-1.20. Both are environmental, per-runner, and version-neutral
+# (the same job passes on ~80% of fresh runners), and both survive the in-suite test reruns
+# (--reruns 2 / rerunFailingTestsCount=2), because those retry into the same wedged process.
+#
+# When the CI run finishes in failure, re-run ONLY the failed integration-test jobs on a
+# fresh runner, which resets the whole job environment and clears the flake. Unit-test, lint,
+# and build failures are never re-run, so a real regression there stays red immediately.
+name: Auto-rerun flaky IT jobs
+
+on:
+  workflow_run:
+    workflows: ["Flink Agents CI"]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  rerun:
+    # Only on the upstream repo, only on failure, and cap the retries so a genuinely broken
+    # job (which fails on every fresh runner) still goes red instead of looping forever.
+    if: >
+      github.repository == 'apache/flink-agents' &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt < 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-run failed integration-test jobs on a fresh runner
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -uo pipefail
+          # Retry only the live-LLM / external-service integration-test jobs. A failed
+          # unit-test, lint, or build job is left red so a real regression is not masked.
+          #
+          # Query the jobs REST endpoint with the repo pinned (this companion has no checkout,
+          # so `gh run view` cannot infer the repo). Poll until every job reports a conclusion,
+          # since the jobs list can briefly lag the workflow_run:completed event.
+          ids=()
+          for i in $(seq 1 15); do
+            jobs_json=$(gh api "repos/${GH_REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" 2>/dev/null || echo '{"jobs":[]}')
+            total=$(echo "$jobs_json" | jq '.jobs | length')
+            pending=$(echo "$jobs_json" | jq '[.jobs[] | select(.conclusion == null)] | length')
+            if [ "$total" -gt 0 ] && [ "$pending" -eq 0 ]; then
+              mapfile -t ids < <(echo "$jobs_json" | jq -r '.jobs[]
+                    | select(.conclusion == "failure")
+                    | select(.name | test("^(it-python|it-java|cross-language)"))
+                    | .id')
+              break
+            fi
+            sleep 4
+          done
+          if [ "${#ids[@]}" -eq 0 ]; then
+            echo "No failed integration-test jobs to re-run."
+            exit 0
+          fi
+          for id in "${ids[@]}"; do
+            echo "Re-running integration-test job $id on a fresh runner..."
+            gh run rerun --job "$id"
+          done


### PR DESCRIPTION
Linked issue: #893

### Purpose of change

The integration-test jobs (`it-python`, `it-java`, `cross-language`) run against a live local Ollama server, and the `llama-server` process intermittently segfaults mid-run. Once it does, every subsequent inference in that job fails, so the in-suite reruns already configured (pytest `--reruns 2`, surefire `rerunFailingTestsCount=2`) cannot recover it — they retry into the same wedged process.

The crash tracks the runner environment rather than anything in the repo: it is not reproducible in isolation, the installed Ollama version has been constant across both the green and the red days, and the failures roam between matrix jobs from run to run rather than pinning to one. The reliable way to clear it is a fresh runner — not a larger in-suite retry count, an in-process restart, or a version pin.

Because the run goes red if any single integration job fails, one segfaulted job is enough to redden an otherwise-green matrix. Recent example on `main` ([run 29227640397](https://github.com/apache/flink-agents/actions/runs/29227640397)): 10 of the 11 integration jobs passed, and the single failure — `it-python [python-3.11] [flink-2.0]` — was purely the segfault (`llama-server process has terminated: signal: segmentation fault`). Re-running the whole workflow re-rolls all 11 jobs; re-running just the failed one is enough.

This adds a `workflow_run` companion that, when the CI run finishes in failure, re-runs only the failed integration-test jobs on a fresh runner, which resets the whole job environment. Unit-test, lint, and build failures are never re-run, so a real regression there stays red immediately. The retry is bounded by `run_attempt` (at most two re-runs) so a genuinely broken job — which fails on every fresh runner — still goes red instead of looping.

An earlier version of this description also attributed a PyFlink py4j gateway failure to the environment. That one was an in-repo test bug and has since been fixed by #896, so it is out of scope here — this PR targets the Ollama segfault alone. How often that remains frequent enough to be worth automating is being tracked on #893.

### Tests

The mechanism was validated end-to-end on a fork: a failed job matching the integration-test filter is re-run on a fresh runner and the run flips green, a non-matching job is left untouched, and the `run_attempt` cap stops the retry chain. The job-name filter was checked against the current CI job names, so only `it-python` / `it-java` / `cross-language` match; the unit-test jobs (`ut-python` / `ut-java`), `Code Style Check`, `install.sh tests`, and `ut-build-backend` are excluded.

Two operational notes for reviewers: the companion needs `actions: write` on the workflow token to re-run jobs (the existing labeler companions already run on write-scoped tokens), and because `workflow_run` companions execute from the default branch, this takes effect after merge and cannot be exercised on this PR's own CI.

### API

No public API changes; this only affects CI.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`
