### PR TITLE
[integration][anthropic][python] Keep token usage on non-tool_use responses

### DIFF
--- a/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
@@ -239,6 +239,7 @@ class AnthropicChatModelConnection(BaseChatModelConnection):
             return ChatMessage(
                 role=MessageRole(message.role),
                 content=text,
+                extra_args=extra_args,
             )
 
     @override

--- a/python/flink_agents/integrations/chat_models/anthropic/tests/test_anthropic_response_parsing.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/tests/test_anthropic_response_parsing.py
@@ -94,3 +94,46 @@ def test_plain_text_response() -> None:
         [ChatMessage(role=MessageRole.USER, content="hi")]
     )
     assert response.content == "Hello!"
+
+
+def test_plain_text_response_keeps_token_usage() -> None:
+    # Token usage must survive on non-tool_use responses too: the common
+    # end_turn path previously dropped extra_args entirely, so promptTokens /
+    # completionTokens never reached the token metrics recording.
+    message = Message(
+        id="m",
+        model="claude",
+        role="assistant",
+        type="message",
+        stop_reason="end_turn",
+        content=[TextBlock(type="text", text="Hello!")],
+        usage=Usage(input_tokens=7, output_tokens=3),
+    )
+    response = _connection_returning(message).chat(
+        [ChatMessage(role=MessageRole.USER, content="hi")],
+        model="claude-sonnet-4-5",
+    )
+    assert response.extra_args["model_name"] == "claude-sonnet-4-5"
+    assert response.extra_args["promptTokens"] == 7
+    assert response.extra_args["completionTokens"] == 3
+
+
+def test_tool_use_response_keeps_token_usage() -> None:
+    # Regression guard for the tool_use path, which already carried usage.
+    message = Message(
+        id="m",
+        model="claude",
+        role="assistant",
+        type="message",
+        stop_reason="tool_use",
+        content=[
+            ToolUseBlock(type="tool_use", id="t1", name="add", input={"a": 1, "b": 2})
+        ],
+        usage=Usage(input_tokens=7, output_tokens=3),
+    )
+    response = _connection_returning(message).chat(
+        [ChatMessage(role=MessageRole.USER, content="add 1 and 2")],
+        model="claude-sonnet-4-5",
+    )
+    assert response.extra_args["promptTokens"] == 7
+    assert response.extra_args["completionTokens"] == 3


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #946

### Purpose of change

<!-- What is the purpose of this change? -->

`extra_args` (`model_name` / `promptTokens` / `completionTokens`) is built after every Anthropic API call, but was only attached to the returned `ChatMessage` on the `tool_use` branch. Plain-text responses (`stop_reason == "end_turn"`, the common case) returned without `extra_args`, so `_record_token_metrics` never fired for them: in a ReAct loop only the intermediate tool-calling turns were counted and the final answer's tokens were always lost. All sibling connectors (openai / azure / ollama / tongyi) already pass `extra_args` on every path.

Fix: pass `extra_args=extra_args` in the non-tool_use branch. One line; no behavior change on the tool_use path.

### Tests

<!-- How is this change verified? -->

Two new cases in `test_anthropic_response_parsing.py`: `test_plain_text_response_keeps_token_usage` (regression for the fixed branch) and `test_tool_use_response_keeps_token_usage` (guard for the already-working branch). Both are mock-based with explicit token counts and a `model=` kwarg so the metrics path is actually exercised — the pre-existing `test_plain_text_response` only asserted `content` and never covered this path.

### API

<!-- Does this change touches any public APIs? -->

None.

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->