### PR TITLE
[hotfix][runtime] Aggregate close failures across the Exception/Error boundary

### DIFF
--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStore.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStore.java
@@ -21,6 +21,7 @@ import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.plan.AgentConfiguration;
 import org.apache.flink.agents.plan.actions.Action;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.fluss.client.Connection;
 import org.apache.fluss.client.ConnectionFactory;
@@ -490,31 +491,27 @@ public class FlussActionStateStore implements ActionStateStore {
 
     @Override
     public void close() throws Exception {
-        Exception firstException = null;
-        try {
-            if (table != null) {
+        // Catching Throwable rather than Exception is what keeps the connection close reachable
+        // when the table close fails with an Error, and what keeps that first failure the one the
+        // caller sees — a later connection failure rides along as suppressed instead of replacing
+        // it.
+        Throwable firstException = null;
+        if (table != null) {
+            try {
                 table.close();
+            } catch (Throwable t) {
+                firstException = t;
             }
-        } catch (Exception e) {
-            firstException = e;
-        } finally {
-            // Must stay a finally: a Throwable that is not an Exception skips the catch above, and
-            // only a finally still closes the connection on the way out. The rethrow below stays
-            // outside this block so a connection failure cannot displace such a Throwable.
-            if (connection != null) {
-                try {
-                    connection.close();
-                } catch (Exception e) {
-                    if (firstException == null) {
-                        firstException = e;
-                    } else {
-                        firstException.addSuppressed(e);
-                    }
-                }
+        }
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (Throwable t) {
+                firstException = ExceptionUtils.firstOrSuppressed(t, firstException);
             }
         }
         if (firstException != null) {
-            throw firstException;
+            ExceptionUtils.rethrowException(firstException);
         }
     }
 

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStore.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStore.java
@@ -490,14 +490,31 @@ public class FlussActionStateStore implements ActionStateStore {
 
     @Override
     public void close() throws Exception {
+        Exception firstException = null;
         try {
             if (table != null) {
                 table.close();
             }
+        } catch (Exception e) {
+            firstException = e;
         } finally {
+            // Must stay a finally: a Throwable that is not an Exception skips the catch above, and
+            // only a finally still closes the connection on the way out. The rethrow below stays
+            // outside this block so a connection failure cannot displace such a Throwable.
             if (connection != null) {
-                connection.close();
+                try {
+                    connection.close();
+                } catch (Exception e) {
+                    if (firstException == null) {
+                        firstException = e;
+                    } else {
+                        firstException.addSuppressed(e);
+                    }
+                }
             }
+        }
+        if (firstException != null) {
+            throw firstException;
         }
     }
 

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStore.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStore.java
@@ -22,6 +22,7 @@ import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.plan.AgentConfiguration;
 import org.apache.flink.agents.plan.actions.Action;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -331,27 +332,26 @@ public class KafkaActionStateStore implements ActionStateStore {
 
     @Override
     public void close() throws Exception {
-        Exception firstException = null;
+        // Catching Throwable rather than Exception is what keeps the consumer close reachable when
+        // the producer close fails with an Error, and what keeps that first failure the one the
+        // caller sees — a later consumer failure rides along as suppressed instead of replacing it.
+        Throwable firstException = null;
         if (producer != null) {
             try {
                 producer.close();
-            } catch (Exception e) {
-                firstException = e;
+            } catch (Throwable t) {
+                firstException = t;
             }
         }
         if (consumer != null) {
             try {
                 consumer.close();
-            } catch (Exception e) {
-                if (firstException == null) {
-                    firstException = e;
-                } else {
-                    firstException.addSuppressed(e);
-                }
+            } catch (Throwable t) {
+                firstException = ExceptionUtils.firstOrSuppressed(t, firstException);
             }
         }
         if (firstException != null) {
-            throw firstException;
+            ExceptionUtils.rethrowException(firstException);
         }
     }
 

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStoreTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStoreTest.java
@@ -36,7 +36,9 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -157,6 +159,7 @@ public class FlussActionStateStoreTest {
         assertThat(actionStates).isEmpty();
     }
 
+    /** Contract: both the table and the connection are closed when neither close fails. */
     @Test
     void testCloseClosesResources() throws Exception {
         Table mockTable = mock(Table.class);
@@ -169,5 +172,89 @@ public class FlussActionStateStoreTest {
 
         verify(mockTable).close();
         verify(mockConnection).close();
+    }
+
+    /**
+     * Contract: a recorded table-close failure survives a clean connection close — the table's
+     * exception still reaches the caller, and the connection is closed.
+     */
+    @Test
+    void testCloseClosesConnectionWhenTableCloseFails() throws Exception {
+        Table failingTable = mock(Table.class);
+        Connection mockConnection = mock(Connection.class);
+        RuntimeException tableFailure = new RuntimeException("table close failed");
+        doThrow(tableFailure).when(failingTable).close();
+
+        FlussActionStateStore closeableStore =
+                new FlussActionStateStore(actionStates, mockConnection, failingTable, mockWriter);
+
+        assertThat(catchThrowable(closeableStore::close)).isSameAs(tableFailure);
+
+        verify(mockConnection).close();
+    }
+
+    /**
+     * Contract: when both closes fail, the table's exception is the one thrown and the connection's
+     * is attached to it as a suppressed exception, so neither failure is lost.
+     */
+    @Test
+    void testCloseKeepsTableFailureWhenBothCloseFail() throws Exception {
+        Table failingTable = mock(Table.class);
+        Connection failingConnection = mock(Connection.class);
+        IOException tableFailure = new IOException("table close failed");
+        IOException connectionFailure = new IOException("connection close failed");
+        doThrow(tableFailure).when(failingTable).close();
+        doThrow(connectionFailure).when(failingConnection).close();
+
+        FlussActionStateStore closeableStore =
+                new FlussActionStateStore(
+                        actionStates, failingConnection, failingTable, mockWriter);
+
+        Throwable thrown = catchThrowable(closeableStore::close);
+
+        assertThat(thrown).isSameAs(tableFailure);
+        assertThat(thrown.getSuppressed()).containsExactly(connectionFailure);
+    }
+
+    /**
+     * Contract: when only the connection close fails, its exception reaches the caller unchanged,
+     * with nothing attached as suppressed.
+     */
+    @Test
+    void testCloseThrowsConnectionFailureWhenOnlyConnectionCloseFails() throws Exception {
+        Table mockTable = mock(Table.class);
+        Connection failingConnection = mock(Connection.class);
+        RuntimeException connectionFailure = new RuntimeException("connection close failed");
+        doThrow(connectionFailure).when(failingConnection).close();
+
+        FlussActionStateStore closeableStore =
+                new FlussActionStateStore(actionStates, failingConnection, mockTable, mockWriter);
+
+        Throwable thrown = catchThrowable(closeableStore::close);
+
+        assertThat(thrown).isSameAs(connectionFailure);
+        assertThat(thrown.getSuppressed()).isEmpty();
+    }
+
+    /**
+     * Contract: when closing the table throws a non-{@code Exception} {@code Throwable} and the
+     * connection close then fails too, the throwable stays the failure the caller sees, and the
+     * connection is still closed.
+     */
+    @Test
+    void testCloseKeepsTableErrorWhenConnectionCloseAlsoFails() throws Exception {
+        Table failingTable = mock(Table.class);
+        Connection failingConnection = mock(Connection.class);
+        NoClassDefFoundError tableFailure = new NoClassDefFoundError("simulated teardown failure");
+        doThrow(tableFailure).when(failingTable).close();
+        doThrow(new RuntimeException("connection close failed")).when(failingConnection).close();
+
+        FlussActionStateStore closeableStore =
+                new FlussActionStateStore(
+                        actionStates, failingConnection, failingTable, mockWriter);
+
+        assertThat(catchThrowable(closeableStore::close)).isSameAs(tableFailure);
+
+        verify(failingConnection).close();
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStoreTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStoreTest.java
@@ -238,23 +238,51 @@ public class FlussActionStateStoreTest {
 
     /**
      * Contract: when closing the table throws a non-{@code Exception} {@code Throwable} and the
-     * connection close then fails too, the throwable stays the failure the caller sees, and the
-     * connection is still closed.
+     * connection close then fails too, the throwable stays the failure the caller sees, the
+     * connection is still closed, and the connection's failure is attached as suppressed.
      */
     @Test
     void testCloseKeepsTableErrorWhenConnectionCloseAlsoFails() throws Exception {
         Table failingTable = mock(Table.class);
         Connection failingConnection = mock(Connection.class);
         NoClassDefFoundError tableFailure = new NoClassDefFoundError("simulated teardown failure");
+        RuntimeException connectionFailure = new RuntimeException("connection close failed");
         doThrow(tableFailure).when(failingTable).close();
-        doThrow(new RuntimeException("connection close failed")).when(failingConnection).close();
+        doThrow(connectionFailure).when(failingConnection).close();
 
         FlussActionStateStore closeableStore =
                 new FlussActionStateStore(
                         actionStates, failingConnection, failingTable, mockWriter);
 
-        assertThat(catchThrowable(closeableStore::close)).isSameAs(tableFailure);
+        Throwable thrown = catchThrowable(closeableStore::close);
 
+        assertThat(thrown).isSameAs(tableFailure);
+        assertThat(thrown.getSuppressed()).containsExactly(connectionFailure);
         verify(failingConnection).close();
+    }
+
+    /**
+     * Contract: when the table close fails and the connection close then throws a non-{@code
+     * Exception} {@code Throwable}, the table's exception stays the failure the caller sees and the
+     * connection's throwable is attached as suppressed.
+     */
+    @Test
+    void testCloseKeepsTableFailureWhenConnectionCloseThrowsError() throws Exception {
+        Table failingTable = mock(Table.class);
+        Connection failingConnection = mock(Connection.class);
+        IOException tableFailure = new IOException("table close failed");
+        NoClassDefFoundError connectionFailure =
+                new NoClassDefFoundError("simulated teardown failure");
+        doThrow(tableFailure).when(failingTable).close();
+        doThrow(connectionFailure).when(failingConnection).close();
+
+        FlussActionStateStore closeableStore =
+                new FlussActionStateStore(
+                        actionStates, failingConnection, failingTable, mockWriter);
+
+        Throwable thrown = catchThrowable(closeableStore::close);
+
+        assertThat(thrown).isSameAs(tableFailure);
+        assertThat(thrown.getSuppressed()).containsExactly(connectionFailure);
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStoreTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStoreTest.java
@@ -39,6 +39,7 @@ import java.util.Map;
 
 import static org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy.EARLIEST;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -333,6 +334,62 @@ public class KafkaActionStateStoreTest {
 
         assertThat(thrown).isSameAs(consumerFailure);
         assertThat(thrown.getSuppressed()).isEmpty();
+    }
+
+    /**
+     * Contract: when closing the producer throws a non-{@code Exception} {@code Throwable}, the
+     * consumer is still closed and the throwable reaches the caller unchanged.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testCloseClosesConsumerWhenProducerCloseThrowsError() {
+        Producer<String, ActionState> failingProducer = mock(Producer.class);
+        Consumer<String, ActionState> consumer = mock(Consumer.class);
+        NoClassDefFoundError producerFailure =
+                new NoClassDefFoundError("simulated teardown failure");
+        doThrow(producerFailure).when(failingProducer).close();
+
+        KafkaActionStateStore store =
+                new KafkaActionStateStore(
+                        actionStates,
+                        new AgentConfiguration(),
+                        failingProducer,
+                        consumer,
+                        TEST_TOPIC);
+
+        assertThat(catchThrowable(store::close)).isSameAs(producerFailure);
+
+        verify(consumer).close();
+    }
+
+    /**
+     * Contract: when the producer close fails and the consumer close then throws a non-{@code
+     * Exception} {@code Throwable}, the producer's exception stays the failure the caller sees and
+     * the consumer's throwable is attached as suppressed.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testCloseKeepsProducerFailureWhenConsumerCloseThrowsError() {
+        Producer<String, ActionState> failingProducer = mock(Producer.class);
+        Consumer<String, ActionState> failingConsumer = mock(Consumer.class);
+        RuntimeException producerFailure = new RuntimeException("producer close failed");
+        NoClassDefFoundError consumerFailure =
+                new NoClassDefFoundError("simulated teardown failure");
+        doThrow(producerFailure).when(failingProducer).close();
+        doThrow(consumerFailure).when(failingConsumer).close();
+
+        KafkaActionStateStore store =
+                new KafkaActionStateStore(
+                        actionStates,
+                        new AgentConfiguration(),
+                        failingProducer,
+                        failingConsumer,
+                        TEST_TOPIC);
+
+        Throwable thrown = catchThrowable(store::close);
+
+        assertThat(thrown).isSameAs(producerFailure);
+        assertThat(thrown.getSuppressed()).containsExactly(consumerFailure);
     }
 
     /** Contract: both the producer and the consumer are closed when neither close fails. */


### PR DESCRIPTION
Linked issue: none, this is a hotfix.

### Purpose of change

`FlussActionStateStore.close()` and `KafkaActionStateStore.close()` each close two resources and caught only `Exception` while doing it. That leaves the non-`Exception` cases incomplete, and it cost four distinct failures.

In `FlussActionStateStore.close()`, `table.close()` was wrapped in a `try` with `connection.close()` in the `finally`. The connection did get closed, so there was no leak, but a `finally` that throws discards the in-flight exception. When both closes threw, the caller saw only the connection failure and had no signal that the table close failed at all. When `table.close()` threw an `Error`, the `finally` recorded a connection `Exception` that was then discarded as the pending `Error` resumed, so that connection failure vanished. Conversely, a connection `Error` thrown from the `finally` bypassed the inner catch and replaced an already-recorded table failure outright.

`KafkaActionStateStore.close()` had the same boundary problem in a worse form. A producer `Error` left the method before `consumer.close()` ran at all, which is a live resource leak rather than only exception loss. A consumer `Error` replaced an earlier producer failure.

All four paths were reproduced against the previous code before anything changed. The Kafka leak was confirmed by invocation check: with the producer close throwing an `Error`, `consumer.close()` was never invoked.

Both methods now use the same shape. Each close is wrapped in its own `catch (Throwable t)`, the first failure is kept primary via `ExceptionUtils.firstOrSuppressed`, and the method ends with `ExceptionUtils.rethrowException`, so an `Error` still reaches the caller as an `Error` and a checked exception as itself. `rethrowException` is required rather than a bare `throw` because the accumulator is `Throwable`-typed and would not compile otherwise.

Two notes on the shape, since both are easy to ask about.

Widening to `Throwable` is what removes the need for the `finally` in the Fluss method. The reason to hold a `finally` was that a `catch (Exception)` does not run for an `Error`, so a flat ladder would skip the connection close and leak it. A catch that runs for any `Throwable` already keeps the second close reachable on every path, so the `finally` no longer buys anything and the two methods are now structurally identical. `SkillManager.java` uses the same pattern in its constructor cleanup.

`IOUtils.closeAll` was considered and does not fit. Its first-wins suppression and null-skipping match this contract, but with the default `Exception.class` it rethrows a non-`Exception` `Throwable` immediately without closing the remaining resources, which is the same leak being fixed here. Passing `Throwable.class` avoids that but wraps the throwable, so an `OutOfMemoryError` would reach the caller as an ordinary `Exception`.

The Kafka method is fixed here rather than deferred, because its `Error` path is a resource leak and leaving it would keep the two stores divergent.

### Tests

Each test class now covers the same six close outcomes, one per path: both closes succeed, the first close fails, both fail, only the second fails, and the two `Exception`/`Error` orderings.

Four of those are new or strengthened in this change. The Fluss error-path test now asserts that the connection failure survives as a suppressed exception rather than only that the `Error` stays primary. A new Fluss test pins a checked table exception surviving a connection `Error`. A new Kafka test pins the leak directly, asserting `consumer.close()` still runs when the producer close throws an `Error`. A fourth pins a producer exception surviving a consumer `Error`.

Each of the four kills a distinct mutant. Narrowing any single one of the four `catch (Throwable)` arms back to `catch (Exception)` fails exactly one of them and no others. Swapping the two `firstOrSuppressed` arguments fails seven tests, so the argument order is pinned as well.

The stubs deliberately span checked (`IOException`), unchecked (`RuntimeException`) and `Error` failures. With unchecked stubs only, narrowing a `catch` to `catch (RuntimeException)` would pass the whole suite while reinstating the defect for checked exceptions, which is the likely case in practice given that `FlussConnection.close()` calls `RemoteFileDownloader.close() throws IOException`.

The full `runtime` module suite passes: 419 tests, 0 failures, 0 errors.

### API

No API change. Both methods keep their `@Override public void close() throws Exception` signature, and the caller-visible failure type is unchanged on every path that previously threw.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

`Generated-by: Claude Code (claude-opus-5)`, also present in the commit messages.
