### PR TITLE
[ci] Pin Ollama to the AVX2 CPU build in the integration jobs

### DIFF
--- a/tools/start_ollama_server.sh
+++ b/tools/start_ollama_server.sh
@@ -28,18 +28,80 @@ trap 'rm -f "$install_script"' EXIT
 # The upstream installer probes for the .tar.zst asset with a silent HEAD request, and on
 # any failure of that probe falls back to a .tgz that current releases no longer publish.
 # A single transient network error therefore turns into a hard 404, so retry the install.
-attempts=3
-for attempt in $(seq 1 "$attempts"); do
-  if curl -fsSL https://ollama.com/install.sh -o "$install_script" && sh "$install_script"; then
-    exit 0
-  fi
+install_ollama() {
+  attempts=3
+  for attempt in $(seq 1 "$attempts"); do
+    if curl -fsSL https://ollama.com/install.sh -o "$install_script" && sh "$install_script"; then
+      return 0
+    fi
 
-  if [ "$attempt" -lt "$attempts" ]; then
-    delay=$((attempt * 10))
-    echo "ollama install attempt ${attempt}/${attempts} failed; retrying in ${delay}s" >&2
-    sleep "$delay"
+    if [ "$attempt" -lt "$attempts" ]; then
+      delay=$((attempt * 10))
+      echo "ollama install attempt ${attempt}/${attempts} failed; retrying in ${delay}s" >&2
+      sleep "$delay"
+    fi
+  done
+
+  echo "ollama install failed after ${attempts} attempts" >&2
+  return 1
+}
+
+install_ollama || exit 1
+
+# llama-server ships one libggml-cpu-<microarch> build per instruction set and loads the
+# best match for the host CPU. The hosted runner pool is mixed, so which kernels serve a
+# request depends on the machine the job happens to land on. Log it, so a failure can be
+# attributed to the microarchitecture that served it.
+find_ollama_lib_dir() {
+  for dir in /usr/local/lib/ollama /usr/lib/ollama /opt/ollama/lib; do
+    if compgen -G "${dir}/libggml-cpu-*" > /dev/null 2>&1; then
+      echo "$dir"
+      return 0
+    fi
+  done
+  return 1
+}
+
+cpu_model=$(sed -n 's/^model name[[:space:]]*: *//p' /proc/cpuinfo | head -1)
+cpu_isa=""
+for flag in avx2 avx512f avx512_bf16 amx_tile; do
+  if grep -qm1 "^flags.*\b${flag}\b" /proc/cpuinfo; then
+    cpu_isa="${cpu_isa}${cpu_isa:+,}${flag}"
   fi
 done
+echo "ollama-cpu: model='${cpu_model:-unknown}' isa='${cpu_isa:-none}'"
 
-echo "ollama install failed after ${attempts} attempts" >&2
-exit 1
+lib_dir=$(find_ollama_lib_dir) || lib_dir=""
+if [ -z "$lib_dir" ]; then
+  echo "ollama-cpu: no libggml-cpu-* builds found; leaving backend selection untouched"
+  exit 0
+fi
+
+# Upstream reports llama-server segfaulting on hosts whose CPU exposes the newer vector
+# extensions (ollama/ollama#17006). Every AVX-512-bearing build is removed so llama-server
+# falls back to the AVX2 build, whose kernels are shared by every runner in the pool and do
+# not crash. Keep this list in sync with ggml's GGML_CPU_ALL_VARIANTS x86 variants.
+avx512_variants="skylakex cannonlake cascadelake icelake cooperlake zen4 sapphirerapids"
+
+for variant in $avx512_variants; do
+  for build in "$lib_dir"/libggml-cpu-"$variant".*; do
+    [ -e "$build" ] || continue
+    sudo mv "$build" "${build}.disabled"
+    echo "ollama-cpu: disabled $(basename "$build")"
+  done
+done
+
+echo "ollama-cpu: remaining builds:"
+for build in "$lib_dir"/libggml-cpu-*; do
+  case "$build" in
+    *.disabled) continue ;;
+  esac
+  echo "ollama-cpu:   $(basename "$build")"
+done
+
+# The installer runs ollama as a systemd unit, so restart it to drop any backend the
+# running process already mapped.
+if systemctl is-active --quiet ollama; then
+  sudo systemctl restart ollama
+  echo "ollama-cpu: restarted ollama"
+fi


### PR DESCRIPTION
Linked issue: #893

### Purpose of change

`llama-server` ships one `libggml-cpu-<microarch>` build per instruction set and loads the best match for the host CPU at load time. The hosted runner pool is mixed, so the kernels that serve a request depend on which machine a job happens to land on, and jobs that land on the newer hosts intermittently die with `llama-server process has terminated: signal: segmentation fault`. Upstream reports the same crash on hosts with the newer vector extensions (ollama/ollama#17006, open).

That explains the shape of the flake described on #893: it is deterministic per runner rather than random, it survives the in-suite reruns (they retry into the same wedged process), and it never reproduced in isolation, because a fork probe kept landing on unaffected hardware.

A census of 40 `ubuntu-latest` runners shows how mixed the pool is:

| Runner CPU | Count | AVX-512 | AMX |
|---|---|---|---|
| AMD EPYC 7763 | 16 | no | no |
| AMD EPYC 9V74 | 11 | no | no |
| AMD EPYC 9V74 | 5 | yes (incl. BF16) | no |
| Intel Xeon Platinum 8573C | 3 | yes | no |
| Intel Xeon Platinum 8370C | 3 | yes | no |
| Intel Xeon 6973P-C | 2 | yes (incl. BF16) | yes |

13 of 40 runners expose AVX-512, and `llama-server` selects `skylakex` / `icelake` / `zen4` / `sapphirerapids` on those. The remaining runners fall back to the AVX2 build, which does not crash. The crash rate measured on `main` was 6 segfaults in 44 integration jobs (~14%), which is the same order as the share of the pool running those builds.

This removes the AVX-512-bearing builds after install, so `llama-server` falls back to the AVX2 build that every runner in the pool can execute. It also logs the runner CPU and the remaining builds, so a future failure can be attributed to the microarchitecture that served it.

The exact extension at fault is not pinned down: AMX, AVX-512 and AVX512-BF16 are each present on a share of the pool close enough to the observed crash rate that the data here cannot separate them. The change therefore removes all of them rather than guessing, and falls back to the one build the whole pool shares.

Note for reviewers: `OLLAMA_LLM_LIBRARY` is not a usable lever for this on 0.31.x. It is consumed in `discover/runner.go` inside `GPUDevices()`, where it filters GPU library directories by name (`cuda_v12`, `rocm_v6`, `mlx_*`); a CPU value matches no directory and has no effect on which CPU build `llama-server` loads.

### Tests

Validated on a fork, since the crash only reproduces on the hosted runner pool.

Three full CI runs with this change: **33 integration jobs, 0 segfaults.** At the ~14% per-job rate measured on `main`, ~4-5 segfaults were expected, and the chance of 33 clean jobs by luck is under 1%. The suspect hardware did come up during those runs (3 jobs on AVX512-BF16 hosts, 1 on an AMX host) and none of them crashed.

The one unrelated failure in those 33 jobs was `EmbeddingIntegrationTest` on an AVX2-only host, with no segfault in the job; that host has no AVX-512 build to remove, so it ran the same kernels either way.

No measurable runtime cost: median `it-python` 16m and `it-java` 10m, unchanged from the same jobs without the change.

### API

No public API changes; this only affects CI.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`
