### PR TITLE
[python] Tolerate Java tool params without a description

### DIFF
--- a/python/flink_agents/api/tools/tests/test_utils.py
+++ b/python/flink_agents/api/tools/tests/test_utils.py
@@ -174,6 +174,16 @@ def test_model_from_java_schema_fields_are_required() -> None:
     assert field.is_required()
 
 
+def test_model_from_java_schema_without_description() -> None:
+    # Java only emits a "description" key for a @ToolParam with a non-empty
+    # description (ToolParam.description() defaults to ""), so a param without
+    # one must be tolerated and fall back to a generated description.
+    schema_str = json.dumps({"properties": {"a": {"type": "number"}}})
+    field = create_model_from_java_tool_schema_str("J", schema_str).model_fields["a"]
+    assert field.annotation is float
+    assert field.description == "Parameter: a"
+
+
 # ---- create_java_tool_schema_str_from_model ----------------------------------
 
 

--- a/python/flink_agents/api/tools/utils.py
+++ b/python/flink_agents/api/tools/utils.py
@@ -193,7 +193,7 @@ def create_model_from_java_tool_schema_str(
 
     fields = {}
     for param_name in properties:
-        description = properties[param_name]["description"]
+        description = properties[param_name].get("description")
         if description is None:
             description = f"Parameter: {param_name}"
         type = TYPE_MAPPING.get(properties[param_name]["type"])


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #913

### Purpose of change

<!-- What is the purpose of this change? -->

`create_model_from_java_tool_schema_str` read `properties[name]["description"]`
directly, but Java's `SchemaUtils.generateSchema` only emits a `"description"`
key when a `@ToolParam` has a non-empty description (`ToolParam.description()`
defaults to `""`). A description-less param — which the project's own tools
produce, e.g. `@ToolParam(name = "a")` — therefore crashed the Python schema
converter with `KeyError: 'description'`.

Read it with `.get()` so the existing `if description is None` fallback
fabricates the default `"Parameter: <name>"` description instead of crashing.

Closes #913

### Tests

<!-- How is this change verified? -->

Added `test_model_from_java_schema_without_description`, covering a property
with no `description` key. It fails on `main` with `KeyError: 'description'`
(`utils.py:196`) and passes with this change.

- `pytest flink_agents/api/tools/`: 16 passed.
- `ruff check --no-fix` / `ruff format --check` (pinned 0.11.13): clean.

### API

<!-- Does this change touches any public APIs? -->

No. The function signature and contract are unchanged; it only stops raising
`KeyError` for a schema that omits `description`, falling back to the default
description that the surrounding code already implements. The Java schema
generator is untouched.

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->