### PR TITLE
[infra] Surface the ASF generative-AI disclosure in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,4 +33,4 @@ Linked issue: #xxx
 - [ ] Yes
 - [ ] No
 
-If yes, include a `Generated-by: <tool name and version>` line in this description. See the [ASF generative tooling guidance](https://www.apache.org/legal/generative-tooling.html).
+If yes, include a `Generated-by: <tool name and version>` line in the commit message so it reaches Git history, and repeat it here for reviewer visibility. See the [ASF generative tooling guidance](https://www.apache.org/legal/generative-tooling.html).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,3 +25,12 @@ Linked issue: #xxx
 - [ ] `doc-needed` <!-- Your PR changes impact docs -->
 - [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
 - [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
+
+### Was this patch authored or co-authored using generative AI tooling?
+
+<!-- Do not remove this section. Check the proper box only. -->
+
+- [ ] Yes
+- [ ] No
+
+If yes, include a `Generated-by: <tool name and version>` line in this description. See the [ASF generative tooling guidance](https://www.apache.org/legal/generative-tooling.html).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Java tests use JUnit 5 with AssertJ and Mockito. Python tests use pytest; integr
 
 ## Commit & Pull Request Guidelines
 
-Use concise subjects with bracketed components, matching existing history, such as `[python] Admit bytes in memory values` or `[api][java] Add event constants`. For nontrivial behavior changes, open or link a GitHub issue before the PR. PR titles should include relevant components like `[api]`, `[runtime]`, `[java]`, `[python]`, or `[hotfix]`; describe the change, test evidence, and any compatibility impact.
+Use concise subjects with bracketed components, matching existing history, such as `[python] Admit bytes in memory values` or `[api][java] Add event constants`. For nontrivial behavior changes, open or link a GitHub issue before the PR. PR titles should include relevant components like `[api]`, `[runtime]`, `[java]`, `[python]`, or `[hotfix]`; describe the change, test evidence, and any compatibility impact. Answer the PR template's generative-AI question, and when such tooling was used, include a `Generated-by: <tool name and version>` line in the PR description, per the [ASF generative tooling guidance](https://www.apache.org/legal/generative-tooling.html).
 
 ## Code Review
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Java tests use JUnit 5 with AssertJ and Mockito. Python tests use pytest; integr
 
 ## Commit & Pull Request Guidelines
 
-Use concise subjects with bracketed components, matching existing history, such as `[python] Admit bytes in memory values` or `[api][java] Add event constants`. For nontrivial behavior changes, open or link a GitHub issue before the PR. PR titles should include relevant components like `[api]`, `[runtime]`, `[java]`, `[python]`, or `[hotfix]`; describe the change, test evidence, and any compatibility impact. Answer the PR template's generative-AI question, and when such tooling was used, include a `Generated-by: <tool name and version>` line in the PR description, per the [ASF generative tooling guidance](https://www.apache.org/legal/generative-tooling.html).
+Use concise subjects with bracketed components, matching existing history, such as `[python] Admit bytes in memory values` or `[api][java] Add event constants`. For nontrivial behavior changes, open or link a GitHub issue before the PR. PR titles should include relevant components like `[api]`, `[runtime]`, `[java]`, `[python]`, or `[hotfix]`; describe the change, test evidence, and any compatibility impact. Answer the PR template's generative-AI question, and when such tooling was used, include a `Generated-by: <tool name and version>` line in the commit message so it reaches Git history, repeating it in the PR description for reviewer visibility, per the [ASF generative tooling guidance](https://www.apache.org/legal/generative-tooling.html).
 
 ## Code Review
 


### PR DESCRIPTION
Linked issue: #932

### Purpose of change

The [ASF generative tooling guidance](https://www.apache.org/legal/generative-tooling.html) asks contributors to disclose when generative AI tooling was used to author or co-author a contribution. Our PR template has no field for that, and `AGENTS.md` does not mention it, so the disclosure is not surfaced anywhere in this project today.

This adds a disclosure section to the PR template, plus one sentence in the `AGENTS.md` commit and PR guidelines recording the same convention, so that a human contributor and a coding agent reading the repo guide both know to fill it in.

The wording follows the shorter of the two Apache precedents. `apache/auron` uses a yes/no question with a `Generated-by` instruction and a link to the ASF guidance. `apache/flink` uses a longer form with a commented-out trailer plus a project policy line stating that low-effort AI-generated PRs will be closed. I left that policy line out, since it is a project decision rather than a mechanical alignment with the ASF guidance, and seems better raised on its own if maintainers want it.

Two small choices worth a reviewer's eye:

- The `Generated-by` line is asked for in the commit message, with the PR description carrying a copy for reviewer visibility. The guidance asks for the token in the source control commit message so future release tooling can pull it into a machine-parsable provenance file. This repository enables squash and rebase merges, and squash composes the merged body from the source commit messages, so a line present only in the PR description does not reach Git history on either path.
- The heading is phrased as a question to match both Apache precedents, which reads differently from the noun headings used elsewhere in the template. Happy to switch to a noun heading if that consistency matters more.

### Tests

Not applicable, documentation only, no logic change.

Ran `python3 tools/check-agents-md.py`: passes, confirming the `AGENTS.md` edit leaves the version facts the checker asserts untouched.

Ran `./tools/check-license.sh`: RAT checks pass.

### API

No. No code or public API change.

### Documentation

- [x] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

Generated-by: Claude Code 2.1.220
