### PR TITLE
[integration][openai] Update stale default model gpt-3.5-turbo to gpt-4o-mini

### DIFF
--- a/docs/content/docs/development/chat_models.md
+++ b/docs/content/docs/development/chat_models.md
@@ -845,7 +845,7 @@ OpenAI provides cloud-based chat models with state-of-the-art performance for a 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `connection` | str | Required | Reference to connection method name |
-| `model` | str | `"gpt-3.5-turbo"` | Name of the chat model to use |
+| `model` | str | `"gpt-4o-mini"` | Name of the chat model to use |
 | `prompt` | Prompt \| str | None | Prompt template or reference to prompt resource |
 | `tools` | List[str] | None | List of tool names available to the model |
 | `temperature` | float | `0.1` | Sampling temperature (0.0 to 2.0) |
@@ -863,7 +863,7 @@ OpenAI provides cloud-based chat models with state-of-the-art performance for a 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `connection` | String | Required | Reference to connection method name |
-| `model` | String | `"gpt-3.5-turbo"` | Name of the chat model to use |
+| `model` | String | `"gpt-4o-mini"` | Name of the chat model to use |
 | `prompt` | Prompt \| String | None | Prompt template or reference to prompt resource |
 | `tools` | List<String> | None | List of tool names available to the model |
 | `temperature` | double | `0.1` | Sampling temperature (0.0 to 2.0) |

--- a/integrations/chat-models/openai/src/main/java/org/apache/flink/agents/integrations/chatmodels/openai/OpenAICompletionsSetup.java
+++ b/integrations/chat-models/openai/src/main/java/org/apache/flink/agents/integrations/chatmodels/openai/OpenAICompletionsSetup.java
@@ -58,7 +58,7 @@ import java.util.Set;
  */
 public class OpenAICompletionsSetup extends BaseChatModelSetup {
 
-    private static final String DEFAULT_MODEL = "gpt-3.5-turbo";
+    private static final String DEFAULT_MODEL = "gpt-4o-mini";
     private static final double DEFAULT_TEMPERATURE = 0.1d;
     private static final int DEFAULT_TOP_LOGPROBS = 0;
     private static final boolean DEFAULT_STRICT = false;

--- a/python/flink_agents/integrations/chat_models/openai/openai_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/openai/openai_chat_model.py
@@ -35,7 +35,7 @@ from flink_agents.integrations.chat_models.openai.openai_utils import (
     resolve_openai_credentials,
 )
 
-DEFAULT_OPENAI_MODEL = "gpt-3.5-turbo"
+DEFAULT_OPENAI_MODEL = "gpt-4o-mini"
 
 
 class OpenAIChatModelConnection(BaseChatModelConnection):


### PR DESCRIPTION
Linked issue: #905

### Purpose of change

The OpenAI Chat Completions chat model defaults to `gpt-3.5-turbo` when the caller omits `model`. This is a legacy OpenAI model, superseded by cheaper and more capable small models. A user who takes the default silently gets an outdated model — and the Java Javadoc example already uses `gpt-4o-mini`, so the code base is inconsistent with its own default.

This change updates the default to `gpt-4o-mini` — the current low-cost successor to `gpt-3.5-turbo` — in both language runtimes and the docs, keeping a sensible zero-config default while dropping the legacy model and keeping Java and Python in parity.

- Java — `OpenAICompletionsSetup.DEFAULT_MODEL`
- Python — `DEFAULT_OPENAI_MODEL`
- Docs — the `OpenAICompletionsSetup` parameter tables for both languages

### Tests

No new tests. The existing Python test asserts against the imported `DEFAULT_OPENAI_MODEL` constant rather than a hard-coded string, so it continues to pin the default without change (`test_openai_chat_model.py`). There is no equivalent Java assertion on the default. Verified the Python OpenAI chat-model tests pass and the OpenAI Java module compiles.

### API

No API signature change. Only the value of the default model changes; callers that pass `model` explicitly are unaffected.

### Documentation

- [ ] `doc-needed`
- [ ] `doc-not-needed`
- [X] `doc-included`
