### PR TITLE
[test][python] Assert long-term memory content instead of an exact LLM item count

### DIFF
--- a/python/flink_agents/e2e_tests/e2e_tests_integration/long_term_memory_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/long_term_memory_test.py
@@ -303,13 +303,35 @@ def check_result(*, result_dir: Path) -> None:
     for record in actual_result:
         records[f"{record.name}.{record.count}"] = record
 
+    assert "alice.2" in records, f"missing alice.2; got {sorted(records)}"
     items = records["alice.2"].items
-    # LLMs may treat different review comments as updates to the same
-    # fact or as distinct facts.
-    assert len(items) == 1
-    item: MemorySetItem = items[-1]
-    assert item.created_at < item.updated_at
-    assert "bananas" in item.value
+    # The extraction model decides whether alice's two facts collapse into a
+    # single item or stay separate, so the item count is not fixed. bob's set
+    # is reported alongside a failure to tell a per-key miss from a store-wide
+    # one.
+    bob_items = records["bob.2"].items if "bob.2" in records else None
+    bob_values = None if bob_items is None else [item.value for item in bob_items]
+    assert items, f"alice's memory set is empty (bob's set: {bob_values})"
+
+    values = [item.value for item in items]
+    # The stored text is the model's paraphrase of the input, so match loosely.
+    assert any("bananas" in value.lower() for value in values), (
+        f"no stored item carries the updated fact: {values}"
+    )
+    # Each partition key is scoped to its own memories, so bob's facts must
+    # never surface in alice's set.
+    leaked = [
+        value
+        for value in values
+        if "swimming" in value.lower() or "vegetarian" in value.lower()
+    ]
+    assert not leaked, f"alice's set contains bob's facts: {values}"
+    # Both timestamps are populated whether an item was created or updated, and
+    # the parser turns an unrecognized format into None rather than raising.
+    assert all(item.created_at and item.updated_at for item in items), (
+        f"stored items are missing timestamps: "
+        f"{[(item.created_at, item.updated_at) for item in items]}"
+    )
 
     # verify async add doesn't block process other key
     assert datetime.fromisoformat(

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/long_term_memory_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/long_term_memory_test.py
@@ -304,26 +304,29 @@ def check_result(*, result_dir: Path) -> None:
         records[f"{record.name}.{record.count}"] = record
 
     assert "alice.2" in records, f"missing alice.2; got {sorted(records)}"
+    assert "bob.2" in records, f"missing bob.2; got {sorted(records)}"
+    # The extraction model decides whether each key's two facts collapse into a
+    # single item or stay separate, so the item count is not fixed. Each set is
+    # reported alongside the other's failure to tell a per-key miss from a
+    # store-wide one.
     items = records["alice.2"].items
-    # The extraction model decides whether alice's two facts collapse into a
-    # single item or stay separate, so the item count is not fixed. bob's set
-    # is reported alongside a failure to tell a per-key miss from a store-wide
-    # one.
-    bob_items = records["bob.2"].items if "bob.2" in records else None
-    bob_values = None if bob_items is None else [item.value for item in bob_items]
+    values = [item.value for item in items or []]
+    bob_values = [item.value for item in records["bob.2"].items or []]
     # A scoping break misattributes in either direction. alice's facts landing
     # in bob's set leaves alice's set short rather than inflated, so check that
     # direction ahead of the emptiness assertion below, which would otherwise
-    # report the symptom in place of the cause.
+    # report the symptom in place of the cause. bob's set has to be populated
+    # for that scan to carry any weight, since an empty one satisfies it
+    # without ever being examined.
+    assert bob_values, f"bob's memory set is empty (alice's set: {values})"
     bob_leaked = [
         value
-        for value in (bob_values or [])
+        for value in bob_values
         if "watermelon" in value.lower() or "bananas" in value.lower()
     ]
     assert not bob_leaked, f"bob's set contains alice's facts: {bob_values}"
-    assert items, f"alice's memory set is empty (bob's set: {bob_values})"
+    assert values, f"alice's memory set is empty (bob's set: {bob_values})"
 
-    values = [item.value for item in items]
     # The stored text is the model's paraphrase of the input, so match loosely.
     assert any("bananas" in value.lower() for value in values), (
         f"no stored item carries the updated fact: {values}"

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/long_term_memory_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/long_term_memory_test.py
@@ -311,6 +311,16 @@ def check_result(*, result_dir: Path) -> None:
     # one.
     bob_items = records["bob.2"].items if "bob.2" in records else None
     bob_values = None if bob_items is None else [item.value for item in bob_items]
+    # A scoping break misattributes in either direction. alice's facts landing
+    # in bob's set leaves alice's set short rather than inflated, so check that
+    # direction ahead of the emptiness assertion below, which would otherwise
+    # report the symptom in place of the cause.
+    bob_leaked = [
+        value
+        for value in (bob_values or [])
+        if "watermelon" in value.lower() or "bananas" in value.lower()
+    ]
+    assert not bob_leaked, f"bob's set contains alice's facts: {bob_values}"
     assert items, f"alice's memory set is empty (bob's set: {bob_values})"
 
     values = [item.value for item in items]


### PR DESCRIPTION
Linked issue: #983

### Purpose of change

`test_long_term_memory_async_execution_in_action` asserts `len(items) == 1`, which pins how many items mem0 stores after alice's two inputs. Whether those two facts collapse into one item or stay separate is the extraction model's decision, so the count is not guaranteed. The comment above the assertion already conceded the variability.

On 2026-08-08 the test failed on `main` with `assert 0 == 1`, on a commit that changed three markdown files under `docs/content` with one line each. All three attempts failed, exhausting the `--reruns 2` budget. The run before it passed this test only on retry, and it was the only rerun in that job.

This asserts on retrievable content instead of an exact count.

Two things this does not claim. Counts above `1` have not been observed on this test, so loosening them is preventive rather than a response to a recorded failure. And the one failure that has been recorded, the empty set, still fails after this change, deliberately. The immediate value here is the diagnostic and the restored coverage rather than a greener CI.

The empty case is deliberately kept as a failure rather than tolerated. Zero stored items means neither add landed, which may be a real defect in the add path rather than model variance, and it is the only one of the four observed outcomes that carries information. To make the next occurrence diagnosable, bob's memory set is reported alongside the failure: if bob has items and alice does not, the miss is per-key; if both are empty, extraction or the store failed wholesale. That matters because the e2e arm runs with `log_cli_level=OFF` and pytest-rerunfailures reports only the final attempt, so today an occurrence leaves no trace.

Two related changes come with it.

The `created_at < updated_at` assertion is dropped. On a plain add mem0 sets `updated_at` equal to `created_at`, so the strict comparison holds only when the model picked the update branch. That made it a second instance of the same flake, and it can also fail on a legitimate delete-then-add even when exactly one item survives.

An explicit cross-key leak check is added. The exact count was incidentally covering this: alice and bob share a job id and a memory set name, so `agent_id` is the only isolation boundary between them, and a scoping break would have surfaced as an inflated count. Asserting that bob's facts never appear in alice's set restores that coverage without depending on a count.

The content match is case-insensitive because the stored text is the model's paraphrase rather than the input, so a title-cased "Bananas" would otherwise fail for the same reason the count does.

Timestamp coverage is kept, in a form that does not depend on which branch the model picked. The dropped ordering assertion was incidentally the only thing in the repo asserting that `created_at` and `updated_at` parse at all: `_to_memory_set_item` suppresses `ValueError`/`TypeError` and yields `None`, so an unrecognized timestamp format would otherwise go unnoticed. Asserting both fields are populated covers that and holds on both the create and the update path, since mem0 sets `updated_at` equal to `created_at` on a plain add.

### Tests

Test-only change. The modified assertions were exercised against the observed and adjacent outcomes:

| Case | Result |
|---|---|
| 0 items | fails, with bob's set in the message |
| 1 item, consolidated | passes |
| 2 items, kept separate | passes |
| 4 items, kept separate | passes |
| single item, title-cased "Bananas" | passes |
| single item added without an update, timestamps equal | passes |
| stale read, only the watermelon fact | fails |
| bob's facts present in alice's set | fails |
| timestamps parsed as `None` | fails |

The first row is the failure seen on `main`, which still fails. Rows two through four are the counts the model may legitimately produce. Rows five and six are cases the previous assertions failed on for reasons unrelated to the product. The last three are regressions that must still fail.

`ruff check` and `ruff format --check` pass on the file.

The test is gated on `ACTION_API_KEY` and needs a Flink cluster plus a local Ollama embedding model, so it does not run locally without those. Verification of the end-to-end path comes from CI.

### API

No public API change.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`
