### PR TITLE
[integration][gemini] Synthesize a tool-call id when the API omits functionCall.id

### DIFF
--- a/integrations/chat-models/gemini/src/main/java/org/apache/flink/agents/integrations/chatmodels/gemini/GeminiChatModelConnection.java
+++ b/integrations/chat-models/gemini/src/main/java/org/apache/flink/agents/integrations/chatmodels/gemini/GeminiChatModelConnection.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -430,7 +431,9 @@ public class GeminiChatModelConnection extends BaseChatModelConnection {
 
         FunctionCall.Builder fcBuilder = FunctionCall.builder().name(functionName).args(argsMap);
         Object originalId = call.get("original_id");
-        if (originalId != null) {
+        // A synthetic id exists only for runtime correlation (the API omitted the native id);
+        // echoing a fabricated id back to Gemini would claim the model produced it.
+        if (originalId != null && !Boolean.TRUE.equals(call.get("synthetic_id"))) {
             fcBuilder.id(originalId.toString());
         }
 
@@ -504,6 +507,17 @@ public class GeminiChatModelConnection extends BaseChatModelConnection {
         if (id != null) {
             toolCall.put("id", id);
             toolCall.put("original_id", id);
+        } else {
+            // The Gemini Developer API frequently omits functionCall.id. Downstream correlation
+            // still needs one: ToolCallAction keys its result maps on `id` (two id-less parallel
+            // calls would otherwise collide on the literal "null") and only propagates
+            // `original_id` as the TOOL message's externalId, which is how the follow-up turn
+            // recovers the function name for Gemini's functionResponse part. Synthesize an id for
+            // the runtime round-trip and mark it so it is never echoed back to the API.
+            String syntheticId = UUID.randomUUID().toString();
+            toolCall.put("id", syntheticId);
+            toolCall.put("original_id", syntheticId);
+            toolCall.put("synthetic_id", Boolean.TRUE);
         }
         toolCall.put("type", "function");
         toolCall.put("function", functionMap);

--- a/integrations/chat-models/gemini/src/test/java/org/apache/flink/agents/integrations/chatmodels/gemini/GeminiChatModelConnectionTest.java
+++ b/integrations/chat-models/gemini/src/test/java/org/apache/flink/agents/integrations/chatmodels/gemini/GeminiChatModelConnectionTest.java
@@ -224,6 +224,71 @@ class GeminiChatModelConnectionTest {
     }
 
     @Test
+    @DisplayName(
+            "convertFunctionCall synthesizes a unique id when the API omits functionCall.id, so"
+                    + " parallel id-less calls cannot collide")
+    void testConvertFunctionCallWithoutIdSynthesizesUniqueIds() {
+        // The Gemini Developer API frequently returns functionCall parts with no id.
+        FunctionCall first = FunctionCall.builder().name("get_weather").args(Map.of()).build();
+        FunctionCall second = FunctionCall.builder().name("get_time").args(Map.of()).build();
+
+        GeminiChatModelConnection conn = connection();
+        Map<String, Object> firstCall = conn.convertFunctionCall(first, null);
+        Map<String, Object> secondCall = conn.convertFunctionCall(second, null);
+
+        assertThat(firstCall.get("id")).isNotNull();
+        assertThat(firstCall.get("original_id")).isEqualTo(firstCall.get("id"));
+        assertThat(firstCall).containsEntry("synthetic_id", Boolean.TRUE);
+        // ToolCallAction keys success/responses/error on `id`; distinct ids are what prevent two
+        // parallel id-less calls from overwriting each other.
+        assertThat(firstCall.get("id")).isNotEqualTo(secondCall.get("id"));
+    }
+
+    @Test
+    @DisplayName("A synthetic id is never echoed back to the Gemini API on replay")
+    void testSyntheticIdNotEchoedToGemini() {
+        FunctionCall fc = FunctionCall.builder().name("get_weather").args(Map.of()).build();
+
+        GeminiChatModelConnection conn = connection();
+        Map<String, Object> toolCall = conn.convertFunctionCall(fc, null);
+        Part part = conn.convertToolCallToPart(toolCall);
+
+        FunctionCall replayed = part.functionCall().orElseThrow();
+        assertThat(replayed.id()).isEmpty();
+        assertThat(replayed.name()).hasValue("get_weather");
+    }
+
+    @Test
+    @DisplayName(
+            "Second turn resolves the function name via the synthetic id (full id-less round"
+                    + " trip)")
+    void testSyntheticIdResolvesFunctionNameOnSecondTurn() {
+        FunctionCall fc = FunctionCall.builder().name("get_weather").args(Map.of()).build();
+
+        GeminiChatModelConnection conn = connection();
+        Map<String, Object> toolCall = conn.convertFunctionCall(fc, null);
+        String syntheticId = (String) toolCall.get("original_id");
+
+        // Assistant turn carrying the id-less tool call, exactly as convertResponse builds it.
+        ChatMessage assistant = ChatMessage.assistant("");
+        assistant.setToolCalls(List.of(toolCall));
+
+        // Runtime contract: ToolCallAction copies `original_id` into the TOOL message's
+        // `externalId`. Before the fix, no id existed, externalId was never set, and this
+        // second-turn conversion threw "Tool message must carry the function name".
+        ChatMessage tool = ChatMessage.tool("sunny, 22C");
+        tool.getExtraArgs().put("externalId", syntheticId);
+
+        Map<String, String> idToName =
+                GeminiChatModelConnection.buildToolCallIdToNameMap(List.of(assistant, tool));
+        Content content = conn.convertToContent(tool, idToName);
+
+        Part part = content.parts().orElseThrow().get(0);
+        assertThat(part.functionResponse()).isPresent();
+        assertThat(part.functionResponse().orElseThrow().name()).hasValue("get_weather");
+    }
+
+    @Test
     @DisplayName("Tool-call round-trip preserves name, args and thoughtSignature")
     void testToolCallRoundTrip() {
         byte[] signature = new byte[] {9, 8, 7};


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #947

### Purpose of change

<!-- What is the purpose of this change? -->

The Gemini Developer API frequently returns `functionCall` parts without an id. `convertFunctionCall` previously emitted neither `id` nor `original_id` in that case, which broke the runtime round-trip twice:

1. `ToolCallAction` reads the id via `String.valueOf(toolCall.get("id"))`, so every id-less call keyed the `success`/`responses`/`error` maps on the literal string `"null"` — two parallel id-less calls collided and only the last result survived.
2. `original_id` is what `ToolCallAction` propagates as the TOOL message's `externalId`; without it the follow-up turn cannot resolve the function name for Gemini's `functionResponse` part, and `resolveToolFunctionName` throws `"Tool message must carry the function name"` — turn 1 executes the tool, turn 2 crashes.

Fix: when the native id is absent, synthesize a UUID and set both `id` and `original_id`, plus a `synthetic_id` marker. `convertToolCallToPart` skips echoing the id back to Gemini when the marker is present, so on-the-wire behavior for id-less calls is unchanged — the synthetic id exists purely for runtime correlation. Calls that carry a native id are untouched.

### Tests

<!-- How is this change verified? -->

Three new cases in `GeminiChatModelConnectionTest`: id-less calls get unique synthetic ids (`id == original_id`, `synthetic_id` set, two calls never collide); a synthetic id is never echoed back to the API (`Part.functionCall().id()` stays empty); and the full id-less round trip — assistant turn → `buildToolCallIdToNameMap` → TOOL turn with `externalId` — resolves the function name (this exact flow threw before the fix). Existing 16 tests pass unchanged (20/20 total).

### API

<!-- Does this change touches any public APIs? -->

None (`synthetic_id` is an internal marker key inside the tool-call map).

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->