### PR TITLE
[infra] Add a docs-only review guide

### DIFF
--- a/code_review.md
+++ b/code_review.md
@@ -43,7 +43,7 @@ Guides load on demand, so the general passes here stay short.
 | Python-Java bridge | cross-language parity, type mapping across Pemja | [review-guides/python-java-bridge.md](review-guides/python-java-bridge.md) |
 | `api/` contract | API shape, compatibility policy, deprecation | planned |
 | `dist` and dependency | shading, LICENSE and NOTICE, dist registration | planned |
-| docs-only | facts match their source of truth | planned |
+| docs-only | facts match their source of truth | [review-guides/docs-only.md](review-guides/docs-only.md) |
 
 ## Required Review Passes
 

--- a/review-guides/docs-only.md
+++ b/review-guides/docs-only.md
@@ -1,0 +1,53 @@
+# Review Guide: Docs-Only Changes
+
+Load this guide when a PR changes only documentation: pages under
+`docs/content`, including the fenced code blocks inside them. It narrows the
+full passes in `code_review.md` to the ones that matter most for this area; the
+general passes still apply.
+
+## Focused checklist
+
+- Search the source for every identifier a page names. A method, class, module
+  path, or index that a page states has to exist in the code that owns it, and
+  a fenced block is where this drifts first, because nothing compiles, imports,
+  or runs the code inside a page. A sibling page spelling the same call
+  differently is a reliable sign that one of them is stale.
+- Check a claim of support against the maturity the code records. A comment or
+  Javadoc marking a path as experimental, smoke-tested, or a follow-up is the
+  strongest claim the page can make about it. A test named as the proof of a
+  guarantee has to be read for what it asserts rather than for what its name
+  suggests.
+- Re-derive every value a page restates from whatever owns it: a version
+  literal, a configuration default, a supported-provider list. The owner
+  usually sits in another module, so a page and its source can be edited in
+  separate PRs and drift apart with nothing to catch it. Confirm which side is
+  current rather than assuming the code is.
+- Read a copy-paste sample as a reader outside this repository would. A
+  version, property, or coordinate that resolves only inside this project's own
+  build fails for everyone else, and the sample often already defines the
+  properties that would have made it work.
+- Check the front matter, not only the prose. `weight` orders a page among the
+  pages it will sit beside, so reusing a value one of them already holds makes
+  the intended order ambiguous.
+
+## Validation
+
+A change under `docs/content` runs the full CI matrix and passes it without
+any job reading a changed line. `ci.yml` has no path filter, so every job
+runs, but none of them read `docs/content`, and ruff runs with `python/` as
+its root. The site build lives in a separate workflow triggered on a schedule
+and by manual dispatch rather than on pull requests. Treat the green check as
+unrelated to the change and verify by hand.
+
+- Resolve each identifier a page asserts against the source that owns it:
+  `grep -rn "<identifier>" --include='*.java' --include='*.py' .`
+- Resolve each `{{< ref >}}` target to a file under `docs/content`, and where
+  the target carries an anchor, to a heading in that file. No link checker runs
+  anywhere in the repository.
+
+## Examples from past reviews
+
+| Case | Pass it exercises | Review |
+|---|---|---|
+| A page stated that collection metadata is kept in a dedicated index, naming it. The identifier appeared nowhere in the code, and the implementation's own Javadoc recorded the opposite, that it persists no collection-level metadata. | Whether an identifier a page names can be found in the code that owns it, and whether the implementation's own documentation agrees. | [#680](https://github.com/apache/flink-agents/pull/680#discussion_r3297930919) |
+| A page presented a backend as supported, while a comment in the connection class recorded that path as wired and smoke-tested at construction with a full end-to-end run still a follow-up. | Whether a claim of support matches the maturity the code records. | [#898](https://github.com/apache/flink-agents/pull/898#discussion_r3585466817) |


### PR DESCRIPTION
Linked issue: #894

### Purpose of change

Fills the `docs-only` row that #911 left as `planned`, the third of the four per-change-type guides. #957 filled the `Python-Java bridge` row the same way, and #961 is the `api/` row.

#### Runtime flow

No executable path changes. The flow this PR completes is the routing one that #911 introduced.

A reviewer opens a documentation PR, reads the Change-Type Review Guides table in `code_review.md`, and follows the row matching the change. Before this PR the `docs-only` row terminated at the word `planned`, so the reviewer fell back to the general passes, which are written for code. After it, the row resolves to `review-guides/docs-only.md`, which narrows the passes to this change type and then hands back to the general ones.

#### Key decisions

The `Validation` section leads with a negative fact rather than a command list, because for this change type that is the useful content. A change under `docs/content` runs the full CI matrix and passes without any job reading a changed line. `ci.yml` has no path filter so every job runs, ruff runs with `python/` as its root, and the site build lives in `docs.yml`, triggered on a schedule and by manual dispatch rather than on pull requests. There is no markdown linter and no link checker in the repo. A guide that listed commands here would be inventing them.

No local site-build command is published. `tools/docs.sh` mutates global git config with a container-only path, fetches a Linux x86-64 Hugo binary, and needs the theme submodule initialized, so it is not something a reviewer can be told to run.

The checklist is five bullets rather than the sibling's six. A sixth was drafted, covering pages that document a feature without naming its language scope, and cut when its evidence proved wrong: every section I had flagged does carry a scope hint, in a phrasing variant my original search missed. Nothing was added back to restore the count.

Both example rows cite docs findings raised on merged, genuinely documentation-only PRs, so neither row illustrates its change type with a PR of a different type.

### Implementation Description

#### Behavioral contracts

The guide is prose, so its contracts are the claims it makes about this repository. Each is separately checkable.

1. No CI job reads any file under `docs/content`.
2. The site build is triggered on a schedule and by manual dispatch, not on pull requests.
3. Ruff runs with `python/` as its root, so it does not reach `docs/`.
4. No link checker runs anywhere in the repository.
5. Nothing compiles, imports, or runs the code inside a documentation page.
6. `weight` orders a page among the pages it sits beside.
7. Each of the two cited review threads raised what the guide's table says it raised.

#### Failure behavior

There is no runtime failure path. The failure mode is a wrong claim, and nothing in CI would catch one: RAT excludes `docs` and `review-guides`, no markdown linter exists, and the relative link in `code_review.md` is checked by nothing.

That makes a false sentence here worse than a false sentence in a comment, because it is guidance a reviewer acts on. One such claim did occur and is worth stating. An earlier draft said no CI job reads anything under `docs/`. That is false: `SchemaParityTest` and `test_specs.py` both read `docs/yaml-schema.json`, so a PR touching only that file is documentation-only by path and is validated byte for byte. Contract 1 is now scoped to `docs/content`, verified separately, with the only references to that path outside the subtree being Hugo's own settings in `docs/config.toml`.

One consequence I did not try to solve here: a `docs/yaml-schema.json` PR is docs-only by path, so the table routes it to this guide, which is then the wrong guide for it. That seems better settled once the remaining rows are filled than by carving an exception into this one.

### Tests

Not applicable in the executable sense, documentation only, no logic. `./tools/check-license.sh` passes. No license header is needed: `tools/.rat-excludes` covers `review-guides/`, and `.licenserc.yaml` ignores `**/*.md`.

Each contract above was verified against source rather than written from memory.

| Contract | How it was checked |
|---|---|
| 1. No CI job reads `docs/content` | Grepped all workflows, `tools/`, and every `.java`, `.py`, `.sh` for `docs/content` and `content.zh`. Only hits are `docs/config.toml`, consumed by `tools/docs.sh` from `docs.yml` alone |
| 2. Site build trigger | `docs.yml`'s `on:` block is `schedule` plus `workflow_dispatch`, no `pull_request` |
| 3. Ruff root | `tools/lint.sh`, on both its uv and pip paths |
| 4. No link checker | Searched all workflows and config, zero hits |
| 5. Page code never run | `tools/lint.sh`, `tools/ut.sh`, ruff config, pytest config for `addopts` and `doctest_glob` |
| 6. `weight` ordering | Documented at `docs/README.md` |
| 7. Both review threads | Both comment bodies re-fetched through the API, both PRs confirmed merged and confirmed docs-only |

### API

No. No code or public API change, and no compatibility impact for any caller.

For a reader, one row of the `code_review.md` table changes from `planned` to a link. The two already-linked rows and the two still `planned` are untouched, and the Focus cell wording is unchanged from #911.

### Documentation

- [x] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes

`Generated-by: Claude Code 2.1.223`
