### PR TITLE
[docs] Fix two Python snippets that do not run and an inaccurate schema parity claim

### DIFF
--- a/docs/content/docs/development/tool_use.md
+++ b/docs/content/docs/development/tool_use.md
@@ -189,7 +189,7 @@ The model only sees and provides normal tool parameters. The injected parameters
 
 {{< tab "Python" >}}
 ```python
-from flink_agents.api.agents import Agent
+from flink_agents.api.agents.agent import Agent
 from flink_agents.api.decorators import tool
 from flink_agents.api.tools import InjectedArg
 

--- a/docs/content/docs/development/yaml.md
+++ b/docs/content/docs/development/yaml.md
@@ -644,7 +644,7 @@ python -m flink_agents.api.yaml.specs > docs/yaml-schema.json
 Continuous tests then verify cross-runtime consistency:
 
 - the JSON Schema exported by the Pydantic specs matches the checked-in `docs/yaml-schema.json`;
-- the JSON Schema exported by the Java POJOs matches the checked-in `docs/yaml-schema.json`;
+- the Java POJOs match the checked-in `docs/yaml-schema.json` in property names, required fields, and `additionalProperties` strictness;
 - the Pydantic specs stay aligned with the Python `Agent` API;
 - the Java POJOs stay aligned with the Java `Agent` API.
 

--- a/docs/content/docs/operations/configuration.md
+++ b/docs/content/docs/operations/configuration.md
@@ -48,7 +48,7 @@ env = StreamExecutionEnvironment.get_execution_environment()
 agents_env = AgentsExecutionEnvironment.get_execution_environment(env)
 
 # Get configuration object from the environment
-config = agents_env.get_configuration()
+config = agents_env.get_config()
 
 # Set custom configuration using a direct key (string-based key)
 # This is suitable for user-defined or non-standardized settings.


### PR DESCRIPTION
Linked issue: #973

### Purpose of change

Two Python samples on the doc site call APIs that do not exist, so a reader who copies either one gets an immediate failure. Other pages already spell both correctly, so this is drift rather than a convention.

`docs/content/docs/operations/configuration.md:51` called `agents_env.get_configuration()`. That method is not declared anywhere. The real one is `get_config`, at `python/flink_agents/api/execution_environment.py:163`. Five other doc locations already use `get_config`, and the Java snippet further down the same page was already correct.

`docs/content/docs/development/tool_use.md:192` imported `Agent` from `flink_agents.api.agents`. That package's `__init__.py` is the license header alone, so the import raises `ImportError`. `docs/content/docs/development/skills.md:94` uses the path that works.

`docs/content/docs/development/yaml.md:647` listed, among the consistency guarantees, "the JSON Schema exported by the Java POJOs matches the checked-in `docs/yaml-schema.json`". There is no such export. `SchemaParityTest` reads the checked-in schema and reflects over the Java classes, asserting property names, required fields and `additionalProperties` strictness. The bullet now says that. The Pydantic bullet directly above it is accurate and is unchanged, since `test_specs.py` genuinely regenerates the schema and compares.

One known documentation issue is deliberately not in this PR. Two pairs of pages share a front-matter `weight`, which needs a decision about intended sidebar order rather than a defect fix, so it will be raised separately.

### Tests

No test harness executes documentation snippets, so both fixes were verified by running the code directly.

The import was checked in both directions against the source tree. `from flink_agents.api.agents.agent import Agent` resolves to `<class 'flink_agents.api.agents.agent.Agent'>`, and the previous form raises `ImportError: cannot import name 'Agent' from 'flink_agents.api.agents'`, with the traceback pointing at the checked-out `__init__.py` rather than an installed wheel. The other two imports in the same snippet, `decorators.tool` and `tools.InjectedArg`, both resolve, and so does `InjectedArg.from_config`, so the corrected block works as a whole.

The configuration sample cannot be executed without a live gateway, so it was verified by introspection instead. `RemoteExecutionEnvironment` is the only `AgentsExecutionEnvironment` subclass, so the sample's type is unambiguous. On it, `hasattr(env, "get_configuration")` is false while `get_config` returns `AgentConfiguration`. The methods the sample then calls on that object, `set_int(key, value)` and `set(option, value)`, both exist with matching argument shapes, so correcting the getter does not leave a broken chain behind it.

For the YAML guide, `SchemaParityTest` is the only Java file referencing `yaml-schema.json`, it reads the file rather than generating one, and no JSON Schema generator appears in any pom. The replacement wording says "match" rather than "match exactly" deliberately: the per-property assertion is normally an equality check, but relaxes to a containment check for classes carrying `@JsonAnySetter`, so an exact-match claim would not have held.

`./tools/check-license.sh` passes.

### API

No. Documentation only, no code or public API change, and no runtime behavior changes.

### Documentation

- [x] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes

`Generated-by: Claude Code 2.1.223`
