### PR TITLE
[integrations][openai] Preserve provider refusals in the Python message converter

### DIFF
--- a/integrations/chat-models/openai/src/test/java/org/apache/flink/agents/integrations/chatmodels/openai/OpenAIChatCompletionsUtilsTest.java
+++ b/integrations/chat-models/openai/src/test/java/org/apache/flink/agents/integrations/chatmodels/openai/OpenAIChatCompletionsUtilsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.integrations.chatmodels.openai;
+
+import com.openai.models.chat.completions.ChatCompletionMessage;
+import org.apache.flink.agents.api.chat.messages.ChatMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for how {@link OpenAIChatCompletionsUtils} carries a provider refusal from a Chat
+ * Completions message onto the returned {@link ChatMessage}. The converter is shared by every Chat
+ * Completions connection in this module.
+ */
+class OpenAIChatCompletionsUtilsTest {
+
+    @Test
+    @DisplayName("A refusal reason is carried into extraArgs")
+    void testRefusalPreservedInExtraArgs() {
+        // A refused response has no content, so the reason is the only thing separating it
+        // from a genuinely empty completion.
+        ChatCompletionMessage message =
+                ChatCompletionMessage.builder()
+                        .content(Optional.empty())
+                        .refusal("I cannot help with that")
+                        .build();
+
+        ChatMessage result = OpenAIChatCompletionsUtils.convertFromOpenAIMessage(message);
+
+        assertThat(result.getExtraArgs()).containsEntry("refusal", "I cannot help with that");
+    }
+
+    @Test
+    @DisplayName("No refusal key is added when the provider did not refuse")
+    void testNoRefusalKeyWhenAbsent() {
+        ChatCompletionMessage message =
+                ChatCompletionMessage.builder().content("hello").refusal(Optional.empty()).build();
+
+        ChatMessage result = OpenAIChatCompletionsUtils.convertFromOpenAIMessage(message);
+
+        assertThat(result.getExtraArgs()).doesNotContainKey("refusal");
+    }
+}

--- a/python/flink_agents/integrations/chat_models/openai/openai_utils.py
+++ b/python/flink_agents/integrations/chat_models/openai/openai_utils.py
@@ -196,7 +196,11 @@ def convert_to_openai_message(message: ChatMessage) -> ChatCompletionMessagePara
 def convert_from_openai_message(
     message: ChatCompletionMessage, extra_args: Dict[str, Any]
 ) -> ChatMessage:
-    """Convert an OpenAI message to a chat message."""
+    """Convert an OpenAI message to a chat message.
+
+    A provider refusal is surfaced under extra_args["refusal"], including when
+    the refusal reason is an empty string.
+    """
     tool_calls = []
     if message.tool_calls:
         # Generate internal UUID for each tool call while preserving
@@ -214,6 +218,8 @@ def convert_from_openai_message(
             }
             for tool_call in message.tool_calls
         ]
+    if message.refusal is not None:
+        extra_args = {**extra_args, "refusal": message.refusal}
     return ChatMessage(
         role=MessageRole(message.role),
         content=message.content or "",

--- a/python/flink_agents/integrations/chat_models/openai/tests/test_openai_native_structured_output.py
+++ b/python/flink_agents/integrations/chat_models/openai/tests/test_openai_native_structured_output.py
@@ -47,6 +47,7 @@ def _connection() -> OpenAIChatModelConnection:
     mock_message.role = "assistant"
     mock_message.content = "ok"
     mock_message.tool_calls = None
+    mock_message.refusal = None
     mock_client.chat.completions.create.return_value.choices = [
         MagicMock(message=mock_message)
     ]

--- a/python/flink_agents/integrations/chat_models/openai/tests/test_openai_response_parsing.py
+++ b/python/flink_agents/integrations/chat_models/openai/tests/test_openai_response_parsing.py
@@ -1,0 +1,52 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+import pytest
+from openai.types.chat import ChatCompletionMessage
+
+from flink_agents.integrations.chat_models.openai.openai_utils import (
+    convert_from_openai_message,
+)
+
+
+@pytest.mark.parametrize("refusal", ["I cannot help with that", ""])
+def test_refusal_is_preserved_in_extra_args(refusal: str) -> None:
+    """A provider refusal reaches the caller through extra_args."""
+    # A refused response carries no content, so the reason is the only thing that
+    # distinguishes it from a genuinely empty completion. An empty reason is still
+    # a refusal, which a truthiness guard would silently drop. Callers hand in an
+    # extra_args already holding token metrics, so recording the reason must add to
+    # that dict rather than replace it. The reason belongs in extra_args alone:
+    # folding it into content would make a refusal read as an ordinary answer.
+    message = ChatCompletionMessage(role="assistant", content=None, refusal=refusal)
+
+    result = convert_from_openai_message(message, {"promptTokens": 3})
+
+    assert result.extra_args["refusal"] == refusal
+    assert result.extra_args["promptTokens"] == 3
+    assert result.content == ""
+
+
+def test_no_refusal_key_when_refusal_absent() -> None:
+    """A response that was not refused leaves no refusal key behind."""
+    # extra_args is merged back into the outbound assistant message, so a null
+    # refusal key here would be echoed to the provider on every later request.
+    message = ChatCompletionMessage(role="assistant", content="ok", refusal=None)
+
+    result = convert_from_openai_message(message, {})
+
+    assert "refusal" not in result.extra_args


### PR DESCRIPTION
Linked issue: #936

Addresses case 1 only. Cases 2 and 3 are design questions and are left as follow-ups, as recorded on the issue.

### Purpose of change

Java and Python disagree on what a caller receives when a provider refuses a request. Java treats the refusal as recoverable information and Python discards it, so this is a parity fix with Java as the specification.

On a refusal the provider returns an assistant message with no content and the reason in `refusal`. `OpenAIChatCompletionsUtils.convertFromOpenAIMessage` records it as `extraArgs["refusal"]`. The Python converter never read the field, so the reason was lost and `content` became `""`. A Python caller could not tell a refusal apart from a genuinely empty completion.

The gap predates the native structured-output work, but `strict: true` makes the refusal path materially more reachable, because a model refuses rather than emitting non-conforming JSON.

#### Runtime flow

Unchanged except for one step. A connection calls `chat.completions.create`, builds a local `extra_args` holding `model_name` and token counts when usage is present, and passes it with `response.choices[0].message` to `convert_from_openai_message`. The converter builds the tool-call list, then, when `message.refusal is not None`, rebinds `extra_args` to a new dict carrying the reason before constructing the `ChatMessage`. Pydantic copies that dict during validation, so the write must precede construction to be visible.

Both the OpenAI and the Azure OpenAI connections call this helper, so one change covers both.

#### Key decisions

The guard is `is not None` rather than a truthiness test, so an empty refusal reason is still recorded. Java uses `Optional.ifPresent`, which keeps an empty string, and a truthiness test would have left a new divergence in the function meant to remove one.

There is no `isinstance` check. The inbound Java path has none. Java's `instanceof String` guards the outbound direction, where `extra_args` holds arbitrary caller data, which is a different situation.

The write rebinds rather than mutating the argument. Both callers pass a fresh local dict and pydantic copies it, so this is hygiene and not a guarantee. No test pins it, deliberately.

Java gets tests but no production change. Its behavior had no coverage, so a refactor could have removed it and reopened the gap from the other side.

### Implementation Description

#### Behavioral contracts

1. A refusal reason present on the SDK message appears unchanged at `extra_args["refusal"]` on the returned `ChatMessage`.
2. An empty-string refusal is recorded, not skipped.
3. When the SDK message carries no refusal, no `refusal` key is added.
4. Keys already present in the `extra_args` passed by the caller survive, including the token metrics both connections put there.
5. A refusal leaves `content` as `""`. The reason is never written into `content`.
6. The Java converter's behavior is unchanged.

#### Failure behavior

Nothing in this change raises, falls back, or retries. It adds one conditional dict write with no error path. Invalid configuration does not apply, since the converter takes none.

An error from the provider is unaffected and still propagates out of the Python connection unwrapped, which is case 3 on the linked issue and is deliberately not touched.

A response violating the expected shape is rejected before the converter sees it, since `refusal` is declared `Optional[str]` on the SDK's pydantic model. The converter does no type checking of its own, so a caller bypassing that model and supplying another type would have it stored as-is.

A message lacking the attribute would raise `AttributeError`. The field exists at the floor of the `openai>=1.66.3` pin, so no version guard is used.

### Tests

There was no non-integration coverage of the response-conversion path before this, in either language.

| Contract | Tests |
|---|---|
| 1, refusal preserved | `test_refusal_is_preserved_in_extra_args`, Python. `testRefusalPreservedInExtraArgs`, Java |
| 2, empty refusal preserved | `test_refusal_is_preserved_in_extra_args`, the `""` parameter |
| 3, no key when absent | `test_no_refusal_key_when_refusal_absent`, Python. `testNoRefusalKeyWhenAbsent`, Java |
| 4, caller keys survive | `test_refusal_is_preserved_in_extra_args`, which passes a non-empty `extra_args` and asserts it survives |
| 5, content not overwritten | `test_refusal_is_preserved_in_extra_args` |
| 6, Java unchanged | both Java tests, which lock existing behavior |

Each test was run against a deliberately broken implementation to confirm it fails when the behavior it covers breaks. A truthiness guard is caught only by the empty-string parameter, and replacing the merge with a plain assignment only by the surviving-keys assertion.

One existing fixture in `test_openai_native_structured_output.py` mocked the SDK message with only `role`, `content` and `tool_calls`. It now sets `refusal` too, so it does not hand back an auto-generated attribute.

Java runs 22 tests in the openai integration module, up from 20. The Python unit suite runs 657.

Azure is covered through the shared helper rather than by a test of its own, because every Azure test in the repo is integration-marked.

### API

No signature change, no new class, no new dependency.

`extra_args` is an existing field on `ChatMessage`, and `refusal` is a key Java already writes, so the cross-language contract is unchanged. Python starts honoring it.

For a caller who does nothing differently, one thing changes: on a refused response, `extra_args` now carries an extra key. Responses that were not refused are unaffected and gain no key.

There is one effect beyond the changed files. `convert_to_openai_message` merges `extra_args` into the outbound assistant message, so a `ChatMessage` that carries a refusal and is later sent back to the provider will now include `refusal` in that request. It is a declared field there, so this is valid and matches Java.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`
