### PR TITLE
[infra] Add an api/ contract review guide

### DIFF
--- a/code_review.md
+++ b/code_review.md
@@ -41,7 +41,7 @@ Guides load on demand, so the general passes here stay short.
 |---|---|---|
 | `runtime/` state and recovery | serde and replay type fidelity, real failure-path tests | [review-guides/runtime-state-recovery.md](review-guides/runtime-state-recovery.md) |
 | Python-Java bridge | cross-language parity, type mapping across Pemja | [review-guides/python-java-bridge.md](review-guides/python-java-bridge.md) |
-| `api/` contract | API shape, compatibility policy, deprecation | planned |
+| `api/` contract | API shape, compatibility policy, deprecation | [review-guides/api-contract.md](review-guides/api-contract.md) |
 | `dist` and dependency | shading, LICENSE and NOTICE, dist registration | planned |
 | docs-only | facts match their source of truth | planned |
 

--- a/review-guides/api-contract.md
+++ b/review-guides/api-contract.md
@@ -25,12 +25,17 @@ still apply.
   count on the Python side.
 - Treat the public base classes users extend as source-compatibility boundaries.
   A new abstract method breaks every implementation, including ones outside this
-  repo, while a defaulted overload plus a capability probe does not. The Python
+  repo, while a defaulted overload plus a capability probe does not. Compiling
+  is not the same as honoring the new argument: a default that forwards to the
+  older signature drops it in silence, so check that the default rejects what it
+  cannot honor, and that an override gating it behind a capability probe leaves
+  a fallback in force or fails, rather than silently doing neither. The Python
   guard that catches a mis-declared override only sees connections whose module
   is imported by hand at the top of the test.
 - Check that a removal is complete rather than asking whether to deprecate.
   There is no deprecation mechanism in this repo, so an API is either kept or
-  deleted outright.
+  deleted outright. Under the beta policy, prefer deleting unless a concrete
+  compatibility obligation requires keeping it.
 - Name the docs the change invalidates. Config keys, YAML aliases, and whole
   code samples are restated by hand across the doc site, and nothing in pull
   request CI builds or checks them, so a doc that contradicts the code ships
@@ -43,11 +48,12 @@ Run both lanes. A change verified in one language only is untested in the other.
 
 - Java, from the repo root: `mvn --batch-mode test -pl api`.
 - Python, from `python/`: `uv sync --extra test`, then `uv pip install
-  apache-flink`, then `uv run --no-sync pytest flink_agents/api
+  apache-flink~=2.3.0`, then `uv run --no-sync pytest flink_agents/api
   flink_agents/plan`. PyFlink is imported at module scope by the event types but
   is declared in neither the base dependencies nor the `test` extra, so
   collection fails without it. Install it after the sync, not before, because
-  `uv sync` removes it.
+  `uv sync` removes it. The pin matches the root `pom.xml`'s `flink.version`, so
+  both lanes run the same Flink.
 - Resource-name constants, from `python/`: `uv run --no-sync python
   ../e2e-test/test-scripts/check_resource_consistency.py`. This one is a script
   rather than a test, so neither Maven nor pytest reaches it.

--- a/review-guides/api-contract.md
+++ b/review-guides/api-contract.md
@@ -48,12 +48,14 @@ Run both lanes. A change verified in one language only is untested in the other.
 
 - Java, from the repo root: `mvn --batch-mode test -pl api`.
 - Python, from `python/`: `uv sync --extra test`, then `uv pip install
-  apache-flink~=2.3.0`, then `uv run --no-sync pytest flink_agents/api
-  flink_agents/plan`. PyFlink is imported at module scope by the event types but
-  is declared in neither the base dependencies nor the `test` extra, so
-  collection fails without it. Install it after the sync, not before, because
-  `uv sync` removes it. The pin matches the root `pom.xml`'s `flink.version`, so
-  both lanes run the same Flink.
+  "apache-flink==$(mvn -q -N --batch-mode -f ../pom.xml help:evaluate
+  -Dexpression=flink.version -DforceStdout)"`, then `uv run --no-sync pytest
+  flink_agents/api flink_agents/plan`. PyFlink is imported at module scope by
+  the event types but is declared in neither the base dependencies nor the
+  `test` extra, so collection fails without it. Install it after the sync, not
+  before, because `uv sync` removes it. Reading the version out of the root
+  `pom.xml` rather than typing it runs this lane on the same Flink the Java
+  bullet resolves, and survives a version bump.
 - Resource-name constants, from `python/`: `uv run --no-sync python
   ../e2e-test/test-scripts/check_resource_consistency.py`. This one is a script
   rather than a test, so neither Maven nor pytest reaches it.

--- a/review-guides/api-contract.md
+++ b/review-guides/api-contract.md
@@ -1,0 +1,72 @@
+# Review Guide: api/ Contract
+
+Load this guide when a PR changes a public API surface: a signature or type in
+`api/`, a new resource implementation, a config option, a YAML-visible name, or
+anything a user's agent code calls. It narrows the full passes in
+`code_review.md` to the ones that matter most for this area; the general passes
+still apply.
+
+## Focused checklist
+
+- When a PR adds a public resource implementation, check that its short YAML
+  alias landed in both alias tables and the doc table. Nothing fails when all
+  three are skipped: each loader passes an unrecognized name through unchanged,
+  so the class stays reachable by fully-qualified name and no test notices the
+  omission.
+- Regenerate the cross-language snapshots on both sides in the same change when
+  a field on a built-in event or on the agent plan is added, renamed, or
+  retyped. Each language pins its own serialization against its own committed
+  file, so refreshing one side leaves the other side's stability test failing. A
+  field added in only one language is caught by nothing, because the payload is
+  a free-form attribute map on the read side.
+- Check that a new public config option landed on both languages' sides. A
+  Java-only option passes every fast CI job: the bidirectional parity check runs
+  only in the slow cross-language lane, and the in-tree guard is a hardcoded
+  count on the Python side.
+- Treat the public base classes users extend as source-compatibility boundaries.
+  A new abstract method breaks every implementation, including ones outside this
+  repo, while a defaulted overload plus a capability probe does not. The Python
+  guard that catches a mis-declared override only sees connections whose module
+  is imported by hand at the top of the test.
+- Check that a removal is complete rather than asking whether to deprecate.
+  There is no deprecation mechanism in this repo, so an API is either kept or
+  deleted outright.
+- Name the docs the change invalidates. Config keys, YAML aliases, and whole
+  code samples are restated by hand across the doc site, and nothing in pull
+  request CI builds or checks them, so a doc that contradicts the code ships
+  green. Java code under `examples/` is in the Maven reactor and breaks loudly,
+  but nothing imports or runs the Python examples.
+
+## Validation
+
+Run both lanes. A change verified in one language only is untested in the other.
+
+- Java, from the repo root: `mvn --batch-mode test -pl api`.
+- Python, from `python/`: `uv sync --extra test`, then `uv pip install
+  apache-flink`, then `uv run --no-sync pytest flink_agents/api
+  flink_agents/plan`. PyFlink is imported at module scope by the event types but
+  is declared in neither the base dependencies nor the `test` extra, so
+  collection fails without it. Install it after the sync, not before, because
+  `uv sync` removes it.
+- Resource-name constants, from `python/`: `uv run --no-sync python
+  ../e2e-test/test-scripts/check_resource_consistency.py`. This one is a script
+  rather than a test, so neither Maven nor pytest reaches it.
+
+Two more when the change reaches further:
+
+- Agent-plan wire format: `mvn --batch-mode test -pl plan -am
+  -Dtest=AgentPlanCrossLanguageTest -Dsurefire.failIfNoSpecifiedTests=false`.
+  The `-am` is what puts your edited `api` classes on the classpath in place of
+  the last installed jar.
+- A new or changed config option: `mvn --batch-mode package -pl api -DskipTests`,
+  then from `python/`, `uv run --no-sync python
+  flink_agents/plan/tests/compatibility/check_java_python_config_options_parity.py`.
+  It loads the Java class out of `api/target/`, so an absent or stale jar is
+  exactly what it reads.
+
+## Examples from past reviews
+
+| Case | Pass it exercises | Review |
+|---|---|---|
+| A new public reconciler contract gave a recovering call two ways out, both of them throws: a terminal business exception, or a fallback exception that re-runs the call. The review asked what a partially succeeded call is supposed to do, and proposed reducing the contract to returning a result or throwing. | Whether a new public contract's semantics fit its users, not only the implementation behind it. | [#600](https://github.com/apache/flink-agents/pull/600#discussion_r3027614878) |
+| Renaming a persisted plan key left a deserializer fallback so plans written under the old name still loaded. The review argued the fallback was not worth keeping, since API compatibility is not guaranteed in the 0.x series and the formal stability commitment starts at 1.0. | Whether a compatibility path is justified under the beta policy. | [#756](https://github.com/apache/flink-agents/pull/756#discussion_r3392902728) |

--- a/review-guides/python-java-bridge.md
+++ b/review-guides/python-java-bridge.md
@@ -36,11 +36,12 @@ Run both language lanes. A bridge change verified on one side only is untested.
 - Java: `mvn --batch-mode test -pl runtime -am`. The `-am` matters here because
   the Java halves of the cross-language snapshot tests live in `api` and
   `plan`, upstream of the module that owns the bridge implementations.
-- Python: from `python/`, run `uv sync --extra test`, install the
-  `apache-flink` release for the Flink version under test (`tools/ut.sh` names
-  the supported versions), then `uv run --no-sync pytest flink_agents/runtime
-  flink_agents/api flink_agents/plan`. PyFlink is not a declared test
-  dependency and the event types import it, so collection fails without it.
+- Python: from `python/`, run `uv sync --extra test`, then `uv pip install
+  "apache-flink==$(mvn -q -N --batch-mode -f ../pom.xml help:evaluate
+  -Dexpression=flink.version -DforceStdout)"`, then `uv run --no-sync pytest
+  flink_agents/runtime flink_agents/api flink_agents/plan`. PyFlink is not a
+  declared test dependency and the event types import it, so collection fails
+  without it.
 
 Together these run the committed cross-language snapshot tests from both sides.
 Dispatch through a real interpreter is only covered by the cross-language


### PR DESCRIPTION
Linked issue: #894

### Purpose of change

Continues item 2 of #894 by filling the `api/` contract row that #911 left as `planned`. This is the third guide, after the merged `runtime-state-recovery.md` and `python-java-bridge.md`.

`review-guides/api-contract.md` follows the same shape as both: a focused checklist that narrows the full passes in `code_review.md`, and two examples drawn from real review threads on merged PRs, each linking the specific comment.

The six bullets are ordered by how often a reviewer will hit one, and each names a failure that is silent in this repo rather than one the build catches. A new integration whose YAML alias was never added still resolves, because both loaders pass an unrecognized name through unchanged. A config option added on the Java side only passes every fast CI job, since the bidirectional parity check runs solely in the cross-language lane. A doc that contradicts the code ships green, because nothing in pull request CI builds the doc site.

One bullet is worth calling out because it removes work rather than adding it. The row's Focus text names deprecation, but there is no deprecation mechanism in this repo, so the question a reviewer should be asking is whether a removal is complete, not whether something should be deprecated first. I left the Focus cell alone and addressed it in the guide instead.

It carries a `Validation` block, like `python-java-bridge.md` and unlike the merged `runtime-state-recovery.md`. Two of its five commands are the reason it is there: `ConfigOption` parity and `ResourceName` parity are standalone scripts rather than tests, so neither `mvn test -pl api` nor `pytest flink_agents/api` reaches them, and today they run only behind the Docker-backed e2e lane. Both finish in well under a second when invoked directly.

That block is why this guide is 80 lines against the merged siblings' 31 and 55. The checklist itself is the same six bullets; the difference is five commands instead of two.

The last commit also touches `python-java-bridge.md`, which is already merged. Both guides published a `Validation` block whose Java command resolves `flink.version` from the root `pom.xml` while its Python command named a Flink version some other way, so the two lanes in one block could run different Flinks. Both Python lanes now read the property at run time instead. Fixing only this guide would leave two files in one directory giving contradictory guidance on the same question.

The remaining two rows, `dist` and docs-only, stay `planned` and will follow the same way.

### Tests

Not applicable, documentation only, no logic.

`./tools/check-license.sh` passes. No license header is needed, since `tools/.rat-excludes` already covers `review-guides/` and `.licenserc.yaml` ignores `**/*.md`.

Every checklist claim was checked against source rather than written from memory, and several drafts were discarded when the source disagreed. The claim about cross-language snapshots was verified by experiment rather than by reading: adding a field to a built-in event on both sides and regenerating only the Java snapshots fails exactly one test, the Python side's own stability test, while its cross-read counterpart still passes. Adding the field on the Java side only and regenerating fails nothing at all, across 292 Java and 450 Python tests. Both of those outcomes are what the bullet now says.

All published commands were executed. Flags that made no difference were removed rather than left in for safety, including `-Dspotless.skip=true`, since spotless runs and passes and skipping it would hide a real CI failure. The two that remain were each confirmed load-bearing.

Both guides install PyFlink by reading `flink.version` out of the root `pom.xml` rather than naming a version, so each block's two lanes share one source of truth. The derivation returns `2.3.0`, and `dependency:tree` on `api` and on `runtime` puts the Flink dependencies that carry `flink.version` at that same `2.3.0`, so both lanes demonstrably run the same Flink. `pytest flink_agents/api flink_agents/plan` reports 450 passed and 11 skipped; the bridge guide's wider selection, `pytest flink_agents/runtime flink_agents/api flink_agents/plan`, reports 614 passed and 11 skipped; `mvn --batch-mode test -pl runtime -am` is BUILD SUCCESS across 919 tests. The read was also exercised on a cold local Maven repository, where it still prints only the version, and against a copy of the POM carrying a different value, which the command follows.

Both review permalinks were re-fetched and both cited PRs re-confirmed merged. The relative link was checked by hand, since no workflow in this repo validates markdown or checks links.

### API

No. No code or public API change.

### Documentation

- [ ] `doc-needed`
- [ ] `doc-not-needed`
- [x] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

Generated-by: Claude Code 2.1.228 (Claude Opus 5)
