### PR TITLE
[infra] Add a Python-Java bridge review guide

### DIFF
--- a/code_review.md
+++ b/code_review.md
@@ -40,7 +40,7 @@ Guides load on demand, so the general passes here stay short.
 | Change type | Focus | Guide |
 |---|---|---|
 | `runtime/` state and recovery | serde and replay type fidelity, real failure-path tests | [review-guides/runtime-state-recovery.md](review-guides/runtime-state-recovery.md) |
-| Python-Java bridge | cross-language parity, type mapping across Pemja | planned |
+| Python-Java bridge | cross-language parity, type mapping across Pemja | [review-guides/python-java-bridge.md](review-guides/python-java-bridge.md) |
 | `api/` contract | API shape, compatibility policy, deprecation | planned |
 | `dist` and dependency | shading, LICENSE and NOTICE, dist registration | planned |
 | docs-only | facts match their source of truth | planned |

--- a/review-guides/python-java-bridge.md
+++ b/review-guides/python-java-bridge.md
@@ -1,0 +1,54 @@
+# Review Guide: Python-Java Bridge
+
+Load this guide when a PR changes code that crosses the Python-Java boundary:
+Pemja entry points, resource or tool wrappers, event and agent-plan
+serialization, or type conversion in either direction. It narrows the full
+passes in `code_review.md` to the ones that matter most for this area; the
+general passes still apply.
+
+## Focused checklist
+
+- When a method lands on a type that exists in both languages, check every
+  wrapper carrying it across, not only the two implementations. A wrapper
+  inheriting the other side's implementation can fail the call instead of
+  crossing it, and one left on the legacy path degrades silently.
+- Settle what an explicitly null declarative argument means. A Java descriptor
+  lookup cannot distinguish an absent argument from one declared null, while
+  Python can, so the same YAML can reach a different conclusion on each side.
+- Keep constants shared by both languages in sync: event type strings, resource
+  types, YAML aliases, flattened-map keys. A new event type or attribute also
+  needs the cross-language snapshots regenerated and committed on both sides.
+- Confirm both legs of a conversion carry the same fields. An argument present
+  on one leg and missing on the other drops data with no error, and the legs
+  usually live in different files.
+- Treat bridge entry-point names as a contract. Python function names called
+  from Java and Java fully-qualified names resolved from Python are string
+  literals, so renaming or moving either breaks only at runtime.
+- Keep values that cross the boundary flattened to primitives, strings, lists,
+  and maps. Returning an arbitrary object in either direction to a call that
+  originated on a non-main interpreter thread can crash the JVM, which is why
+  the existing conversions return flat maps.
+
+## Validation
+
+Run both language lanes. A bridge change verified on one side only is untested.
+
+- Java: `mvn --batch-mode test -pl runtime -am`. The `-am` matters here because
+  the Java halves of the cross-language snapshot tests live in `api` and
+  `plan`, upstream of the module that owns the bridge implementations.
+- Python: from `python/`, run `uv sync --extra test`, install the
+  `apache-flink` release for the Flink version under test (`tools/ut.sh` names
+  the supported versions), then `uv run --no-sync pytest flink_agents/runtime
+  flink_agents/api flink_agents/plan`. PyFlink is not a declared test
+  dependency and the event types import it, so collection fails without it.
+
+Together these run the committed cross-language snapshot tests from both sides.
+Dispatch through a real interpreter is only covered by the cross-language
+end-to-end modules.
+
+## Examples from past reviews
+
+| Case | Pass it exercises | Review |
+|---|---|---|
+| A usage-tracking method reached both setup types but not the wrappers, so each inherited an implementation its connection cannot serve: the Python-backed setup never initializes the Java connection, the Java-backed one holds only a resource name. Calls failed instead of crossing, and the connection wrappers fell back to the legacy call, returning no usage. | Whether every wrapper carrying a call across the boundary was updated, including result conversion and cross-language tests. | [#870](https://github.com/apache/flink-agents/pull/870#discussion_r3592370999) |
+| An explicitly configured null `structured_output_strategy` was normalized to `AUTO` on the Java side, while Python rejected `None` with a validation error. | Comparing the behavior each language derives from the same declarative value. | [#843](https://github.com/apache/flink-agents/pull/843#discussion_r3637512045) |


### PR DESCRIPTION
Linked issue: #894

### Purpose of change

Continues item 2 of #894 by filling the `Python-Java bridge` row that #911 left as `planned`. #911 established the template and noted the remaining change types would follow one small PR each once the shape settled. This is the first of those.

`review-guides/python-java-bridge.md` follows the merged `runtime-state-recovery.md` shape: a focused checklist that narrows the full passes in `code_review.md`, and two examples drawn from real review threads on merged PRs, each linking the specific comment.

It adds one section the first guide does not have, a short `Validation` block naming both language lanes. The bridge is the change type where running one language's tests is most easily mistaken for running the tests, so the guide gives the narrowed Java and Python commands and says what they cover between them.

The checklist is six bullets, matching the sibling. Interpreter close ordering was left out deliberately. It is a real crash source, but the rarest trigger, since only PRs touching open and close reach it. Straightforward to add if you would like it covered.

The other three rows stay `planned` and will follow the same way.

### Tests

Not applicable, documentation only, no logic.

`./tools/check-license.sh` passes with the change. No license header is needed, since `tools/.rat-excludes` already covers `review-guides/`.

Every checklist claim was checked against source rather than written from memory, and both review permalinks were re-fetched with the cited PRs confirmed merged.

The Java command was run. `mvn --batch-mode -pl runtime -am` resolves and runs the upstream module tests. The Python lane was verified by collection rather than by running `uv` itself, and it needed a correction: `uv sync --extra test` on its own is not enough, because `python/flink_agents/api/events/event.py` imports `pyflink.common.Row` at module level while `apache-flink` is declared in neither the `test` extra nor the base dependencies, so collection fails across all three directories without it. The guide points at `tools/ut.sh` for the supported version list rather than naming a version, so it does not drift at the next bump.

### API

No. No code or public API change.

### Documentation

- [x] `doc-included`
