### PR TITLE
[test][python] Fix Action deserialize tests on release branch

### DIFF
--- a/python/flink_agents/plan/tests/test_action.py
+++ b/python/flink_agents/plan/tests/test_action.py
@@ -136,7 +136,7 @@ def test_action_deserialize_python_config_propagates_reconstruction_error() -> N
                 "module": "flink_agents.plan.tests.test_action",
                 "qualname": "legal_signature",
             },
-            "trigger_conditions": ["_input_event"],
+            "listen_event_types": ["_input_event"],
             "config": {
                 "__config_type__": "python",
                 "broken": {
@@ -162,7 +162,7 @@ def test_action_deserialize_python_config_preserves_plain_list() -> None:
                 "module": "flink_agents.plan.tests.test_action",
                 "qualname": "legal_signature",
             },
-            "trigger_conditions": ["_input_event"],
+            "listen_event_types": ["_input_event"],
             "config": {
                 "__config_type__": "python",
                 "hosts": ["host-a", "host-b", "host-c"],


### PR DESCRIPTION
## What changed

- Update two `Action` config deserialization test fixtures to use the
  `release-0.3` field name, `listen_event_types`.

## Why

PR #921 was authored against `main`, where the field is named
`trigger_conditions`. When that change was cherry-picked to `release-0.3`, the
new tests retained the `main` field name even though `Action` on the release
branch still accepts `listen_event_types`.

As a result, all Python unit-test matrix jobs failed before exercising the
intended config deserialization behavior:

```text
TypeError: Action.__init__() got an unexpected keyword argument 'trigger_conditions'
```

This keeps the production implementation unchanged and adapts only the
branch-specific test fixtures.

## Validation

- `python/.venv/bin/python -m pytest flink_agents/plan/tests/test_action.py -q`
  - 7 passed
- Full non-integration Python unit-test selection
  - 571 passed, 11 skipped, 122 deselected
- `ruff check` and `ruff format --check` on the changed file
- `git diff --check`
