### PR TITLE
[hotfix][java][python] Release skill repositories on any load failure and remove dead code

### DIFF
--- a/python/flink_agents/runtime/skill/skill_manager.py
+++ b/python/flink_agents/runtime/skill/skill_manager.py
@@ -137,37 +137,24 @@ class SkillManager:
         repo = self._repos.get(skill_name)
         return None if repo is None else repo.get_skill_dir(skill_name)
 
-    def resolve_resource_path(self, skill_name: str, resource_path: str) -> Path | None:
-        """Resolve a skill resource's relative path to an absolute filesystem path.
-
-        Returns None if the skill's repository doesn't support path resolution.
-        """
-        repo = self._repos.get(skill_name)
-        if repo is None:
-            return None
-        dir_path = repo.get_skill_dir(skill_name)
-        if dir_path is None:
-            return None
-        resolved = dir_path / resource_path
-        return resolved if resolved.is_file() else None
-
     def _load_skills(self) -> None:
-        for spec in self._config.sources:
-            try:
-                handler = skill_source_registry.get(spec.scheme)
-                repo = handler.open(spec.params)
-                self._opened_repos.append(repo)
-            except (OSError, ValueError) as e:
-                # Release repos opened by earlier iterations — the caller never
-                # receives a SkillManager reference to clean them up via close()
-                # itself, so without this their temp dirs / atexit handlers leak
-                # until interpreter exit.
-                self.close()
-                msg = (
-                    f"Failed to load skills from {spec.scheme}:{spec.params}"
-                )
-                raise RuntimeError(msg) from e
-            self._register_repo(repo, _origin_of(spec))
+        try:
+            for spec in self._config.sources:
+                try:
+                    handler = skill_source_registry.get(spec.scheme)
+                    repo = handler.open(spec.params)
+                    self._opened_repos.append(repo)
+                except (OSError, ValueError) as e:
+                    msg = f"Failed to load skills from {spec.scheme}:{spec.params}"
+                    raise RuntimeError(msg) from e
+                self._register_repo(repo, _origin_of(spec))
+        except BaseException:
+            # Release every repo opened so far — the caller never receives a
+            # SkillManager reference to clean them up via close() itself, so
+            # without this their temp dirs / atexit handlers leak until
+            # interpreter exit.
+            self.close()
+            raise
 
     def _register_repo(self, repo: "SkillRepository", origin: SkillOrigin) -> None:
         for skill in repo.get_skills():

--- a/python/flink_agents/runtime/skill/skill_repository.py
+++ b/python/flink_agents/runtime/skill/skill_repository.py
@@ -16,30 +16,10 @@
 # limitations under the License.
 #################################################################################
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List
 
 from flink_agents.runtime.skill.agent_skill import AgentSkill
-
-
-@dataclass
-class SkillRepositoryInfo:
-    """Information about a skill repository.
-
-    Attributes:
-    ----------
-    repo_type : str
-        The type of repository (e.g., "filesystem", "classpath", "url").
-    location : str
-        The location of the repository (e.g., path, URL).
-    writeable : bool
-        Whether the repository supports write operations.
-    """
-
-    repo_type: str
-    location: str
-    writeable: bool
 
 
 class SkillRepository(ABC):

--- a/python/flink_agents/runtime/skill/tests/test_manager.py
+++ b/python/flink_agents/runtime/skill/tests/test_manager.py
@@ -357,3 +357,107 @@ class TestSkillManagerMixedSources:
         assert closed == ["skill-1"], (
             "the repo opened before the partial-load failure must be closed"
         )
+
+    def test_load_failure_outside_wrapped_types_closes_repos_and_propagates(
+        self,
+    ) -> None:
+        # Contract: a source failure that is neither OSError nor ValueError still
+        # closes the repos opened before it, and reaches the caller unwrapped.
+        from typing import Dict, List
+
+        from flink_agents.runtime.skill import skill_source_registry
+        from flink_agents.runtime.skill.agent_skill import AgentSkill
+        from flink_agents.runtime.skill.skill_repository import SkillRepository
+
+        closed: List[str] = []
+
+        class FakeRepo(SkillRepository):
+            def get_skill(self, name: str) -> AgentSkill | None:
+                return self.get_skills()[0] if name == "skill-1" else None
+
+            def get_skills(self) -> List[AgentSkill]:
+                return [AgentSkill(name="skill-1", description="dummy", content="body")]
+
+            def get_resources(self, name: str) -> Dict[str, str]:
+                return {}
+
+            def close(self) -> None:
+                closed.append("skill-1")
+
+        counter = {"n": 0}
+
+        def opener(params) -> SkillRepository:
+            counter["n"] += 1
+            if counter["n"] == 2:
+                msg = "corrupt archive"
+                raise zipfile.BadZipFile(msg)
+            return FakeRepo()
+
+        skill_source_registry.register("test-badzip-close", opener)
+
+        config = Skills(
+            sources=[
+                SkillSourceSpec(scheme="test-badzip-close", params={}),
+                SkillSourceSpec(scheme="test-badzip-close", params={}),
+            ]
+        )
+
+        with pytest.raises(zipfile.BadZipFile):
+            SkillManager(config)
+        assert closed == ["skill-1"], (
+            "a load failure outside (OSError, ValueError) must still close the "
+            "repos opened before it"
+        )
+
+    def test_registration_failure_closes_earlier_repo_and_propagates(self) -> None:
+        # Contract: a failure raised while registering a repo — after its open()
+        # already succeeded — still closes the repo from an earlier source.
+        from typing import Dict, List
+
+        from flink_agents.runtime.skill import skill_source_registry
+        from flink_agents.runtime.skill.agent_skill import AgentSkill
+        from flink_agents.runtime.skill.skill_repository import SkillRepository
+
+        closed: List[str] = []
+
+        class FakeRepo(SkillRepository):
+            def __init__(self, tag: str, *, boom: bool) -> None:
+                self._tag = tag
+                self._boom = boom
+
+            def get_skill(self, name: str) -> AgentSkill | None:
+                return None
+
+            def get_skills(self) -> List[AgentSkill]:
+                if self._boom:
+                    msg = "exploding during registration"
+                    raise KeyError(msg)
+                return [AgentSkill(name=self._tag, description="d", content="b")]
+
+            def get_resources(self, name: str) -> Dict[str, str]:
+                return {}
+
+            def close(self) -> None:
+                closed.append(self._tag)
+
+        counter = {"n": 0}
+
+        def opener(params) -> SkillRepository:
+            counter["n"] += 1
+            return FakeRepo(f"skill-{counter['n']}", boom=counter["n"] == 2)
+
+        skill_source_registry.register("test-register-boom", opener)
+
+        config = Skills(
+            sources=[
+                SkillSourceSpec(scheme="test-register-boom", params={}),
+                SkillSourceSpec(scheme="test-register-boom", params={}),
+            ]
+        )
+
+        with pytest.raises(KeyError):
+            SkillManager(config)
+        assert closed == ["skill-1", "skill-2"], (
+            "a registration failure must close every repo opened so far — the "
+            "earlier source's repo and the one whose registration failed"
+        )

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/skill/SkillManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/skill/SkillManager.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -157,21 +156,6 @@ public class SkillManager implements AutoCloseable {
     public Path getSkillDir(String skillName) {
         SkillRepository repo = repos.get(skillName);
         return repo == null ? null : repo.getSkillDir(skillName);
-    }
-
-    /** Resolve a skill resource's relative path to an absolute path, or {@code null} if missing. */
-    @Nullable
-    public Path resolveResourcePath(String skillName, String resourcePath) {
-        SkillRepository repo = repos.get(skillName);
-        if (repo == null) {
-            return null;
-        }
-        Path dir = repo.getSkillDir(skillName);
-        if (dir == null) {
-            return null;
-        }
-        Path resolved = dir.resolve(resourcePath);
-        return Files.isRegularFile(resolved) ? resolved : null;
     }
 
     private void loadAll() {

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/skill/SkillManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/skill/SkillManager.java
@@ -159,32 +159,37 @@ public class SkillManager implements AutoCloseable {
     }
 
     private void loadAll() {
-        for (SkillSourceSpec spec : config.getSources()) {
-            try {
-                SkillRepository repo =
-                        SkillSourceRegistry.get(spec.getScheme())
-                                .open(spec.getParams(), classLoader);
-                openedRepos.add(repo);
-                registerRepo(repo, originOf(spec));
-            } catch (IOException | IllegalArgumentException e) {
-                IllegalStateException toThrow =
-                        new IllegalStateException(
-                                "Failed to load skills from "
-                                        + spec.getScheme()
-                                        + ":"
-                                        + spec.getParams(),
-                                e);
-                // Release repos registered before this point. The caller never receives a
-                // SkillManager reference (we're throwing from the constructor path), so
-                // without this cleanup their shutdown hooks + temp dirs would leak until
-                // JVM exit.
+        try {
+            for (SkillSourceSpec spec : config.getSources()) {
                 try {
-                    closeRepos();
-                } catch (Exception cleanupError) {
-                    toThrow.addSuppressed(cleanupError);
+                    SkillRepository repo =
+                            SkillSourceRegistry.get(spec.getScheme())
+                                    .open(spec.getParams(), classLoader);
+                    openedRepos.add(repo);
+                    registerRepo(repo, originOf(spec));
+                } catch (IOException | IllegalArgumentException e) {
+                    throw new IllegalStateException(
+                            "Failed to load skills from "
+                                    + spec.getScheme()
+                                    + ":"
+                                    + spec.getParams(),
+                            e);
                 }
-                throw toThrow;
             }
+        } catch (Throwable t) {
+            // Release every repo opened so far, on any failure path. The caller never
+            // receives a SkillManager reference (we're throwing from the constructor
+            // path), so without this cleanup their shutdown hooks + temp dirs would leak
+            // until JVM exit. The original failure propagates unchanged; a cleanup
+            // failure rides along as suppressed so neither is lost — including an Error,
+            // which closeRepos() does not catch per-repo and which would otherwise
+            // replace the original failure outright.
+            try {
+                closeRepos();
+            } catch (Throwable cleanupError) {
+                t.addSuppressed(cleanupError);
+            }
+            throw t;
         }
     }
 

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/skill/SkillManagerTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/skill/SkillManagerTest.java
@@ -291,23 +291,35 @@ class SkillManagerTest {
 
     /**
      * Minimal {@link SkillRepository} for lifecycle tests: each instance owns one fake skill and
-     * records whether {@code close()} was invoked. May be configured to throw a {@link
-     * RuntimeException} on close ({@link SkillRepository#close()} declares no checked exceptions;
-     * {@link SkillManager#close()} catches {@code Exception} so this still exercises the cascade
-     * logic).
+     * records whether {@code close()} was invoked. May be configured to fail on close, exercising
+     * the cascade logic in {@link SkillManager#close()}, and/or to fail from {@link #getSkills()},
+     * which fails the repo's registration after its {@code open()} has already succeeded.
+     *
+     * <p>{@link SkillRepository} declares no checked exceptions, so a configured failure is either
+     * a {@link RuntimeException} or an {@link Error}. Both kinds are needed: they take different
+     * paths through the handlers in {@link SkillManager}.
      */
     private static final class FakeRepo implements SkillRepository {
         private final AgentSkill skill;
         final AtomicBoolean closed = new AtomicBoolean();
-        @javax.annotation.Nullable private final RuntimeException closeException;
+        @javax.annotation.Nullable private final Throwable closeException;
+        @javax.annotation.Nullable private final Throwable getSkillsException;
 
         FakeRepo(String skillName) {
             this(skillName, null);
         }
 
-        FakeRepo(String skillName, @javax.annotation.Nullable RuntimeException closeException) {
+        FakeRepo(String skillName, @javax.annotation.Nullable Throwable closeException) {
+            this(skillName, closeException, null);
+        }
+
+        FakeRepo(
+                String skillName,
+                @javax.annotation.Nullable Throwable closeException,
+                @javax.annotation.Nullable Throwable getSkillsException) {
             this.skill = new AgentSkill(skillName, "fake", "body", null, null, null);
             this.closeException = closeException;
+            this.getSkillsException = getSkillsException;
         }
 
         @Override
@@ -317,6 +329,9 @@ class SkillManagerTest {
 
         @Override
         public List<AgentSkill> getSkills() {
+            if (getSkillsException != null) {
+                throwUnchecked(getSkillsException);
+            }
             return List.of(skill);
         }
 
@@ -329,8 +344,24 @@ class SkillManagerTest {
         public void close() {
             closed.set(true);
             if (closeException != null) {
-                throw closeException;
+                throwUnchecked(closeException);
             }
+        }
+
+        /**
+         * Throw a configured failure. Declaring the fields as {@link Throwable} lets one field
+         * carry either kind of unchecked failure; the interface permits nothing else, so a checked
+         * exception is a test-setup mistake and fails loudly rather than being smuggled past the
+         * compiler.
+         */
+        private static void throwUnchecked(Throwable failure) {
+            if (failure instanceof Error) {
+                throw (Error) failure;
+            }
+            if (failure instanceof RuntimeException) {
+                throw (RuntimeException) failure;
+            }
+            throw new AssertionError("FakeRepo failures must be unchecked", failure);
         }
     }
 
@@ -384,6 +415,60 @@ class SkillManagerTest {
         assertEquals("primary-boom", ex.getCause().getMessage());
         assertEquals(1, ex.getSuppressed().length);
         assertSame(cleanupBoom, ex.getSuppressed()[0]);
+    }
+
+    @Test
+    void registrationFailureOfUnwrappedTypeClosesReposAndPropagates() {
+        // A failure whose type is neither IOException nor IllegalArgumentException reaches the
+        // caller unchanged rather than being wrapped, so only a guard spanning every failure path
+        // can release the repos. Two repos are owned by the time registration fails: the earlier
+        // source's, and the one whose registration failed (it is recorded before registration
+        // runs). Both must be released, and a failure during that release must ride along as
+        // suppressed instead of replacing the original.
+        IllegalStateException registrationBoom = new IllegalStateException("registration-boom");
+        RuntimeException cleanupBoom = new RuntimeException("cleanup-boom");
+        FakeRepo first = new FakeRepo("alpha", cleanupBoom);
+        FakeRepo failing = new FakeRepo("beta", null, registrationBoom);
+        SkillSourceRegistry.register("test-register-boom-ok", (params, cl) -> first);
+        SkillSourceRegistry.register("test-register-boom-fail", (params, cl) -> failing);
+
+        Skills config =
+                new Skills(
+                        List.of(
+                                new SkillSourceSpec("test-register-boom-ok", Map.of()),
+                                new SkillSourceSpec("test-register-boom-fail", Map.of())));
+
+        IllegalStateException ex =
+                assertThrows(IllegalStateException.class, () -> new SkillManager(config));
+        // Identity, not just type: IllegalStateException is also what the wrapping catch builds.
+        assertSame(registrationBoom, ex);
+        assertTrue(first.closed.get(), "repo opened before the failure must be closed");
+        assertTrue(failing.closed.get(), "repo whose registration failed must be closed");
+        assertEquals(1, ex.getSuppressed().length);
+        assertSame(cleanupBoom, ex.getSuppressed()[0]);
+    }
+
+    @Test
+    void errorDuringRegistrationStillClosesRepoAndSuppressesCloseError() {
+        // An Error is not an Exception, so it survives a load failure only if both the guard around
+        // the source loop and the guard around that guard's cleanup accept Throwable. This repo
+        // fails its registration with one Error and then its close() with another: a load guard
+        // narrowed to Exception would skip the cleanup entirely, and a cleanup guard narrowed to
+        // Exception would let the close() Error escape and replace the registration failure.
+        // One source keeps the assertions deterministic — closeRepos() catches only Exception per
+        // repo, so an Error from any repo's close() ends the iteration over the remaining ones.
+        Error registrationBoom = new Error("registration-error");
+        Error closeBoom = new Error("close-error");
+        FakeRepo repo = new FakeRepo("alpha", closeBoom, registrationBoom);
+        SkillSourceRegistry.register("test-error-fail", (params, cl) -> repo);
+
+        Skills config = new Skills(List.of(new SkillSourceSpec("test-error-fail", Map.of())));
+
+        Error ex = assertThrows(Error.class, () -> new SkillManager(config));
+        assertSame(registrationBoom, ex);
+        assertTrue(repo.closed.get(), "the repo owned when registration failed must be closed");
+        assertEquals(1, ex.getSuppressed().length);
+        assertSame(closeBoom, ex.getSuppressed()[0]);
     }
 
     @Test

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/skill/SkillManagerTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/skill/SkillManagerTest.java
@@ -106,14 +106,6 @@ class SkillManagerTest {
         assertTrue(ex.getMessage().contains("github"));
     }
 
-    @Test
-    void resolveResourcePathLocatesBundledFile() {
-        SkillManager manager = new SkillManager(configFromResources());
-        Path resolved = manager.resolveResourcePath("nano-banana-pro", "scripts/generate_image.py");
-        assertNotNull(resolved);
-        assertTrue(Files.isRegularFile(resolved));
-    }
-
     private static void zipDir(Path src, Path dstZip) throws IOException {
         try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(dstZip));
                 Stream<Path> walk = Files.walk(src)) {


### PR DESCRIPTION
Linked issue: none (hotfix)

### Purpose of change

Two related cleanups in the skill module.

**Repositories leaked on unexpected load failures.** `SkillManager` released already-opened repositories only for a narrow set of exception types. Python's `_load_skills` guarded `OSError` and `ValueError`; Java's `loadAll` guarded `IOException` and `IllegalArgumentException`. Any other failure skipped the cleanup, so the repositories' temp directories and shutdown hooks leaked until interpreter or JVM exit. The caller never receives a `SkillManager` reference on a failed construction, so it cannot clean them up itself. Concrete cases: a corrupt archive raises `zipfile.BadZipFile`, which does not inherit from `OSError`; a failure inside `_register_repo` was outside the guarded region entirely; and on the Java side an unexpected `RuntimeException` or `Error` from `open()`, `originOf()`, or `registerRepo()` escaped the constructor.

The source loop is now wrapped in both languages so the cleanup runs on every failure path. Which exceptions get wrapped is unchanged: Python still wraps `OSError` and `ValueError` in `RuntimeError`, Java still wraps `IOException` and `IllegalArgumentException` in `IllegalStateException`, both with the same message and cause chaining, and everything else still propagates unchanged in type and identity. The only behavior change is that the cleanup now runs.

Java's guard takes `Throwable`, and so does the handler around the cleanup call itself. `closeRepos()` does not catch `Error` per repository and `SkillRepository.close()` declares no checked exception, so an `Error` raised while releasing a repository would otherwise escape and replace the original failure with nothing suppressed.

**Dead code removed.** `SkillManager.resolveResourcePath` and `SkillRepositoryInfo` have no callers. The resource-path method existed in both languages, so both are deleted in the same commit rather than leaving one side without its counterpart. Its only reference was a Java test, which is removed with it.

### Tests

Four tests added, two per language, covering the previously unguarded paths.

Python `TestSkillManagerMixedSources`: a source raising `zipfile.BadZipFile` from `open()`, and a failure raised from `_register_repo` after an earlier source loaded cleanly. Both assert the earlier repository was closed and that the original exception propagates unwrapped.

Java `SkillManagerTest`: a repository failing registration with an `IllegalStateException`, asserting both the earlier repository and the failing one were closed, that the original exception arrives by identity, and that a cleanup failure arrives as suppressed. Identity rather than type is the load-bearing assertion, since `IllegalStateException` is also what the wrapping catch builds. A second test covers the `Error` path, which is what pins both handlers to `Throwable`.

All four were verified to be discriminating rather than merely green. On the Python side, re-narrowing the handler so it no longer spans `_register_repo` fails only the registration test while the pre-existing cleanup tests stay green. On the Java side, narrowing either handler back to `Exception` fails the `Error` test, and restricting `addSuppressed` to the wrapped path fails both new tests while the pre-existing suppressed-cleanup test passes.

Java `SkillManagerTest` 19 passed and the full `runtime` module 402 passed. Python skill module 68 passed and the full suite 619 passed, 11 skipped. `spotless:check`, `ruff check`, and `ruff format` are all clean.

### API

No public API change. `SkillManager` is a runtime-internal component, and both removed symbols had no callers in either language.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`
