### PR TITLE
[integration][anthropic] Don't assume the first content block is text

### DIFF
--- a/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
@@ -195,6 +195,13 @@ class AnthropicChatModelConnection(BaseChatModelConnection):
             extra_args["promptTokens"] = message.usage.input_tokens
             extra_args["completionTokens"] = message.usage.output_tokens
 
+        # A response may lead with a non-text block (e.g. a tool_use block when
+        # the model calls a tool without any preface), so pick the first text
+        # block instead of assuming content[0] is text.
+        text = next(
+            (block.text for block in message.content if block.type == "text"), ""
+        )
+
         if message.stop_reason == "tool_use":
             tool_calls = [
                 {
@@ -213,7 +220,7 @@ class AnthropicChatModelConnection(BaseChatModelConnection):
             extra_args["anthropic_content_blocks"] = message.content
             return ChatMessage(
                 role=MessageRole(message.role),
-                content=message.content[0].text,
+                content=text,
                 tool_calls=tool_calls,
                 extra_args=extra_args,
             )
@@ -222,7 +229,7 @@ class AnthropicChatModelConnection(BaseChatModelConnection):
             #  https://docs.anthropic.com/en/api/messages#response-stop-reason
             return ChatMessage(
                 role=MessageRole(message.role),
-                content=message.content[0].text,
+                content=text,
             )
 
     @override

--- a/python/flink_agents/integrations/chat_models/anthropic/tests/test_anthropic_response_parsing.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/tests/test_anthropic_response_parsing.py
@@ -1,0 +1,96 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+from unittest.mock import MagicMock
+
+from anthropic.types import Message, TextBlock, ToolUseBlock, Usage
+
+from flink_agents.api.chat_message import ChatMessage, MessageRole
+from flink_agents.integrations.chat_models.anthropic.anthropic_chat_model import (
+    AnthropicChatModelConnection,
+)
+
+
+def _connection_returning(message: Message) -> AnthropicChatModelConnection:
+    connection = AnthropicChatModelConnection(name="test", api_key="dummy")
+    client = MagicMock()
+    client.messages.create.return_value = message
+    connection._client = client
+    return connection
+
+
+def _usage() -> Usage:
+    return Usage(input_tokens=1, output_tokens=1)
+
+
+def test_tool_use_response_without_leading_text() -> None:
+    # When the model calls a tool it commonly returns only a tool_use block, so
+    # content[0] is not a text block. Parsing must not assume content[0].text.
+    message = Message(
+        id="m",
+        model="claude",
+        role="assistant",
+        type="message",
+        stop_reason="tool_use",
+        content=[
+            ToolUseBlock(type="tool_use", id="t1", name="add", input={"a": 1, "b": 2})
+        ],
+        usage=_usage(),
+    )
+    response = _connection_returning(message).chat(
+        [ChatMessage(role=MessageRole.USER, content="add 1 and 2")]
+    )
+    assert response.content == ""
+    assert len(response.tool_calls) == 1
+    assert response.tool_calls[0]["function"]["name"] == "add"
+
+
+def test_tool_use_response_keeps_leading_text() -> None:
+    # A tool_use response may be preceded by a text block; that text is kept.
+    message = Message(
+        id="m",
+        model="claude",
+        role="assistant",
+        type="message",
+        stop_reason="tool_use",
+        content=[
+            TextBlock(type="text", text="Let me add those."),
+            ToolUseBlock(type="tool_use", id="t1", name="add", input={"a": 1, "b": 2}),
+        ],
+        usage=_usage(),
+    )
+    response = _connection_returning(message).chat(
+        [ChatMessage(role=MessageRole.USER, content="add 1 and 2")]
+    )
+    assert response.content == "Let me add those."
+    assert len(response.tool_calls) == 1
+
+
+def test_plain_text_response() -> None:
+    message = Message(
+        id="m",
+        model="claude",
+        role="assistant",
+        type="message",
+        stop_reason="end_turn",
+        content=[TextBlock(type="text", text="Hello!")],
+        usage=_usage(),
+    )
+    response = _connection_returning(message).chat(
+        [ChatMessage(role=MessageRole.USER, content="hi")]
+    )
+    assert response.content == "Hello!"


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #914

### Purpose of change

<!-- What is the purpose of this change? -->

`AnthropicChatModelConnection.chat` read the response text via
`message.content[0].text`. When the model calls a tool, the response commonly
contains only a `tool_use` block, so `content[0]` is a `ToolUseBlock` and
`.text` raised `AttributeError: 'ToolUseBlock' object has no attribute 'text'`.
Both the `tool_use` and the plain-text return paths used this unsafe access,
even though the code just above already iterates `message.content` filtering by
`type == "tool_use"` — so the blocks are known to be mixed-type there.

Pick the first text block instead (falling back to `""` when there is none) and
reuse it in both return paths.

Closes #914

### Tests

<!-- How is this change verified? -->

Added `test_anthropic_response_parsing.py` with unit tests that mock the client,
so they need no API key and run in the regular unit test job: a tool_use
response with no leading text, one with a leading text block, and a plain text
response.

`test_tool_use_response_without_leading_text` fails on `main` with
`AttributeError: 'ToolUseBlock' object has no attribute 'text'` and passes with
this change.

- `pytest flink_agents/integrations/chat_models/anthropic/tests/`: 5 passed,
  2 skipped (the existing API-key integration tests).
- `ruff check --no-fix` / `ruff format --check` (pinned 0.11.13): clean.

### API

<!-- Does this change touches any public APIs? -->

No. `chat()` keeps its signature and still returns a `ChatMessage`. Text
responses are unaffected — the first text block is the same value `content[0]`
used to yield — it only stops crashing when the first block is not text.

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->