### PR TITLE
[docs] Use a current GA API version in the Azure OpenAI examples

### DIFF
--- a/docs/content/docs/development/chat_models.md
+++ b/docs/content/docs/development/chat_models.md
@@ -506,7 +506,7 @@ Azure OpenAI provides access to OpenAI models (GPT-4, GPT-4o, etc.) through Azur
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `api_key` | str | Required | Azure OpenAI API key for authentication |
-| `api_version` | str | Required | Azure OpenAI REST API version (e.g., "2024-02-15-preview"). See [API versions](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versioning) |
+| `api_version` | str | Required | Azure OpenAI REST API version (e.g., "2024-10-21"). See [API versions](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versioning) |
 | `azure_endpoint` | str | Required | Azure OpenAI endpoint URL (e.g., `https://{resource-name}.openai.azure.com`) |
 | `timeout` | float | `60.0` | API request timeout in seconds |
 | `max_retries` | int | `3` | Maximum number of API retry attempts |
@@ -518,7 +518,7 @@ Azure OpenAI provides access to OpenAI models (GPT-4, GPT-4o, etc.) through Azur
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `api_key` | String | Required | Azure OpenAI API key for authentication |
-| `api_version` | String | Required | Azure OpenAI REST API version (e.g., "2024-02-01"). See [API versions](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versioning) |
+| `api_version` | String | Required | Azure OpenAI REST API version (e.g., "2024-10-21"). See [API versions](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versioning) |
 | `azure_endpoint` | String | Required | Azure OpenAI endpoint URL (e.g., `https://{resource-name}.openai.azure.com`) — either a direct Azure resource or a proxy/gateway URL that fronts an Azure OpenAI service |
 | `timeout` | int | None | Timeout in seconds for API requests; must be greater than 0, otherwise ignored (SDK default applies) |
 | `max_retries` | int | None | Maximum number of API retry attempts; must be non-negative, otherwise ignored (SDK default applies) |
@@ -580,7 +580,7 @@ class MyAgent(Agent):
         return ResourceDescriptor(
             clazz=ResourceName.ChatModel.AZURE_OPENAI_CONNECTION,
             api_key="<your-api-key>",
-            api_version="2024-02-15-preview",
+            api_version="2024-10-21",
             azure_endpoint="https://your-resource.openai.azure.com"
         )
 
@@ -606,7 +606,7 @@ public class MyAgent extends Agent {
     public static ResourceDescriptor azureOpenAIConnection() {
         return ResourceDescriptor.Builder.newBuilder(ResourceName.ChatModel.AZURE_OPENAI_CONNECTION)
                 .addInitialArgument("api_key", "<your-api-key>")
-                .addInitialArgument("api_version", "2024-02-01")
+                .addInitialArgument("api_version", "2024-10-21")
                 .addInitialArgument("azure_endpoint", "https://your-resource.openai.azure.com")
                 .build();
     }


### PR DESCRIPTION
Linked issue: #280

### Purpose of change

The Azure OpenAI documentation used `2024-02-15-preview` in the Python parameter table and example, and `2024-02-01` in the Java ones. Both are early-2024 versions, and the two languages disagreed with each other for no particular reason.

This uses `2024-10-21` in all four places. That is the most recent stable version listed in the `AzureOpenAIServiceVersion` enum of the `openai-java` SDK this project already depends on, so a documented example stays consistent with what the client actually supports.

There is a second reason to prefer a newer version here. Azure gates structured outputs on api-version `2024-08-01-preview` and later, so a user who copies the current example and then passes an `output_schema` gets the prompt-engineering fallback rather than the provider's native path, with nothing indicating why. That was harmless while nothing read the api-version, and becomes a papercut with the native structured-output work in #919 and #930.

Documenting which providers support native structured output is a separate change and is not included here, since that work is still in review.

### Tests

Not applicable, documentation only. No code or example semantics change beyond the version string; the four sites are the two parameter tables and the two connection examples.

### API

No.

### Documentation

- [ ] `doc-needed`
- [ ] `doc-not-needed`
- [x] `doc-included`
