### PR TITLE
[infra] Invoke the build scripts' Python tools through the interpreter

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -102,11 +102,11 @@ if $build_python; then
   cd python
   rm -rf dist/  # Clean old build artifacts before building
   python3 -m pip install uv==0.11.0
-  uv lock
-  uv sync --extra dev
-  uv run python -m ensurepip --default-pip
-  uv run python -m build
-  uv pip install dist/*.whl
+  python3 -m uv lock
+  python3 -m uv sync --extra dev
+  python3 -m uv run python -m ensurepip --default-pip
+  python3 -m uv run python -m build
+  python3 -m uv pip install --python .venv dist/*.whl
 
   rm -rf ${PYTHON_LIB_DIR}
 fi

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -101,7 +101,7 @@ if $build_python; then
   # build python
   cd python
   rm -rf dist/  # Clean old build artifacts before building
-  pip install uv==0.11.0
+  python3 -m pip install uv==0.11.0
   uv lock
   uv sync --extra dev
   uv run python -m ensurepip --default-pip

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -103,10 +103,10 @@ run_python_lint() {
     # Use traditional approach
     if [[ "$action" == "format" ]]; then
       echo "Executing Python format"
-      ruff check --fix python
+      python3 -m ruff check --fix python
     else
       echo "Executing Python format check"
-      ruff check --no-fix python
+      python3 -m ruff check --no-fix python
     fi
     return $?
   fi

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -74,10 +74,10 @@ install_python_deps() {
     # Try modern pyproject.toml first, then fallback to requirements.txt
     if [ -f "python/pyproject.toml" ]; then
       echo "Using pyproject.toml dependency groups"
-      pip install -e "python[lint]"
+      python3 -m pip install -e "python[lint]"
     else
       echo "Using legacy requirements.txt"
-      pip install -r python/requirements/linter_requirements.txt
+      python3 -m pip install -r python/requirements/linter_requirements.txt
     fi
   fi
 }

--- a/tools/ut.sh
+++ b/tools/ut.sh
@@ -272,8 +272,8 @@ python_tests() {
                 if $verbose; then
                     echo "Using pyproject.toml dependency groups"
                 fi
-                pip install -e ".[test]"
-                pip install apache-flink~=${version}.0
+                python3 -m pip install -e ".[test]"
+                python3 -m pip install apache-flink~=${version}.0
             fi
             if $verbose; then
                 echo "Running tests with pytest..."

--- a/tools/ut.sh
+++ b/tools/ut.sh
@@ -279,10 +279,10 @@ python_tests() {
                 echo "Running tests with pytest..."
             fi
             if $run_e2e; then
-                pytest flink_agents -k "e2e_tests_integration" --reruns 2 --reruns-delay 5 -o log_cli=true -o log_cli_level=${LOG_LEVEL:-OFF}
+                python3 -m pytest flink_agents -k "e2e_tests_integration" --reruns 2 --reruns-delay 5 -o log_cli=true -o log_cli_level=${LOG_LEVEL:-OFF}
                 rc1=$?
                 # Arm 2: integration-marked tests; trap exit code 5 as failure.
-                pytest flink_agents -m "integration" -o log_cli=true -o log_cli_level=${LOG_LEVEL:-OFF}
+                python3 -m pytest flink_agents -m "integration" -o log_cli=true -o log_cli_level=${LOG_LEVEL:-OFF}
                 rc2=$?
                 if [ $rc2 -eq 5 ]; then rc2=1; fi
                 # Logical-OR aggregation: any nonzero exit on either arm yields testcode=1.
@@ -291,7 +291,7 @@ python_tests() {
                 # on either arm indicates a selector regression).
                 testcode=$((rc1 || rc2))
             else
-                pytest flink_agents -k "not e2e_tests" -m "not integration" -o log_cli=true -o log_cli_level=${LOG_LEVEL:-OFF}
+                python3 -m pytest flink_agents -k "not e2e_tests" -m "not integration" -o log_cli=true -o log_cli_level=${LOG_LEVEL:-OFF}
                 testcode=$?
             fi
         fi


### PR DESCRIPTION
Linked issue: #980

### Purpose of change

The build scripts install a Python tool and then invoke it by bare name. Both halves depend on the Python scripts directory being on `PATH`, and it is not guaranteed to be there. A Python install commonly exposes only `pip3`, or exposes pip solely as a module, and the console scripts of anything pip installs land in a directory that may not be on `PATH` at all.

`tools/build.sh:104` is the one that bites hardest, because it runs unconditionally rather than behind the `command -v uv` check the other scripts use. On a machine with no bare `pip`, the Python half of the build fails before it starts:

```
./tools/build.sh: line 104: pip: command not found
```

Fixing only the `pip` call moves that failure one line down rather than removing it, because the next line invokes the `uv` that was just installed:

```
./tools/build.sh: line 105: uv: command not found
```

So this routes both the installer and the tool it installed through the interpreter. Ten call sites, on top of the five `pip` ones:

- `tools/build.sh` — `pip install uv`, then five `uv` calls (`lock`, `sync`, two `run`s, `pip install`)
- `tools/lint.sh` — two `pip install` calls, then two `ruff check` calls
- `tools/ut.sh` — two `pip install` calls, then three `pytest` calls

`tools/install.sh` already uses `python -m pip`, so this makes the rest of the scripts consistent with it.

The rule applied is that the interpreter form is used only where the same script pip installed that tool into the same interpreter earlier in the same run. That is what makes the module guaranteed to be importable at the point of use.

Two consequences of that rule are worth spelling out, since both look like omissions:

The `uv` calls inside a `command -v uv` guard are deliberately left bare. Those branches run only when uv is already on `PATH`, so a bare `uv` resolves there by construction, and uv is commonly installed as a standalone binary (the curl installer, homebrew) that ships no importable `uv` module. Routing them through the interpreter would break exactly those installs.

`tools/e2e.sh` is left alone for the same reason, even though it also calls `uv` by bare name. It never installs uv itself, it borrows one that `tools/build.sh` may or may not have installed, and it skips that build whenever `e2e-test/target` and `python/uv.lock` already exist. With a standalone uv on `PATH` and no pip installed module, converting it would turn a working run into a failing one. It has a real weakness, but it needs a guard rather than this change, so it is better handled separately.

Adding the scripts directory to `PATH` was the other option and was not taken: when pip falls back to a `--user` install, the console scripts land in the user scheme directory rather than `sysconfig.get_path("scripts")`, so a correct probe has to try both schemes.

### Why `build.sh:109` also gains `--python .venv`

`python3 -m uv` is not a transparent alias for `uv`. Its module entry point detects a virtualenv from the calling interpreter and injects `VIRTUAL_ENV` into the environment it execs uv with:

```python
venv_marker = os.path.join(sys.prefix, "pyvenv.cfg")
if os.path.exists(venv_marker):
    return sys.prefix
...
env.setdefault("VIRTUAL_ENV", venv)
```

The project commands ignore that and still resolve `.venv`, but `uv pip` honors it. With the same working directory containing a `.venv`, and `VIRTUAL_ENV` unset, the two forms install to different places and both exit 0 with no warning:

```
uv pip install <pkg>            -> ./.venv
python3 -m uv pip install <pkg> -> the interpreter's own venv
```

At `:109` that would silently install the freshly built wheel outside `python/.venv`, and `:111` then removes `python/flink_agents/lib`, leaving the venv with an editable install pointing at a source tree whose jars are gone. `set -e` does not catch it, because the install succeeds. Naming the target keeps the behavior identical to the bare form. It is a no-op wherever the bare form already resolved `.venv`.

### Tests

CI is unaffected. The runners provide bare `pip`, `uv`, `ruff`, and `pytest` on `PATH`, and both forms resolve to the same tool there. The change is only observable where the bare command was absent, which is exactly the case that used to fail.

Reproduced on a machine where the system Python exposes neither a bare `pip` nor a bare `uv`:

```
$ pip --version
command not found: pip
$ python3 -m pip --version
pip 21.2.4 from .../python3.9/site-packages/pip (python 3.9)
$ command -v uv; echo $?
1
$ python3 -m uv --version
uv 0.11.0
```

The module form was checked against the versions the repo pins, and each resolves to the same tool:

| Command | Version | Pinned at |
| --- | --- | --- |
| `python3 -m uv --version` | `uv 0.11.0` | `tools/build.sh` |
| `python3 -m ruff --version` | `ruff 0.11.13` | `python/pyproject.toml` |
| `python3 -m pytest --version` | `pytest 9.0.3` | `python/pyproject.toml` |

Exit codes are unchanged by the module form, which matters because `tools/ut.sh` traps pytest's exit code 5 to turn an empty collection into a failure. Both forms return 5 on an empty collection, and agree on 0, 1, and 4, and on a `-k` selector matching nothing.

`tools/lint.sh` was run end to end through its no-uv fallback path, with `PATH` arranged so that `command -v uv` fails: the pip install branch runs, `python3 -m ruff` runs, and it reports `All checks passed!` and exits 0. Both rewritten ruff sites were exercised, in `--check` and in `--format`.

For `tools/ut.sh`, collection under both forms is identical, 317 selected and 58 deselected across the same 1032 lines of output.

`bash -n` passes on all three scripts, and shellcheck reports the same finding set before and after, with no new findings and no change other than the column offsets caused by the longer command prefix.

No behavior change where the bare commands already resolved.

### API

No API change.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No
