### PR TITLE
[bug] [python] Propagate config model reconstruction errors in Action deserialize

### DIFF
--- a/python/flink_agents/plan/actions/action.py
+++ b/python/flink_agents/plan/actions/action.py
@@ -26,6 +26,9 @@ from flink_agents.api.runner_context import RunnerContext
 from flink_agents.plan.function import Function, JavaFunction, PythonFunction
 
 _CONFIG_TYPE = "__config_type__"
+# Tags a config entry that we serialized from a pydantic model, so on the way
+# back we only rebuild the ones we tagged and leave plain values alone.
+_PYDANTIC_MODEL_MARKER = "__pydantic_model__"
 
 
 class Action(BaseModel):
@@ -70,11 +73,12 @@ class Action(BaseModel):
         data[_CONFIG_TYPE] = "python"
         for name, value in config.items():
             if isinstance(value, BaseModel):
-                data[name] = (
-                    inspect.getmodule(value).__name__,
-                    value.__class__.__name__,
-                    value,
-                )
+                data[name] = {
+                    _PYDANTIC_MODEL_MARKER: True,
+                    "module": inspect.getmodule(value).__name__,
+                    "class": value.__class__.__name__,
+                    "value": value,
+                }
             else:
                 data[name] = value
         return data
@@ -95,10 +99,14 @@ class Action(BaseModel):
                     self["config"][name] = value["value"]
             return self
         for name, value in config.items():
-            if isinstance(value, list | tuple):
-                module = importlib.import_module(value[0])
-                clazz = getattr(module, value[1])
-                self["config"][name] = clazz.model_validate(value[2])
+            # Rebuild only entries with our marker, so a plain list or dict
+            # value is not treated as a model by mistake. Do not catch errors:
+            # if the class cannot be imported (e.g. missing on the worker),
+            # fail here with the real cause instead of a confusing error later.
+            if isinstance(value, dict) and value.get(_PYDANTIC_MODEL_MARKER):
+                module = importlib.import_module(value["module"])
+                clazz = getattr(module, value["class"])
+                self["config"][name] = clazz.model_validate(value["value"])
             else:
                 self["config"][name] = value
         return self

--- a/python/flink_agents/plan/actions/action.py
+++ b/python/flink_agents/plan/actions/action.py
@@ -95,11 +95,11 @@ class Action(BaseModel):
                     self["config"][name] = value["value"]
             return self
         for name, value in config.items():
-            try:
+            if isinstance(value, list | tuple):
                 module = importlib.import_module(value[0])
                 clazz = getattr(module, value[1])
                 self["config"][name] = clazz.model_validate(value[2])
-            except Exception:  # noqa : PERF203
+            else:
                 self["config"][name] = value
         return self
 

--- a/python/flink_agents/plan/tests/resources/action.json
+++ b/python/flink_agents/plan/tests/resources/action.json
@@ -10,10 +10,11 @@
     ],
     "config": {
         "__config_type__": "python",
-        "output_schema": [
-            "flink_agents.api.agents.types",
-            "OutputSchema",
-            {
+        "output_schema": {
+            "__pydantic_model__": true,
+            "module": "flink_agents.api.agents.types",
+            "class": "OutputSchema",
+            "value": {
                 "output_schema": {
                     "names": [
                         "result"
@@ -23,6 +24,6 @@
                     ]
                 }
             }
-        ]
+        }
     }
 }

--- a/python/flink_agents/plan/tests/test_action.py
+++ b/python/flink_agents/plan/tests/test_action.py
@@ -120,3 +120,28 @@ def test_action_deserialize_java_shape_config_unwraps_primitives() -> None:
         "rate": 1.5,
         "label": "fast",
     }
+
+
+def test_action_deserialize_python_config_propagates_reconstruction_error() -> None:
+    """A serialized model whose module is missing must fail loudly.
+
+    The list-shaped entry is treated as a serialized model, so importing a
+    non-existent module raises instead of being silently swallowed.
+    """
+    json_str = json.dumps(
+        {
+            "name": "legal",
+            "exec": {
+                "func_type": "PythonFunction",
+                "module": "flink_agents.plan.tests.test_action",
+                "qualname": "legal_signature",
+            },
+            "trigger_conditions": ["_input_event"],
+            "config": {
+                "__config_type__": "python",
+                "broken": ["nonexistent_module_xyz", "SomeClass", {}],
+            },
+        }
+    )
+    with pytest.raises(ModuleNotFoundError):
+        Action.model_validate_json(json_str)

--- a/python/flink_agents/plan/tests/test_action.py
+++ b/python/flink_agents/plan/tests/test_action.py
@@ -123,10 +123,10 @@ def test_action_deserialize_java_shape_config_unwraps_primitives() -> None:
 
 
 def test_action_deserialize_python_config_propagates_reconstruction_error() -> None:
-    """A serialized model whose module is missing must fail loudly.
+    """A tagged model whose module is missing must fail loudly.
 
-    The list-shaped entry is treated as a serialized model, so importing a
-    non-existent module raises instead of being silently swallowed.
+    The entry is marked as a serialized model, so importing a non-existent
+    module raises instead of being silently swallowed.
     """
     json_str = json.dumps(
         {
@@ -139,9 +139,35 @@ def test_action_deserialize_python_config_propagates_reconstruction_error() -> N
             "trigger_conditions": ["_input_event"],
             "config": {
                 "__config_type__": "python",
-                "broken": ["nonexistent_module_xyz", "SomeClass", {}],
+                "broken": {
+                    "__pydantic_model__": True,
+                    "module": "nonexistent_module_xyz",
+                    "class": "SomeClass",
+                    "value": {},
+                },
             },
         }
     )
     with pytest.raises(ModuleNotFoundError):
         Action.model_validate_json(json_str)
+
+
+def test_action_deserialize_python_config_preserves_plain_list() -> None:
+    """A plain user list must survive untouched, not be mistaken for a model."""
+    json_str = json.dumps(
+        {
+            "name": "legal",
+            "exec": {
+                "func_type": "PythonFunction",
+                "module": "flink_agents.plan.tests.test_action",
+                "qualname": "legal_signature",
+            },
+            "trigger_conditions": ["_input_event"],
+            "config": {
+                "__config_type__": "python",
+                "hosts": ["host-a", "host-b", "host-c"],
+            },
+        }
+    )
+    action = Action.model_validate_json(json_str)
+    assert action.config == {"hosts": ["host-a", "host-b", "host-c"]}


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #920 

### Purpose of change
This change wants to improve the debuggability of Action config deserialization. Before, `Action.__custom_deserialize` catch all errors when it reconstruct `python`-format config models, so if a real error happen (for example `ModuleNotFoundError`), the error is hidden and the raw value is stored. User can not know the real reason, and the problem show up later as a confusing error, e.g. `pemja.core.PythonException: <class 'AttributeError'>: 'list' object has no attribute 'model_dump'`.

Now we replace the broad `try/except` with a explicit isinstance(value, list | tuple)` check, so the real error can propagate and fail fast, and it is easy to find the root cause. Plain values still pass through as before. 

### Tests

<!-- How is this change verified? -->
- Added unit test
- Verified in a test app and checked the real error propagated properly

<img width="1210" height="313" alt="Screenshot 2026-07-20 at 12 12 48 AM" src="https://github.com/user-attachments/assets/36cb6d79-e816-4a37-a201-cb5808db7b72" />



### API

<!-- Does this change touches any public APIs? -->
N/A

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
