### PR TITLE
[ci] Guard the coding-agent skill's bundled YAML schema against drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
         run: ./tools/lint.sh -c
       - name: Check AGENTS.md freshness
         run: python3 tools/check-agents-md.py
+      - name: Check bundled YAML schema freshness
+        run: python3 tools/check-skill-schema.py
 
   install_sh_tests:
     name: install.sh tests (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Check AGENTS.md freshness
         run: python3 tools/check-agents-md.py
       - name: Check bundled YAML schema freshness
+        if: github.ref == 'refs/heads/main' || github.base_ref == 'main'
         run: python3 tools/check-skill-schema.py
 
   install_sh_tests:

--- a/docs/content/docs/development/yaml.md
+++ b/docs/content/docs/development/yaml.md
@@ -636,6 +636,8 @@ Because Pydantic models are easier to author and evolve than raw JSON Schema, th
 python -m flink_agents.api.yaml.specs > docs/yaml-schema.json
 ```
 
+The coding-agent skill under `dev/agent-skills/` bundles a copy of the schema so it can work offline, so refresh that copy in the same change. `python3 tools/check-skill-schema.py` reports whether it is current and prints the two edits needed when it is not.
+
 Continuous tests then verify cross-runtime consistency:
 
 - the JSON Schema exported by the Pydantic specs matches the checked-in `docs/yaml-schema.json`;

--- a/tools/check-skill-schema.py
+++ b/tools/check-skill-schema.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+"""Assert the coding-agent skill still bundles the current YAML schema.
+
+The skill ships a copy of docs/yaml-schema.json so it can answer YAML questions
+offline, and records in yaml-contracts.yaml the git blob SHA that copy was taken
+from. Nothing regenerates either one, so both drift silently the moment the
+schema is re-exported. A stale copy teaches agents a schema the repository no
+longer has, and a stale blob SHA misreports which revision the copy describes.
+
+Only the unversioned "main" contract is checked. The versioned schemas beside it
+pin released refs, so they are expected to differ from the working tree.
+
+Regex-only and dependency-free so it runs on any Python 3 without a build step.
+"""
+
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_SCHEMA = REPO_ROOT / "docs" / "yaml-schema.json"
+ASSETS = REPO_ROOT / "dev" / "agent-skills" / "flink-agents-dev" / "assets"
+BUNDLED_SCHEMA = ASSETS / "yaml-schema.json"
+MANIFEST = ASSETS / "yaml-contracts.yaml"
+
+
+def blob_sha(path: Path) -> str:
+    """Return the git blob SHA of a file, matching `git hash-object <path>`."""
+    data = path.read_bytes()
+    return hashlib.sha1(b"blob %d\0" % len(data) + data).hexdigest()
+
+
+def recorded_sha(manifest: str) -> str:
+    """Return the blob SHA the manifest's "main" contract was copied from."""
+    # Bounded to the "main" block so a sibling contract's SHA cannot be read by
+    # mistake when the main entry loses its own.
+    block = re.search(r"^  main:\n((?:    .*\n|\n)*)", manifest, re.MULTILINE)
+    if not block:
+        sys.exit(f"error: no 'main' contract in {MANIFEST.relative_to(REPO_ROOT)}")
+    match = re.search(r"^\s+blob_sha:\s*([0-9a-f]{40})\s*$", block.group(1), re.MULTILINE)
+    if not match:
+        sys.exit(f"error: 'main' contract has no blob_sha in {MANIFEST.relative_to(REPO_ROOT)}")
+    return match.group(1)
+
+
+def main() -> int:
+    for path in (DOCS_SCHEMA, BUNDLED_SCHEMA, MANIFEST):
+        if not path.is_file():
+            sys.exit(f"error: {path.relative_to(REPO_ROOT)} does not exist")
+
+    expected = blob_sha(DOCS_SCHEMA)
+    bundled = blob_sha(BUNDLED_SCHEMA)
+    recorded = recorded_sha(MANIFEST.read_text(encoding="utf-8"))
+
+    failures = []
+    if bundled != expected:
+        failures.append(
+            f"{BUNDLED_SCHEMA.relative_to(REPO_ROOT)} is {bundled}, expected {expected}"
+        )
+    if recorded != expected:
+        failures.append(
+            f"{MANIFEST.relative_to(REPO_ROOT)} records {recorded}, expected {expected}"
+        )
+
+    if failures:
+        print("The bundled YAML schema is out of sync with docs/yaml-schema.json:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        print(
+            f"\nRefresh both:\n"
+            f"  cp {DOCS_SCHEMA.relative_to(REPO_ROOT)} {BUNDLED_SCHEMA.relative_to(REPO_ROOT)}\n"
+            f"  # then set blob_sha: {expected} under the 'main' contract in\n"
+            f"  # {MANIFEST.relative_to(REPO_ROOT)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Bundled YAML schema matches docs/yaml-schema.json ({expected}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check-skill-schema.py
+++ b/tools/check-skill-schema.py
@@ -27,11 +27,12 @@ longer has, and a stale blob SHA misreports which revision the copy describes.
 Only the unversioned "main" contract is checked. The versioned schemas beside it
 pin released refs, so they are expected to differ from the working tree.
 
-Regex-only and dependency-free so it runs on any Python 3 without a build step.
+Regex-only and stdlib-only, hashing through git, so it runs on any Python 3
+without a build step.
 """
 
-import hashlib
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -43,9 +44,30 @@ MANIFEST = ASSETS / "yaml-contracts.yaml"
 
 
 def blob_sha(path: Path) -> str:
-    """Return the git blob SHA of a file, matching `git hash-object <path>`."""
-    data = path.read_bytes()
-    return hashlib.sha1(b"blob %d\0" % len(data) + data).hexdigest()
+    """Return the blob SHA git would store for a file.
+
+    Hashing the worktree bytes directly is only correct where no clean filter
+    applies. Under core.autocrlf these JSON files are checked out CRLF, and
+    their hash then never matches the LF blob SHA recorded in the manifest, so
+    the check reports a current pin as stale and prescribes a SHA git would not
+    store. Delegating to git applies whatever filter the path's attributes
+    select.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "hash-object", "--", str(path)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        sys.exit("error: git is required to hash the schema files, but is not on PATH")
+    if result.returncode != 0:
+        sys.exit(
+            f"error: git hash-object failed for {path.relative_to(REPO_ROOT)}: "
+            f"{result.stderr.strip()}"
+        )
+    return result.stdout.strip()
 
 
 def recorded_sha(manifest: str) -> str:


### PR DESCRIPTION
Linked issue: #968

### Purpose of change

The `flink-agents-dev` skill ships a copy of `docs/yaml-schema.json` at `dev/agent-skills/flink-agents-dev/assets/yaml-schema.json`, and records the blob SHA it was taken from in `assets/yaml-contracts.yaml`. Nothing regenerates either one, and the two existing schema checks (`test_specs.py`, `SchemaParityTest`) stop at `docs/yaml-schema.json`, so re-exporting the schema leaves both stale with no failing test.

The stale copy teaches agents a schema the repository no longer has. The stale `blob_sha` is the quieter half: `SKILL.md` and `references/local-development.md` both instruct agents to trust the bundled schema only when it describes the same revision as the checkout, and that comparison is decided by exactly this value.

`tools/check-skill-schema.py` asserts the bundled copy and the recorded SHA both match `docs/yaml-schema.json`. It runs from the existing `lint` job next to `Check AGENTS.md freshness`, scoped to `main` pushes and PRs targeting `main` since the bundled skill only exists on `main`. Its Python side is regex-only and stdlib-only for the same reason `check-agents-md.py` is: that job has no Python environment beyond the interpreter.

The SHA itself comes from `git hash-object` rather than from hashing the file's bytes, so it goes through git's clean filters. A worktree-content hash is only the blob SHA where no filter applies: under `core.autocrlf` these JSON files are checked out CRLF, and the check would then report a current pin as stale and prescribe a SHA that the Linux CI rejects.

The versioned schemas beside it (`assets/yaml-schemas/release-0.3.0.json`) pin released refs and are expected to differ, so only the unversioned `main` contract is checked.

`docs/content/docs/development/yaml.md` documents the regeneration command, so it now also says to refresh the bundled copy. Without that, following the documented steps literally leaves CI red.

### Tests

No unit test. The check is itself the test, so it was verified by mutation instead: each pin was desynced independently and the check confirmed red, then restored.

| Mutation | Expected | Result |
|---|---|---|
| unmodified tree | green | green |
| `docs/yaml-schema.json` edited, both copies left behind | red, 2 failures | red, both reported |
| bundled copy edited alone | red, 1 failure | red |
| `blob_sha` edited alone | red, 1 failure | red |
| `main` contract loses its `blob_sha`, `0.3.0` keeps one | red, must not read the sibling SHA | red, `'main' contract has no blob_sha` |
| bundled copy deleted | red | red, names the missing path |
| `release-0.3.0.json` edited | green, out of scope | green |

The fifth row is why the manifest is read with a bounded match rather than a document-wide search for `blob_sha`. An unbounded search falls through to the `0.3.0` contract's SHA and the guard passes on a manifest that has lost the value it is supposed to check.

The hashing path was checked separately in a scratch repository with `core.autocrlf=true`, committing LF content and checking it back out: the byte hash and the blob SHA diverge there, and only `git hash-object` returns the committed blob. All seven rows above were re-run afterwards and are unchanged. Two further cases were covered by hand, since the check now depends on git being present: run outside a git repository it still reports the correct SHA, and with git off `PATH` it exits with a plain message rather than a traceback.

Also run locally: `tools/check-license.sh` (RAT passed), `python3 tools/check-agents-md.py`.

### API

No public API change. New file is a repository tooling script.

### Documentation

- [ ] `doc-needed`
- [ ] `doc-not-needed`
- [x] `doc-included`
