### PR TITLE
[hotfix][runtime] Close the Kafka consumer when the producer fails to close

### DIFF
--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStore.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStore.java
@@ -331,11 +331,14 @@ public class KafkaActionStateStore implements ActionStateStore {
 
     @Override
     public void close() throws Exception {
-        if (producer != null) {
-            producer.close();
-        }
-        if (consumer != null) {
-            consumer.close();
+        try {
+            if (producer != null) {
+                producer.close();
+            }
+        } finally {
+            if (consumer != null) {
+                consumer.close();
+            }
         }
     }
 

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStore.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStore.java
@@ -331,14 +331,27 @@ public class KafkaActionStateStore implements ActionStateStore {
 
     @Override
     public void close() throws Exception {
-        try {
-            if (producer != null) {
+        Exception firstException = null;
+        if (producer != null) {
+            try {
                 producer.close();
+            } catch (Exception e) {
+                firstException = e;
             }
-        } finally {
-            if (consumer != null) {
+        }
+        if (consumer != null) {
+            try {
                 consumer.close();
+            } catch (Exception e) {
+                if (firstException == null) {
+                    firstException = e;
+                } else {
+                    firstException.addSuppressed(e);
+                }
             }
+        }
+        if (firstException != null) {
+            throw firstException;
         }
     }
 

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStoreTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStoreTest.java
@@ -21,9 +21,11 @@ import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.api.InputEvent;
 import org.apache.flink.agents.plan.AgentConfiguration;
 import org.apache.flink.agents.plan.actions.Action;
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
@@ -38,6 +40,9 @@ import java.util.Map;
 import static org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy.EARLIEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /** Unit tests for {@link KafkaActionStateStore}. */
 public class KafkaActionStateStoreTest {
@@ -253,5 +258,26 @@ public class KafkaActionStateStoreTest {
                         actionStates.get(
                                 ActionStateUtil.generateKey(TEST_KEY, 3L, testAction, testEvent)))
                 .isEqualTo(thirdState);
+    }
+
+    /** Contract: the consumer is closed even when closing the producer throws. */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testCloseClosesConsumerWhenProducerCloseFails() {
+        Producer<String, ActionState> failingProducer = mock(Producer.class);
+        Consumer<String, ActionState> consumer = mock(Consumer.class);
+        doThrow(new RuntimeException("producer close failed")).when(failingProducer).close();
+
+        KafkaActionStateStore store =
+                new KafkaActionStateStore(
+                        actionStates,
+                        new AgentConfiguration(),
+                        failingProducer,
+                        consumer,
+                        TEST_TOPIC);
+
+        assertThrows(RuntimeException.class, store::close);
+
+        verify(consumer).close();
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStoreTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStoreTest.java
@@ -280,4 +280,67 @@ public class KafkaActionStateStoreTest {
 
         verify(consumer).close();
     }
+
+    /**
+     * Contract: when both closes fail, the producer's exception is the one thrown and the
+     * consumer's is attached to it as a suppressed exception, so neither failure is lost.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testCloseKeepsProducerFailureWhenBothCloseFail() {
+        Producer<String, ActionState> failingProducer = mock(Producer.class);
+        Consumer<String, ActionState> failingConsumer = mock(Consumer.class);
+        RuntimeException producerFailure = new RuntimeException("producer close failed");
+        RuntimeException consumerFailure = new RuntimeException("consumer close failed");
+        doThrow(producerFailure).when(failingProducer).close();
+        doThrow(consumerFailure).when(failingConsumer).close();
+
+        KafkaActionStateStore store =
+                new KafkaActionStateStore(
+                        actionStates,
+                        new AgentConfiguration(),
+                        failingProducer,
+                        failingConsumer,
+                        TEST_TOPIC);
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, store::close);
+
+        assertThat(thrown).isSameAs(producerFailure);
+        assertThat(thrown.getSuppressed()).containsExactly(consumerFailure);
+    }
+
+    /**
+     * Contract: when only the consumer close fails, its exception reaches the caller unchanged,
+     * with nothing attached as suppressed.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testCloseThrowsConsumerFailureWhenOnlyConsumerCloseFails() {
+        Producer<String, ActionState> producer = mock(Producer.class);
+        Consumer<String, ActionState> failingConsumer = mock(Consumer.class);
+        RuntimeException consumerFailure = new RuntimeException("consumer close failed");
+        doThrow(consumerFailure).when(failingConsumer).close();
+
+        KafkaActionStateStore store =
+                new KafkaActionStateStore(
+                        actionStates,
+                        new AgentConfiguration(),
+                        producer,
+                        failingConsumer,
+                        TEST_TOPIC);
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, store::close);
+
+        assertThat(thrown).isSameAs(consumerFailure);
+        assertThat(thrown.getSuppressed()).isEmpty();
+    }
+
+    /** Contract: both the producer and the consumer are closed when neither close fails. */
+    @Test
+    void testCloseClosesProducerAndConsumer() throws Exception {
+        actionStateStore.close();
+
+        assertThat(mockProducer.closed()).isTrue();
+        assertThat(mockConsumer.closed()).isTrue();
+    }
 }


### PR DESCRIPTION
Linked issue: none (hotfix)

### Purpose of change

`KafkaActionStateStore.close()` closed the producer and the consumer as two sequential statements. If `producer.close()` threw, `consumer.close()` was never reached, and the consumer's network client, background heartbeat thread, and coordinator connection leaked for the lifetime of the TaskManager JVM.

#### Runtime flow

`ActionExecutionOperator.close()` calls `DurableExecutionManager.close()`, which calls `KafkaActionStateStore.close()`. Both callers only propagate, neither catches or inspects.

Inside `close()`, the producer is closed first inside a `try`, and any exception is captured into a local `firstException` instead of propagating immediately. The consumer is then closed in its own `try`. Its exception becomes `firstException` if none is held yet, otherwise it is attached to the held one with `addSuppressed`. After both attempts, `close()` rethrows `firstException` if one was captured, and returns normally otherwise.

#### Key decisions

Capture and rethrow, rather than closing the consumer in a `finally`. A `finally` that completes abruptly discards the in-flight exception (JLS 14.20.2), so a consumer failure would erase a producer failure rather than merely accompany it. The producer failure is the more diagnostic of the two, since it is the one that indicates unflushed action state.

The shape matches `ResourceCache.close()` and `SkillManager.closeRepos()`, which already aggregate multi-resource close failures this way in the same module.

Try-with-resources over the two fields was rejected. It closes in reverse declaration order, so it reintroduces the same masking with the roles swapped.

### Implementation Description

#### Behavioral contracts

1. Both closes are attempted on every call, producer first, consumer second.
2. A null producer or consumer is skipped rather than raising.
3. When only the producer close fails, its exception reaches the caller.
4. When only the consumer close fails, its exception reaches the caller unchanged, with nothing suppressed.
5. When both fail, the producer's exception is the one thrown, and the consumer's is attached to it via `addSuppressed`.
6. When neither fails, `close()` returns normally.

#### Failure behavior

Nothing is retried, absorbed, or degraded. Every close failure reaches the caller.

A producer close failure no longer prevents the consumer close from running.

A consumer close failure never replaces a producer close failure, it is attached as suppressed.

Exceptions are rethrown as caught rather than wrapped, so the type and stack trace a caller sees are the ones Kafka raised.

`close()` returns normally only when neither close threw, so a normal return remains a truthful signal of a clean shutdown.

There is no configuration path here and no external response shape to validate, so those failure classes do not apply.

### Tests

| Contract | Test |
|---|---|
| 1, 6 | `testCloseClosesProducerAndConsumer` |
| 1 | `testCloseClosesConsumerWhenProducerCloseFails`, for the consumer still being closed after a producer failure |
| 2 | None. The public constructor never yields a null producer or consumer, so the guards are reachable only from the package-private test constructor. |
| 3 | `testCloseClosesConsumerWhenProducerCloseFails`, which asserts that a `RuntimeException` propagates, not its identity nor that nothing is suppressed |
| 4 | `testCloseThrowsConsumerFailureWhenOnlyConsumerCloseFails` |
| 5 | `testCloseKeepsProducerFailureWhenBothCloseFail` |

Each test was checked against a mutant, and each mutant is caught by exactly one of the four.

Reverting to `try`/`finally` fails contract 5 on the identity assertion, with the consumer's exception arriving where the producer's was expected. `assertThrows(RuntimeException.class, ...)` still passes there, so the identity assertion is what carries that test.

Dropping the assignment in the consumer's `catch` fails contract 4 with "Expected java.lang.RuntimeException to be thrown, but nothing was thrown", meaning `close()` reported a clean shutdown that did not happen.

Closing the consumer only on the producer-failure path fails contract 1.

Moving the final `throw` into the consumer's `catch` fails contract 3.

`KafkaActionStateStoreTest` 11/11 and `-Dtest='*ActionState*'` 87/87 pass, as does the `runtime` module at 405/405 from a clean build. `spotless:check` is clean. The 87 includes 13 Fluss integration tests that need Docker, which the module run does not select.

### API

No signature change. `close()` is an existing `ActionStateStore` method, inherited from `AutoCloseable`.

For a caller that does nothing differently, one case changes. When both closes fail, the exception received is now the producer's rather than the consumer's, and `getSuppressed()` is non-empty. Everything else is unchanged, including close order, the number of close attempts, and the exception instance received when exactly one close fails. Both callers in the repo only propagate, and no code catches by type, unwraps a cause, or reads `getSuppressed()`.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`
