### PR TITLE
[dist][runtime] Use Flink-provided Log4j dependencies

### DIFF
--- a/dist/common/pom.xml
+++ b/dist/common/pom.xml
@@ -79,15 +79,6 @@ under the License.
                             <shadeTestJar>false</shadeTestJar>
                             <shadedArtifactAttached>false</shadedArtifactAttached>
                             <filters>
-                                <!-- Exclude signature files -->
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
-                                    </excludes>
-                                </filter>
                                 <!-- Exclude flink-agents own code from common JAR -->
                                 <filter>
                                     <artifact>org.apache.flink:flink-agents-*</artifact>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -135,6 +135,35 @@ under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <artifactSet>
+                        <excludes>
+                            <exclude>org.apache.logging.log4j:*</exclude>
+                            <exclude>org.slf4j:*</exclude>
+                        </excludes>
+                    </artifactSet>
+                    <filters combine.children="append">
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                                <!-- Also remove logging classes and configuration embedded in shaded dependencies. -->
+                                <exclude>org/apache/logging/log4j/**</exclude>
+                                <exclude>org/slf4j/**</exclude>
+                                <exclude>log4j2*.xml</exclude>
+                                <exclude>log4j2*.properties</exclude>
+                                <exclude>log4j2*.json</exclude>
+                                <exclude>log4j2*.yaml</exclude>
+                                <exclude>log4j2*.yml</exclude>
+                                <exclude>META-INF/org/apache/logging/log4j/**</exclude>
+                                <exclude>META-INF/services/org.apache.logging.log4j.*</exclude>
+                                <exclude>META-INF/licenses/LICENSE.slf4j*</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
                 <executions>
                     <execution>
                         <id>shade-flink-agents</id>
@@ -145,16 +174,6 @@ under the License.
                         <configuration>
                             <shadeTestJar>false</shadeTestJar>
                             <shadedArtifactAttached>false</shadedArtifactAttached>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>

--- a/dist/src/main/resources/META-INF/NOTICE
+++ b/dist/src/main/resources/META-INF/NOTICE
@@ -14,9 +14,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.18.2
 - com.fasterxml.jackson.module:jackson-module-kotlin:2.18.2
 - com.fasterxml:classmate:1.7.0
-- org.apache.logging.log4j:log4j-api:2.23.1
-- org.apache.logging.log4j:log4j-core:2.23.1
-- org.apache.logging.log4j:log4j-slf4j-impl:2.23.1
 - org.apache.kafka:kafka-clients:4.0.0
 - org.lz4:lz4-java:1.8.0
 - org.xerial.snappy:snappy-java:1.1.10.5
@@ -145,7 +142,6 @@ This project bundles the following dependencies under the Apache Software Licens
 This project bundles the following dependencies under the MIT license.
 See bundled license files for details.
 
-- slf4j-api:slf4j-api:1.7.36
 - io.github.ollama4j:ollama4j:1.1.5
 - org.jsoup:jsoup:1.21.2
 - com.anthropic:anthropic-java:2.11.1

--- a/e2e-test/flink-agents-end-to-end-tests-integration/pom.xml
+++ b/e2e-test/flink-agents-end-to-end-tests-integration/pom.xml
@@ -158,29 +158,8 @@ under the License.
             <properties>
                 <flink.version>${flink.1.20.version}</flink.version>
                 <flink.agents.dist.artifactId>flink-agents-dist-flink-1.20</flink.agents.dist.artifactId>
+                <flink.log4j2.version>2.24.3</flink.log4j2.version>
             </properties>
-            <dependencies>
-                <!-- Flink 1.20 does not transitively provide log4j-core in test classpath,
-                     needed for Slf4jEventLogger which uses log4j2 core APIs -->
-                <dependency>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                    <version>${log4j2.version}</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-core</artifactId>
-                    <version>${log4j2.version}</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-slf4j-impl</artifactId>
-                    <version>${log4j2.version}</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
         </profile>
 
         <!-- Flink 2.0 Profile -->
@@ -189,6 +168,7 @@ under the License.
             <properties>
                 <flink.version>${flink.2.0.version}</flink.version>
                 <flink.agents.dist.artifactId>flink-agents-dist-flink-2.0</flink.agents.dist.artifactId>
+                <flink.log4j2.version>2.24.3</flink.log4j2.version>
             </properties>
         </profile>
 
@@ -198,6 +178,7 @@ under the License.
             <properties>
                 <flink.version>${flink.2.1.version}</flink.version>
                 <flink.agents.dist.artifactId>flink-agents-dist-flink-2.1</flink.agents.dist.artifactId>
+                <flink.log4j2.version>2.24.3</flink.log4j2.version>
             </properties>
         </profile>
 
@@ -207,6 +188,7 @@ under the License.
             <properties>
                 <flink.version>${flink.2.2.version}</flink.version>
                 <flink.agents.dist.artifactId>flink-agents-dist-flink-2.2</flink.agents.dist.artifactId>
+                <flink.log4j2.version>2.24.3</flink.log4j2.version>
             </properties>
         </profile>
     </profiles>

--- a/e2e-test/pom.xml
+++ b/e2e-test/pom.xml
@@ -28,6 +28,33 @@ under the License.
     <artifactId>flink-agents-e2e-tests</artifactId>
     <packaging>pom</packaging>
     <name>Flink Agents : E2E Tests: </name>
+
+    <properties>
+        <!-- The default E2E runtime is Flink 2.3. Profiles override this when needed. -->
+        <flink.log4j2.version>2.25.3</flink.log4j2.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${flink.log4j2.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${flink.log4j2.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${flink.log4j2.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <modules>
         <module>flink-agents-end-to-end-tests-agent-plan-compatibility</module>
         <module>flink-agents-end-to-end-tests-integration</module>

--- a/plan/pom.xml
+++ b/plan/pom.xml
@@ -85,16 +85,6 @@ under the License.
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
-        </dependency>
     </dependencies>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@ under the License.
         <junit5.version>5.10.1</junit5.version>
         <jackson.version>2.18.2</jackson.version>
         <pemja.version>0.5.7</pemja.version>
-        <log4j2.version>2.23.1</log4j2.version>
+        <log4j2.version>2.24.3</log4j2.version>
         <slf4j.version>1.7.36</slf4j.version>
         <assertj.version>3.27.7</assertj.version>
         <mockito.version>5.14.2</mockito.version>


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #953 

### Purpose of change

The shaded Dist artifacts currently receive Log4j and SLF4J dependencies transitively from Plan, even though the default logging setup of the supported Flink distributions already provides Log4j2 and the SLF4J binding for JobManager and TaskManager processes.

This can place different Log4j API and Core versions on the same runtime classpath and cause linkage errors such as `NoSuchMethodError`.

This PR makes the logging dependency and packaging boundary explicit:

- Keep `slf4j-api` as a normal Plan dependency so standalone Plan tools remain usable, but remove `log4j-core` and `log4j-slf4j-impl` from Plan.
- Keep Runtime's Log4j dependencies as `provided` and align the compile-time Log4j version with 2.24.3, the version used by the oldest supported Flink distributions.
- Exclude Log4j and SLF4J artifacts, classes, service metadata, and `log4j2.*` configuration files from all shaded Dist artifacts.
- Add test-scoped Log4j dependencies for the E2E test JVM and align them with the selected Flink version: 2.24.3 for Flink 1.20 through 2.2 and 2.25.3 for Flink 2.3.
- Update `META-INF/NOTICE` so it no longer lists Log4j or SLF4J as bundled dependencies.

After this change, Flink Agents uses the Log4j2 implementation provided by the default logging setup of the selected supported Flink distribution and no longer packages a second logging stack.

### Tests

- [x] Built all common, full, and thin Dist artifacts for the supported Flink versions.
- [x] Verified that the generated Dist JARs contain no Log4j or SLF4J classes, Log4j service metadata, or `log4j2.*` configuration files.
- [x] Verified that the generated NOTICE files match the updated artifact contents.

Full E2E and clean Flink deployment tests were not run locally.

### API

No public API changes.

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
