### PR TITLE
[infra] Add CLAUDE.md importing AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/tools/.rat-excludes
+++ b/tools/.rat-excludes
@@ -25,3 +25,4 @@ skills/*
 .*\.yaml$
 AGENTS.md
 code_review.md
+CLAUDE.md


### PR DESCRIPTION
Linked issue: #894

### Purpose of change

Item 4 of #894: give Claude Code a pointer to the repository guide.

Claude Code reads `CLAUDE.md`, not `AGENTS.md`, so today it picks up nothing from `AGENTS.md`. This adds a one-line `CLAUDE.md` that imports the guide via `@AGENTS.md`, keeping a single source of truth with no duplicated content.

Following the issue discussion, this uses an `@AGENTS.md` import rather than a checked-in symlink. Both keep one source of truth and the symlink has Apache precedent (spark/airflow/superset/datafusion all check in `CLAUDE.md` as a symlink to `AGENTS.md`), but a symlink degrades on Windows: with `core.symlinks=false` git checks it out as a plain text file whose entire content is the string `AGENTS.md`, so an agent reading it gets nothing. The `@AGENTS.md` import is a real one-line file that works on every platform and leaves room for Claude-specific content later.

`CLAUDE.md` is added to `tools/.rat-excludes` alongside `AGENTS.md`, since a one-line import file cannot carry an Apache license header.

### Tests

Not applicable — a one-line documentation pointer with no logic.

Ran `./tools/check-license.sh` with the change: RAT passes, confirming `CLAUDE.md` is correctly excluded. The `@AGENTS.md` line is Claude Code's documented memory-import syntax (https://code.claude.com/docs/en/memory).

### API

No. No public API change.

### Documentation

- [x] `doc-included`
