### PR TITLE
[hotfix] Ignore the local directories check-license.sh creates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ python/.DS_Store
 
 # Build
 target/
+/build/
+/lib/
 **/dependency-reduced-pom.xml
 tools/releasing/release/
 __pycache__


### PR DESCRIPTION
<!-- Hotfix, so no linked issue. -->

### Purpose of change

`tools/check-license.sh` creates two directories in the repository root before it runs:

- `mkdir -p "$FWDIR"/lib` (line 65) for the Apache RAT jar it downloads
- `mkdir -p build` (line 72) for the `rat-results.txt` it writes

Neither was in `.gitignore`, so anyone who runs the repository's own license check ends up with `?? build/` and `?? lib/` sitting in `git status` from then on.

Both patterns are anchored to the root (`/build/`, `/lib/`) so that nested directories of the same name keep matching their own existing rules. In particular `python/flink_agents/lib/` still matches its own entry rather than the new one, and no tracked file is affected: `git ls-files build lib` is empty.

### Tests

Not applicable, this only changes `.gitignore`. Verified with `git check-ignore -v`:

```
build                      .gitignore:16:/build/    build
lib                        .gitignore:17:/lib/      lib
python/flink_agents/lib    .gitignore:25:python/flink_agents/lib/    python/flink_agents/lib
```

After the change, `tools/check-license.sh` leaves a clean `git status`.

### API

No.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`
