### PR TITLE
[docs] Correct the documented provider for the azure YAML alias

### DIFF
--- a/docs/content/docs/development/yaml.md
+++ b/docs/content/docs/development/yaml.md
@@ -529,7 +529,7 @@ Common chat-model aliases:
 | `openai_responses`   | —                           | OpenAI Responses (Java)     |
 | `anthropic`          | Anthropic                   | Anthropic                   |
 | `azure_openai`       | Azure OpenAI (Python)       | —                           |
-| `azure`              | —                           | Azure OpenAI (Java)         |
+| `azure`              | —                           | Azure AI (Java)             |
 | `bedrock`            | —                           | Bedrock (Java)              |
 | `tongyi`             | Tongyi (Python)             | —                           |
 


### PR DESCRIPTION
Linked issue: #958

### Purpose of change

The `clazz:` alias table in `yaml.md` lists the java-side `azure` alias as resolving to Azure OpenAI:

| Alias | `type: python` | `type: java` |
| --- | --- | --- |
| `azure` | — | Azure OpenAI (Java) |

The code resolves it elsewhere. `Aliases.java:89`:

```java
chatConnJava.put("azure", ResourceName.ChatModel.AZURE_CONNECTION);
```

and `AZURE_CONNECTION` is the Azure AI Inference connection (`ResourceName.java:57-58`):

```java
public static final String AZURE_CONNECTION =
        "org.apache.flink.agents.integrations.chatmodels.azureai.AzureAIChatModelConnection";
```

These are two different integrations against two different services. `AzureAIChatModelConnection` builds on `com.azure.ai.inference` and reaches models deployed through Azure AI Studio, while `AzureOpenAIChatModelConnection` lives in the `openai` package and targets Azure OpenAI deployments. `chat_models.md:402` already draws that distinction explicitly for readers of the provider docs.

So a user who follows the alias table and writes `clazz: azure` expecting Azure OpenAI silently gets a different service, with no error to point at the mistake.

This points the row at Azure AI, which is the name `chat_models.md:393` uses for that provider section. The `azure` alias itself is unchanged, so nothing breaks for anyone already using it, and the Python side needs no change because `aliases.py` already mirrors the Java mapping faithfully. This is a documentation correction only.

Scope: this is item 2 of #958. Item 1, the six implementations that have no alias at all, is handled separately in #962, which is why this is not marked as closing the issue. #962 touches the `azure_openai` row directly above this one, so whichever merges second may need a trivial rebase of that hunk.

One thing worth a maintainer's view, though it is not required for this change: the class `azure` currently resolves to is the subject of #931, whose SDK retires on 2026-08-26. If that integration is removed or replaced, the `azure` alias needs a decision rather than a doc edit, and that decision is better made once, there.

### Tests

No tests. The change is a single documentation table cell and touches no code path.

Verified by reading the resolution chain at `main`: `yaml.md:532` → `Aliases.java:89` → `ResourceName.java:57-58` → `AzureAIChatModelConnection`, and confirming `aliases.py:75` resolves the same java-bucket alias to the same class through `resource.py:276`, so the two languages already agree with each other and only the documentation was out of step.

### API

No. No public API signature or behavior changes. Alias resolution is untouched.

### Documentation

- [ ] `doc-needed`
- [ ] `doc-not-needed`
- [x] `doc-included`
