### PR TITLE
[test][python] Use the registered checkpoint interval key in the Python e2e tests

### DIFF
--- a/python/flink_agents/e2e_tests/e2e_tests_integration/checkpointing_config_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/checkpointing_config_test.py
@@ -1,0 +1,58 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+"""Guard for the checkpointing configuration the Flink e2e tests set."""
+
+import re
+from pathlib import Path
+
+from pyflink.java_gateway import get_gateway
+
+_E2E_TESTS_PACKAGE = Path(__file__).parents[1]
+
+# Deliberately loose on setter name, stem, and quote style: a near miss Flink
+# would silently ignore has to be caught whatever spelling it arrives in.
+_CHECKPOINT_INTERVAL_KEY = re.compile(
+    r"set_\w+\(\s*(?P<quote>['\"])"
+    r"(?P<key>[^'\"]*checkpoint[^'\"]*interval[^'\"]*)(?P=quote)"
+)
+
+
+def test_checkpoint_interval_key_matches_the_flink_option() -> None:
+    """Every checkpoint interval the e2e tests set uses the key Flink registers.
+
+    Flink ignores an unregistered configuration key silently, with no exception
+    and no log line, so a near miss such as ``checkpointing.interval`` leaves
+    checkpointing disabled while the test still passes. Reading the expected key
+    off ``CheckpointingOptions#CHECKPOINTING_INTERVAL`` takes it from Flink
+    itself rather than from another hand-written copy of the string.
+    """
+    flink_config = get_gateway().jvm.org.apache.flink.configuration
+    expected = flink_config.CheckpointingOptions.CHECKPOINTING_INTERVAL.key()
+
+    found: dict[str, set[str]] = {}
+    for path in sorted(_E2E_TESTS_PACKAGE.rglob("*_test.py")):
+        for match in _CHECKPOINT_INTERVAL_KEY.finditer(path.read_text()):
+            found.setdefault(match["key"], set()).add(path.name)
+
+    assert found, "no checkpoint interval configured; the pattern above is stale"
+    assert set(found) == {expected}, (
+        f"checkpointing must be configured with {expected!r}, found "
+        + "; ".join(
+            f"{key!r} in {sorted(files)}" for key, files in sorted(found.items())
+        )
+    )

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/e2e_tests_mcp/mcp_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/e2e_tests_mcp/mcp_test.py
@@ -211,7 +211,7 @@ def test_mcp(
 
         config = Configuration()
         config.set_string("state.backend.type", "rocksdb")
-        config.set_string("checkpointing.interval", "1s")
+        config.set_string("execution.checkpointing.interval", "1s")
         config.set_string("restart-strategy.type", "disable")
         env = StreamExecutionEnvironment.get_execution_environment(config)
         env.set_runtime_mode(RuntimeExecutionMode.STREAMING)

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/execute_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/execute_test.py
@@ -56,7 +56,7 @@ def test_durable_execute_basic_flink(tmp_path: Path) -> None:
     """Test basic synchronous durable_execute() functionality in Flink environment."""
     config = Configuration()
     config.set_string("state.backend.type", "rocksdb")
-    config.set_string("checkpointing.interval", "1s")
+    config.set_string("execution.checkpointing.interval", "1s")
     config.set_string("restart-strategy.type", "disable")
     env = StreamExecutionEnvironment.get_execution_environment(config)
     env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
@@ -108,7 +108,7 @@ def test_durable_execute_multiple_calls_flink(tmp_path: Path) -> None:
     """Test multiple durable_execute() calls in Flink environment."""
     config = Configuration()
     config.set_string("state.backend.type", "rocksdb")
-    config.set_string("checkpointing.interval", "1s")
+    config.set_string("execution.checkpointing.interval", "1s")
     config.set_string("restart-strategy.type", "disable")
     env = StreamExecutionEnvironment.get_execution_environment(config)
     env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
@@ -160,7 +160,7 @@ def test_durable_execute_with_async_flink(tmp_path: Path) -> None:
     """Test durable_execute() and durable_execute_async() in Flink environment."""
     config = Configuration()
     config.set_string("state.backend.type", "rocksdb")
-    config.set_string("checkpointing.interval", "1s")
+    config.set_string("execution.checkpointing.interval", "1s")
     config.set_string("restart-strategy.type", "disable")
     env = StreamExecutionEnvironment.get_execution_environment(config)
     env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
@@ -212,7 +212,7 @@ def test_durable_execute_async_exception_flink(tmp_path: Path) -> None:
     """Test durable_execute_async() exception handling in Flink environment."""
     config = Configuration()
     config.set_string("state.backend.type", "rocksdb")
-    config.set_string("checkpointing.interval", "1s")
+    config.set_string("execution.checkpointing.interval", "1s")
     config.set_string("restart-strategy.type", "disable")
     env = StreamExecutionEnvironment.get_execution_environment(config)
     env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
@@ -264,7 +264,7 @@ def test_durable_execute_sync_exception_flink(tmp_path: Path) -> None:
     """Test synchronous durable_execute() exception handling in Flink environment."""
     config = Configuration()
     config.set_string("state.backend.type", "rocksdb")
-    config.set_string("checkpointing.interval", "1s")
+    config.set_string("execution.checkpointing.interval", "1s")
     config.set_string("restart-strategy.type", "disable")
     env = StreamExecutionEnvironment.get_execution_environment(config)
     env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
@@ -316,7 +316,7 @@ def test_durable_execute_with_kwargs_flink(tmp_path: Path) -> None:
     """Test durable_execute() with keyword arguments in Flink environment."""
     config = Configuration()
     config.set_string("state.backend.type", "rocksdb")
-    config.set_string("checkpointing.interval", "1s")
+    config.set_string("execution.checkpointing.interval", "1s")
     config.set_string("restart-strategy.type", "disable")
     env = StreamExecutionEnvironment.get_execution_environment(config)
     env.set_runtime_mode(RuntimeExecutionMode.STREAMING)

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/flink_intergration_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/flink_intergration_test.py
@@ -51,7 +51,7 @@ os.environ["PYTHONPATH"] = sysconfig.get_paths()["purelib"]
 def test_from_datastream_to_datastream(tmp_path: Path) -> None:
     config = Configuration()
     config.set_string("state.backend.type", "rocksdb")
-    config.set_string("checkpointing.interval", "1s")
+    config.set_string("execution.checkpointing.interval", "1s")
     config.set_string("restart-strategy.type", "disable")
     env = StreamExecutionEnvironment.get_execution_environment(config)
     env.set_runtime_mode(RuntimeExecutionMode.STREAMING)

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/mock_chat_model_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/mock_chat_model_test.py
@@ -57,7 +57,7 @@ def test_built_in_chat_tool_action_content(tmp_path: Path) -> None:
     """
     config = Configuration()
     config.set_string("state.backend.type", "rocksdb")
-    config.set_string("checkpointing.interval", "1s")
+    config.set_string("execution.checkpointing.interval", "1s")
     config.set_string("restart-strategy.type", "disable")
     env = StreamExecutionEnvironment.get_execution_environment(config)
     env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
@@ -115,7 +115,7 @@ def test_chat_model_get_resource_in_action(tmp_path: Path) -> None:
     """
     config = Configuration()
     config.set_string("state.backend.type", "rocksdb")
-    config.set_string("checkpointing.interval", "1s")
+    config.set_string("execution.checkpointing.interval", "1s")
     config.set_string("restart-strategy.type", "disable")
     env = StreamExecutionEnvironment.get_execution_environment(config)
     env.set_runtime_mode(RuntimeExecutionMode.STREAMING)

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/workflow_memory_remote_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/workflow_memory_remote_test.py
@@ -55,7 +55,7 @@ def test_short_term_memory_same_key_accumulation(tmp_path: Path) -> None:
     """
     config = Configuration()
     config.set_string("state.backend.type", "rocksdb")
-    config.set_string("checkpointing.interval", "1s")
+    config.set_string("execution.checkpointing.interval", "1s")
     config.set_string("restart-strategy.type", "disable")
     env = StreamExecutionEnvironment.get_execution_environment(config)
     env.set_runtime_mode(RuntimeExecutionMode.STREAMING)


### PR DESCRIPTION
Linked issue: #976

### Purpose of change

`checkpointing.interval` is not a Flink configuration key. The real one is `execution.checkpointing.interval` (`CheckpointingOptions#CHECKPOINTING_INTERVAL`). The bare form is not registered, and it is not wired as a deprecated or fallback key either, so Flink ignores it silently. Since the real option has `noDefaultValue()`, no periodic checkpointing was ever scheduled.

The Python e2e tests set the bare form in 11 places across 5 files, so they configure a RocksDB state backend that is never snapshotted while reading as though they exercise checkpointing.

The first commit renames the key at all 11 sites. The neighbouring `state.backend.type` and `restart-strategy.type` are both genuine registered options and are left unchanged.

The second commit adds one test so this cannot recur. Nothing today can catch this class of bug: Flink emits no signal for an unregistered key, `Configuration` logs only for registered fallbacks, PyFlink writes to a file appender rather than the console, and no lint rule can check a plain string argument. The guard scans the e2e sources for the checkpoint interval keys they configure and compares them against the key read from Flink itself, so neither side of the comparison is a hand-written copy of the string. A guard carrying its own copy of the key would pass while every real call site stayed broken.

Two things worth setting expectations on. The rename does not make these tests meaningfully exercise checkpointing: measured on Flink 2.2 it yields one completed checkpoint per job, of largely drained state, because the operator drains its in-flight keys before the snapshot lands. Getting a checkpoint to complete with in-flight state did not happen at intervals down to 10ms, with slow agents, or with larger inputs. Doing better needs a different test design rather than a configuration fix.

The other is that the fix activates a path that was previously dead. At every site `tolerable-failed-checkpoints` is 0 and `restart-strategy.type` is `disable`, and with no checkpoint directory configured the storage falls back to JobManager memory, which caps state at 5 MiB. So a failed or oversized checkpoint now fails the job outright, where before it could not occur at all. Nothing hit this in practice, but it is the first thing to check if these tests ever go flaky.

### Tests

`./tools/ut.sh -p -e -f 2.2` passes. All 14 tests across the 5 renamed files pass, and they pass on the first attempt rather than being retried by `--reruns`.

`mcp_test.py` is normally skipped without a local Ollama, so a local `qwen3:1.7b` was stood up to cover the 11th site rather than leaving it to CI. Both parametrizations pass.

The new key was checked against the shipped `flink-dist` jar rather than taken from documentation: `CHECKPOINTING_INTERVAL.key()` resolves to `execution.checkpointing.interval`, its fallback keys are empty, reading the option from a `Configuration` holding the bare key returns `null`, and `"1s"` parses to `PT1S` for its `Duration` type, so the value needed no change. The same holds on 1.20.3. The option is present in `flink-core` on 1.20, 2.0, 2.1, 2.2 and 2.3; 2.0, 2.1 and 2.3 were verified by inspection rather than executed locally.

The guard was verified to fail, not just to pass. It goes red on the original defect, on a `set_integer` spelling, on `execution.checkpoint.interval`, on a single-quoted key, on all of those combined, on the longer registered key `execution.checkpointing.interval-during-backlog`, and on a scan that matches nothing. Each failure names the offending file. It produces no false positives: exactly 11 matches across the 5 files, resolving to the single expected key.

The guard sits in the pytest selection that runs the full Flink version matrix, since what it checks is whether the key resolves against a given Flink version. It costs about 10ms there, where the JVM gateway is already warm.

### API

No public API change. Both commits are test-only.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

Generated-by: Claude Code 2.1.224
