### PR TITLE
[api][yaml] Add aliases for six unaliased resource implementations

### DIFF
--- a/api/src/main/java/org/apache/flink/agents/api/yaml/Aliases.java
+++ b/api/src/main/java/org/apache/flink/agents/api/yaml/Aliases.java
@@ -86,6 +86,8 @@ public final class Aliases {
                 "openai_completions", ResourceName.ChatModel.OPENAI_COMPLETIONS_CONNECTION);
         chatConnJava.put("openai_responses", ResourceName.ChatModel.OPENAI_RESPONSES_CONNECTION);
         chatConnJava.put("anthropic", ResourceName.ChatModel.ANTHROPIC_CONNECTION);
+        chatConnJava.put("gemini", ResourceName.ChatModel.GEMINI_CONNECTION);
+        chatConnJava.put("azure_openai", ResourceName.ChatModel.AZURE_OPENAI_CONNECTION);
         chatConnJava.put("azure", ResourceName.ChatModel.AZURE_CONNECTION);
         chatConnJava.put("bedrock", ResourceName.ChatModel.BEDROCK_CONNECTION);
         Map<String, String> chatConnPython = new HashMap<>();
@@ -102,6 +104,8 @@ public final class Aliases {
         chatJava.put("openai_completions", ResourceName.ChatModel.OPENAI_COMPLETIONS_SETUP);
         chatJava.put("openai_responses", ResourceName.ChatModel.OPENAI_RESPONSES_SETUP);
         chatJava.put("anthropic", ResourceName.ChatModel.ANTHROPIC_SETUP);
+        chatJava.put("gemini", ResourceName.ChatModel.GEMINI_SETUP);
+        chatJava.put("azure_openai", ResourceName.ChatModel.AZURE_OPENAI_SETUP);
         chatJava.put("azure", ResourceName.ChatModel.AZURE_SETUP);
         chatJava.put("bedrock", ResourceName.ChatModel.BEDROCK_SETUP);
         Map<String, String> chatPython = new HashMap<>();
@@ -137,8 +141,12 @@ public final class Aliases {
         // VECTOR_STORE
         Map<String, String> vsJava = new HashMap<>();
         vsJava.put("elasticsearch", ResourceName.VectorStore.ELASTICSEARCH_VECTOR_STORE);
+        vsJava.put("opensearch", ResourceName.VectorStore.OPENSEARCH_VECTOR_STORE);
+        vsJava.put("s3_vectors", ResourceName.VectorStore.S3_VECTORS_VECTOR_STORE);
+        vsJava.put("milvus", ResourceName.VectorStore.MILVUS_VECTOR_STORE);
         Map<String, String> vsPython = new HashMap<>();
         vsPython.put("chroma", ResourceName.VectorStore.Python.CHROMA_VECTOR_STORE);
+        vsPython.put("mem0", ResourceName.VectorStore.Python.MEM0_VECTOR_STORE);
         ca.put(ResourceType.VECTOR_STORE, buildLangBuckets(vsJava, vsPython));
 
         CLAZZ_ALIASES = Collections.unmodifiableMap(ca);

--- a/api/src/test/java/org/apache/flink/agents/api/yaml/AliasesTest.java
+++ b/api/src/test/java/org/apache/flink/agents/api/yaml/AliasesTest.java
@@ -60,6 +60,37 @@ class AliasesTest {
     }
 
     @Test
+    void clazzAliasCoversChatModelJavaGeminiAndAzureOpenAI() {
+        String geminiConn =
+                Aliases.resolveClazz("gemini", ResourceType.CHAT_MODEL_CONNECTION, Language.JAVA);
+        assertThat(geminiConn).isEqualTo(ResourceName.ChatModel.GEMINI_CONNECTION);
+        String geminiSetup =
+                Aliases.resolveClazz("gemini", ResourceType.CHAT_MODEL, Language.JAVA);
+        assertThat(geminiSetup).isEqualTo(ResourceName.ChatModel.GEMINI_SETUP);
+        String azureOpenAIConn =
+                Aliases.resolveClazz(
+                        "azure_openai", ResourceType.CHAT_MODEL_CONNECTION, Language.JAVA);
+        assertThat(azureOpenAIConn).isEqualTo(ResourceName.ChatModel.AZURE_OPENAI_CONNECTION);
+        String azureOpenAISetup =
+                Aliases.resolveClazz("azure_openai", ResourceType.CHAT_MODEL, Language.JAVA);
+        assertThat(azureOpenAISetup).isEqualTo(ResourceName.ChatModel.AZURE_OPENAI_SETUP);
+    }
+
+    @Test
+    void clazzAliasCoversVectorStoreJavaAndPython() {
+        String opensearch =
+                Aliases.resolveClazz("opensearch", ResourceType.VECTOR_STORE, Language.JAVA);
+        assertThat(opensearch).isEqualTo(ResourceName.VectorStore.OPENSEARCH_VECTOR_STORE);
+        String s3Vectors =
+                Aliases.resolveClazz("s3_vectors", ResourceType.VECTOR_STORE, Language.JAVA);
+        assertThat(s3Vectors).isEqualTo(ResourceName.VectorStore.S3_VECTORS_VECTOR_STORE);
+        String milvus = Aliases.resolveClazz("milvus", ResourceType.VECTOR_STORE, Language.JAVA);
+        assertThat(milvus).isEqualTo(ResourceName.VectorStore.MILVUS_VECTOR_STORE);
+        String mem0 = Aliases.resolveClazz("mem0", ResourceType.VECTOR_STORE, Language.PYTHON);
+        assertThat(mem0).isEqualTo(ResourceName.VectorStore.Python.MEM0_VECTOR_STORE);
+    }
+
+    @Test
     void clazzAliasMissPassesThrough() {
         String fqn =
                 Aliases.resolveClazz(

--- a/api/src/test/java/org/apache/flink/agents/api/yaml/AliasesTest.java
+++ b/api/src/test/java/org/apache/flink/agents/api/yaml/AliasesTest.java
@@ -64,8 +64,7 @@ class AliasesTest {
         String geminiConn =
                 Aliases.resolveClazz("gemini", ResourceType.CHAT_MODEL_CONNECTION, Language.JAVA);
         assertThat(geminiConn).isEqualTo(ResourceName.ChatModel.GEMINI_CONNECTION);
-        String geminiSetup =
-                Aliases.resolveClazz("gemini", ResourceType.CHAT_MODEL, Language.JAVA);
+        String geminiSetup = Aliases.resolveClazz("gemini", ResourceType.CHAT_MODEL, Language.JAVA);
         assertThat(geminiSetup).isEqualTo(ResourceName.ChatModel.GEMINI_SETUP);
         String azureOpenAIConn =
                 Aliases.resolveClazz(

--- a/docs/content/docs/development/yaml.md
+++ b/docs/content/docs/development/yaml.md
@@ -528,7 +528,8 @@ Common chat-model aliases:
 | `openai_completions` | —                           | OpenAI Completions (Java)   |
 | `openai_responses`   | —                           | OpenAI Responses (Java)     |
 | `anthropic`          | Anthropic                   | Anthropic                   |
-| `azure_openai`       | Azure OpenAI (Python)       | —                           |
+| `gemini`             | —                           | Gemini (Java)               |
+| `azure_openai`       | Azure OpenAI (Python)       | Azure OpenAI (Java)         |
 | `azure`              | —                           | Azure AI (Java)             |
 | `bedrock`            | —                           | Bedrock (Java)              |
 | `tongyi`             | Tongyi (Python)             | —                           |
@@ -544,10 +545,14 @@ Embedding-model aliases (apply to both `embedding_model_connections` and `embedd
 
 Vector-store aliases:
 
-| Alias           | `type: python` | `type: java`   |
-| --------------- | -------------- | -------------- |
-| `chroma`        | Chroma         | —              |
-| `elasticsearch` | —              | Elasticsearch  |
+| Alias           | `type: python` | `type: java`    |
+| --------------- | -------------- | --------------- |
+| `chroma`        | Chroma         | —               |
+| `mem0`          | Mem0           | —               |
+| `elasticsearch` | —              | Elasticsearch   |
+| `opensearch`    | —              | OpenSearch      |
+| `s3_vectors`    | —              | S3 Vectors      |
+| `milvus`        | —              | Milvus          |
 
 The full alias tables live in `flink_agents.api.yaml.aliases` (Python) and `org.apache.flink.agents.api.yaml.Aliases` (Java).
 

--- a/python/flink_agents/api/yaml/aliases.py
+++ b/python/flink_agents/api/yaml/aliases.py
@@ -72,6 +72,8 @@ CLAZZ_ALIASES: Dict[ResourceType, Dict[str, Dict[str, str]]] = {
             "openai_completions": ResourceName.ChatModel.Java.OPENAI_COMPLETIONS_CONNECTION,
             "openai_responses": ResourceName.ChatModel.Java.OPENAI_RESPONSES_CONNECTION,
             "anthropic": ResourceName.ChatModel.Java.ANTHROPIC_CONNECTION,
+            "gemini": ResourceName.ChatModel.Java.GEMINI_CONNECTION,
+            "azure_openai": ResourceName.ChatModel.Java.AZURE_OPENAI_CONNECTION,
             "azure": ResourceName.ChatModel.Java.AZURE_CONNECTION,
             "bedrock": ResourceName.ChatModel.Java.BEDROCK_CONNECTION,
         },
@@ -89,6 +91,8 @@ CLAZZ_ALIASES: Dict[ResourceType, Dict[str, Dict[str, str]]] = {
             "openai_completions": ResourceName.ChatModel.Java.OPENAI_COMPLETIONS_SETUP,
             "openai_responses": ResourceName.ChatModel.Java.OPENAI_RESPONSES_SETUP,
             "anthropic": ResourceName.ChatModel.Java.ANTHROPIC_SETUP,
+            "gemini": ResourceName.ChatModel.Java.GEMINI_SETUP,
+            "azure_openai": ResourceName.ChatModel.Java.AZURE_OPENAI_SETUP,
             "azure": ResourceName.ChatModel.Java.AZURE_SETUP,
             "bedrock": ResourceName.ChatModel.Java.BEDROCK_SETUP,
         },
@@ -118,9 +122,13 @@ CLAZZ_ALIASES: Dict[ResourceType, Dict[str, Dict[str, str]]] = {
     ResourceType.VECTOR_STORE: {
         "python": {
             "chroma": ResourceName.VectorStore.CHROMA_VECTOR_STORE,
+            "mem0": ResourceName.VectorStore.MEM0_VECTOR_STORE,
         },
         "java": {
             "elasticsearch": ResourceName.VectorStore.Java.ELASTICSEARCH_VECTOR_STORE,
+            "opensearch": ResourceName.VectorStore.Java.OPENSEARCH_VECTOR_STORE,
+            "s3_vectors": ResourceName.VectorStore.Java.S3_VECTORS_VECTOR_STORE,
+            "milvus": ResourceName.VectorStore.Java.MILVUS_VECTOR_STORE,
         },
     },
 }

--- a/python/flink_agents/api/yaml/tests/test_aliases.py
+++ b/python/flink_agents/api/yaml/tests/test_aliases.py
@@ -134,12 +134,17 @@ def test_resolve_clazz_covers_chat_model_java_gemini_and_azure_openai() -> None:
     assert resolve_clazz("gemini", ResourceType.CHAT_MODEL, "java").endswith(
         "GeminiChatModelSetup"
     )
-    assert resolve_clazz(
+    # `azure_openai` is the only alias whose Java/Python simple names collide
+    # (AzureOpenAIChatModelConnection); pin the package so a Java entry that lost
+    # its `.Java` suffix and resolved to the Python class would fail here.
+    azure_conn = resolve_clazz(
         "azure_openai", ResourceType.CHAT_MODEL_CONNECTION, "java"
-    ).endswith("AzureOpenAIChatModelConnection")
-    assert resolve_clazz("azure_openai", ResourceType.CHAT_MODEL, "java").endswith(
-        "AzureOpenAIChatModelSetup"
     )
+    assert azure_conn.startswith("org.apache.flink.agents")
+    assert azure_conn.endswith("AzureOpenAIChatModelConnection")
+    azure_setup = resolve_clazz("azure_openai", ResourceType.CHAT_MODEL, "java")
+    assert azure_setup.startswith("org.apache.flink.agents")
+    assert azure_setup.endswith("AzureOpenAIChatModelSetup")
 
 
 def test_resolve_clazz_covers_vector_store_java_and_python() -> None:

--- a/python/flink_agents/api/yaml/tests/test_aliases.py
+++ b/python/flink_agents/api/yaml/tests/test_aliases.py
@@ -127,6 +127,36 @@ def test_resolve_clazz_default_language_is_python() -> None:
     assert default == explicit
 
 
+def test_resolve_clazz_covers_chat_model_java_gemini_and_azure_openai() -> None:
+    assert resolve_clazz("gemini", ResourceType.CHAT_MODEL_CONNECTION, "java").endswith(
+        "GeminiChatModelConnection"
+    )
+    assert resolve_clazz("gemini", ResourceType.CHAT_MODEL, "java").endswith(
+        "GeminiChatModelSetup"
+    )
+    assert resolve_clazz(
+        "azure_openai", ResourceType.CHAT_MODEL_CONNECTION, "java"
+    ).endswith("AzureOpenAIChatModelConnection")
+    assert resolve_clazz("azure_openai", ResourceType.CHAT_MODEL, "java").endswith(
+        "AzureOpenAIChatModelSetup"
+    )
+
+
+def test_resolve_clazz_covers_vector_store_java_and_python() -> None:
+    assert resolve_clazz("opensearch", ResourceType.VECTOR_STORE, "java").endswith(
+        "OpenSearchVectorStore"
+    )
+    assert resolve_clazz("s3_vectors", ResourceType.VECTOR_STORE, "java").endswith(
+        "S3VectorsVectorStore"
+    )
+    assert resolve_clazz("milvus", ResourceType.VECTOR_STORE, "java").endswith(
+        "MilvusVectorStore"
+    )
+    assert resolve_clazz("mem0", ResourceType.VECTOR_STORE, "python").endswith(
+        "Mem0VectorStore"
+    )
+
+
 def test_java_wrapper_clazz_table_covers_supported_types() -> None:
     # The Python-side wrappers must exist for every cross-language type
     expected = {


### PR DESCRIPTION
Linked issue: #958

### Purpose of change

The YAML loader resolves short `clazz:` aliases through three hand-maintained copies of the same alias table (Java `Aliases.java`, Python `aliases.py`, docs `yaml.md`). Six resource implementations already have a `ResourceName` constant but **no alias entry** in any of the three tables, so users must reach them by fully-qualified class path. Per item 1 of #958, this adds the missing entries across all three tables, mirroring the shape of existing entries (e.g. the Bedrock aliases added in #812).

| Alias | Resource type | Language | Implementation |
| --- | --- | --- | --- |
| `gemini` | chat model connection + setup | java | Gemini |
| `azure_openai` | chat model connection + setup | java | Azure OpenAI |
| `opensearch` | vector store | java | OpenSearch |
| `s3_vectors` | vector store | java | S3 Vectors |
| `milvus` | vector store | java | Milvus |
| `mem0` | vector store | python | Mem0 |

All additions are **purely additive**. Java/Python/API-YAML alignment is preserved (the same six entries land in the Java table, the Python table, and the docs table).

Scope: **item 1 of #958 only**. **Item 2** — the `azure` alias resolving to the Azure AI Inference connection (`AzureAIChatModelConnection`) while `yaml.md` documents it as "Azure OpenAI (Java)" — is a behavior change for users who already have `clazz: azure` in their YAML and is intentionally left for a separate PR, as the issue suggests. The existing `azure` alias and its docs row are untouched here. Adding `azure_openai` as a *new* Java alias is independent of that decision and gives the Azure OpenAI Java connection a reachable short name either way.

Open question from the issue: *should any of these six be deliberately unaliased?* I defaulted to aliasing all six, since an alias is an optional short name (fully-qualified `clazz:` still works) and adding one is reversible. Happy to drop any a maintainer feels should stay first-class-only.

### Tests

- `python/flink_agents/api/yaml/tests/test_aliases.py`: added two cases asserting the six new aliases resolve to the expected FQNs. For `azure_openai` — the only alias whose Java/Python simple names collide (`AzureOpenAIChatModelConnection`) — the assertions pin the package prefix (`startswith("org.apache.flink.agents")`) in addition to the simple name, so a Java entry that lost its `.Java` suffix and resolved to the Python class would fail. Full file passes locally: `13 passed`.
- `api/src/test/java/org/apache/flink/agents/api/yaml/AliasesTest.java`: added two parallel cases mirroring the existing `clazzAliasJavaBucket` style.
- `ruff check` clean on the changed Python file.

Java build was not run locally (sparse checkout of a large repo; host JDK is 8 vs the project Java 11 target). The change is mechanical — each new entry mirrors the immediately adjacent existing `put`/dict lines — and the referenced `ResourceName` constants all exist at `main`. CI will confirm.

### API

No public API signature changes. Aliases are optional short names; fully-qualified `clazz:` values keep passing through unchanged.

### Documentation

- [x] `doc-included`

`docs/content/docs/development/yaml.md` is updated in this PR: the `azure_openai` row gains a `type: java` column entry, and `mem0` / `opensearch` / `s3_vectors` / `milvus` rows are added to the vector-store alias table.

Part of #958 (item 1).

Generated-by: Claude Code (Anthropic) — used to author this patch and PR description; reviewed and submitted by a human contributor.
