### PR TITLE
[e2e][java] Validate ReActAgent output without schema

### DIFF
--- a/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/ReActAgentTest.java
+++ b/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/ReActAgentTest.java
@@ -215,9 +215,14 @@ public class ReActAgentTest {
                         .apply(agent)
                         .toDataStream();
 
-        out.print();
+        CloseableIterator<Object> results = out.collectAsync();
 
         env.execute();
+
+        Assertions.assertTrue(results.hasNext(), "The agent should emit a result.");
+        Assertions.assertTrue(
+                results.next() instanceof String,
+                "The result should be a String when no output schema is provided.");
     }
 
     // create ReAct agent; pass false to skip the output schema.


### PR DESCRIPTION
Related to #837 and the review discussion in #838.

### Purpose of change

Strengthen the Java ReActAgent regression test for the no-output-schema path.

The test previously only printed the output and therefore passed as long as the
job executed without throwing. This change collects the result and verifies
that the agent emits an output and that the output is a `String`, matching the
no-schema contract and the existing Python coverage.

### Tests

- `mvn --batch-mode --no-transfer-progress spotless:check -pl e2e-test/flink-agents-end-to-end-tests-integration`
- `mvn --batch-mode --no-transfer-progress test-compile -pl e2e-test/flink-agents-end-to-end-tests-integration -am -DskipTests`
- `./tools/ut.sh --java --e2e --flink 2.3` (29 tests, 0 failures, 0 errors, 8 skipped)

### API

No public API changes.

### Documentation

- [x] `doc-not-needed`
