### PR TITLE
[test][python] Avoid forking MCP test server from PyFlink process

### DIFF
--- a/python/flink_agents/e2e_tests/e2e_tests_integration/e2e_tests_mcp/mcp_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/e2e_tests_mcp/mcp_test.py
@@ -27,9 +27,9 @@ Prerequisites:
 - Run the MCP server first: mcp_server.py or mcp_server_without_prompts.py
 """
 
-import multiprocessing
 import os
-import runpy
+import subprocess
+import sys
 import sysconfig
 import time
 from pathlib import Path
@@ -157,11 +157,6 @@ class MyMCPAgent(Agent):
             ctx.send_event(OutputEvent(output=response.content))
 
 
-def run_mcp_server(server_file: str) -> None:
-    """Run the MCP server in a separate process."""
-    runpy.run_path(f"{current_dir}/{server_file}")
-
-
 current_dir = Path(__file__).parent
 
 client = pull_model(OLLAMA_MODEL)
@@ -203,8 +198,7 @@ def test_mcp(
     """
     # Start MCP server in background
     print(f"Starting MCP server: {server_file}...")
-    server_process = multiprocessing.Process(target=run_mcp_server, args=(server_file,))
-    server_process.start()
+    server_process = subprocess.Popen([sys.executable, str(current_dir / server_file)])
     try:
         time.sleep(5)
 
@@ -274,4 +268,9 @@ def test_mcp(
         records = [line for line in actual_result if line.strip()]
         assert len(records) == 2, f"expected 2 output records, got {records!r}"
     finally:
-        server_process.kill()
+        server_process.terminate()
+        try:
+            server_process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            server_process.kill()
+            server_process.wait()


### PR DESCRIPTION
### Purpose of change

The MCP integration test starts its local MCP server with `multiprocessing.Process`. In GitHub Actions, this forks the already multi-threaded PyFlink and gRPC test process. The fork can corrupt the shared Py4J gateway, causing later PyFlink calls to fail with errors such as `Py4JError: org does not exist in the JVM`.

Start each MCP server in a fresh Python subprocess instead, and wait for it to terminate during cleanup. This isolates the server from the PyFlink gateway and avoids leaking server processes between parameterized cases.

### Tests

- `ruff check` and `ruff format --check` for the changed Python test
- MCP integration tests for both server modes
- MCP integration tests followed by `test_durable_execute_basic_flink` to verify the PyFlink gateway remains usable
- Result: 3 passed

### API

No public API changes.

### Documentation

- [x] `doc-not-needed`
