### PR TITLE
[infra] Guard uv in e2e.sh and fix the pytest log level in ut.sh

### DIFF
--- a/tools/e2e.sh
+++ b/tools/e2e.sh
@@ -45,7 +45,7 @@ function run_agent_plan_compatibility_test {
     return 1
   fi
 
-  cd "$python_dir" && uv run --no-sync bash ../e2e-test/test-scripts/test_agent_plan_compatibility.sh "$tempdir" "$jar_path"
+  cd "$python_dir" && "${UV[@]}" run --no-sync bash ../e2e-test/test-scripts/test_agent_plan_compatibility.sh "$tempdir" "$jar_path"
 }
 
 function run_cross_language_config_test {
@@ -54,7 +54,7 @@ function run_cross_language_config_test {
     return 1
   fi
 
-  cd "$python_dir" && uv run --no-sync bash ../e2e-test/test-scripts/test_java_config_in_python.sh
+  cd "$python_dir" && "${UV[@]}" run --no-sync bash ../e2e-test/test-scripts/test_java_config_in_python.sh
 }
 
 function run_resource_cross_language_test_in_java {
@@ -66,13 +66,13 @@ function run_resource_cross_language_test_in_java {
   cd "$python_dir"
 
   # Get Python version from uv's virtual environment and set PYTHONPATH
-  local python_version=$(uv run --no-sync python -c "import sys; print(f'python{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null)
+  local python_version=$("${UV[@]}" run --no-sync python -c "import sys; print(f'python{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null)
   if [[ -n "$python_version" ]]; then
     export PYTHONPATH="$python_dir/.venv/lib/$python_version/site-packages:$PYTHONPATH"
     echo "PYTHONPATH set to: $PYTHONPATH"
   fi
 
-  uv run --no-sync bash ../e2e-test/test-scripts/test_resource_cross_language.sh
+  "${UV[@]}" run --no-sync bash ../e2e-test/test-scripts/test_resource_cross_language.sh
 }
 
 function run_resource_cross_language_test_in_python {
@@ -81,7 +81,7 @@ function run_resource_cross_language_test_in_python {
       return 1
     fi
 
-    cd "$python_dir" && uv run --no-sync pytest flink_agents -s -k "e2e_tests_resource_cross_language" --reruns 2 --reruns-delay 5
+    cd "$python_dir" && "${UV[@]}" run --no-sync pytest flink_agents -s -k "e2e_tests_resource_cross_language" --reruns 2 --reruns-delay 5
 }
 
 function run_resource_name_consistency_check {
@@ -90,7 +90,7 @@ function run_resource_name_consistency_check {
     return 1
   fi
 
-  cd "$python_dir" && uv run --no-sync python ../e2e-test/test-scripts/check_resource_consistency.py
+  cd "$python_dir" && "${UV[@]}" run --no-sync python ../e2e-test/test-scripts/check_resource_consistency.py
 }
 
 export TOTAL=0
@@ -120,6 +120,15 @@ if [[ ! -f "uv.lock" ]]; then
 fi
 
 cd ..
+
+if command -v uv >/dev/null 2>&1; then
+  UV=(uv)
+elif python3 -m uv --version >/dev/null 2>&1; then
+  UV=(python3 -m uv)
+else
+  echo "Error: uv not found. Run tools/build.sh first, or install uv." >&2
+  exit 1
+fi
 
 # Create temporary directory with better cross-platform compatibility
 if command -v mktemp >/dev/null 2>&1; then
@@ -153,7 +162,7 @@ if [[ ! -d "$python_dir" ]]; then
 fi
 
 cd "$python_dir"
-uv pip install apache-flink~=${DEFAULT_FLINK_VERSION}.0
+"${UV[@]}" pip install --python .venv apache-flink~=${DEFAULT_FLINK_VERSION}.0
 
 export JVM_ARGS="${JVM_ARGS} --add-exports java.base/jdk.internal.vm=ALL-UNNAMED"
 

--- a/tools/ut.sh
+++ b/tools/ut.sh
@@ -279,10 +279,10 @@ python_tests() {
                 echo "Running tests with pytest..."
             fi
             if $run_e2e; then
-                python3 -m pytest flink_agents -k "e2e_tests_integration" --reruns 2 --reruns-delay 5 -o log_cli=true -o log_cli_level=${LOG_LEVEL:-OFF}
+                python3 -m pytest flink_agents -k "e2e_tests_integration" --reruns 2 --reruns-delay 5 -o log_cli=true -o log_cli_level=${LOG_LEVEL:-CRITICAL}
                 rc1=$?
                 # Arm 2: integration-marked tests; trap exit code 5 as failure.
-                python3 -m pytest flink_agents -m "integration" -o log_cli=true -o log_cli_level=${LOG_LEVEL:-OFF}
+                python3 -m pytest flink_agents -m "integration" -o log_cli=true -o log_cli_level=${LOG_LEVEL:-CRITICAL}
                 rc2=$?
                 if [ $rc2 -eq 5 ]; then rc2=1; fi
                 # Logical-OR aggregation: any nonzero exit on either arm yields testcode=1.
@@ -291,7 +291,7 @@ python_tests() {
                 # on either arm indicates a selector regression).
                 testcode=$((rc1 || rc2))
             else
-                python3 -m pytest flink_agents -k "not e2e_tests" -m "not integration" -o log_cli=true -o log_cli_level=${LOG_LEVEL:-OFF}
+                python3 -m pytest flink_agents -k "not e2e_tests" -m "not integration" -o log_cli=true -o log_cli_level=${LOG_LEVEL:-CRITICAL}
                 testcode=$?
             fi
         fi


### PR DESCRIPTION
Linked issue: #982

### Purpose of change

Two defects in fallback paths that CI never exercises, which is why neither has surfaced before. Both were found while working on #979.

#### `tools/e2e.sh` breaks without `uv` on PATH

It invokes `uv` by bare name seven times and has no `command -v uv` guard anywhere, so a machine without uv on PATH gets seven `uv: command not found` lines and no hint about what to install.

It is the odd one out among the build scripts. `tools/lint.sh` and `tools/ut.sh` both guard their uv usage and fall back to pip, and `tools/build.sh` installs uv before using it. `tools/e2e.sh` does neither. It only delegates to `tools/build.sh` conditionally, and that delegation is skipped once `e2e-test/target` and `python/uv.lock` exist.

So it now probes once, after the build delegation so that a build performed in the same run counts:

```bash
if command -v uv >/dev/null 2>&1; then
  UV=(uv)
elif python3 -m uv --version >/dev/null 2>&1; then
  UV=(python3 -m uv)
else
  echo "Error: uv not found. Run tools/build.sh first, or install uv." >&2
  exit 1
fi
```

The binary on PATH has to win over the module. A standalone uv, from the curl installer or homebrew, gives a working binary and no importable `uv` module, so preferring the module would break exactly those installs.

The module branch tests uv by *running* it rather than by importing it. `uv/__init__.py` imports `find_uv_bin` without calling it, and the five-directory search for the binary happens at call time inside `uv/__main__.py`. So `import uv` succeeds even when the binary is missing, and a probe built on it would select a module that then fails at all seven sites, relocating the very failure this change removes.

The `uv pip install` site also names its target environment. `uv pip` honors the `VIRTUAL_ENV` that uv's module entry point derives from the calling interpreter, so without `--python .venv` the fallback could install `apache-flink` outside the venv the tests actually run in. `tools/build.sh` already does the same at its own wheel install.

#### `tools/ut.sh` passes a log level pytest rejects

The pip fallback passed `-o log_cli_level=${LOG_LEVEL:-OFF}` while the uv branch in the same function passed `${LOG_LEVEL:-CRITICAL}`. `OFF` is not a Python logging level name, so pytest rejects it during startup:

```
ERROR: 'OFF' is not recognized as a logging level name for 'log_cli_level'. Please consider passing the logging level num instead.
```

That is exit 4, raised before any test is collected, which `ut.sh` then reports through its "unknown error" arm. Aligning the fallback with the uv branch lets the path run.

### Tests

CI behavior is unchanged. `LOG_LEVEL: INFO` is set at four workflow sites, and the two Python jobs that fall back to the default take the uv branch, which already used `CRITICAL`. The runners also provide uv on PATH, so the probe selects the same binary the script used before.

The probe was exercised across every combination of binary and module availability:

| uv on PATH | module importable | binary findable | Selected | Exit |
| --- | --- | --- | --- | --- |
| yes | yes | yes | `uv` | 0 |
| yes | no | n/a | `uv` | 0 |
| no | yes | yes | `python3 -m uv` | 0 |
| no | no | n/a | error | 1 |
| no | yes | **no** | error | 1 |

The last row is the case that motivated testing the module by running it. With an import-based probe it selected `python3 -m uv` and exited 0, then failed at the first real call site.

Argument passing was checked at all seven sites against the previous version with a stub on PATH, including the one inside a command substitution and the ones in `cd ... &&` chains. Byte-identical under both probe branches.

For `tools/ut.sh`, the fallback path previously exited 4 with nothing collected. It now collects 375 tests and 293 pass locally. The rest are `apache-flink~=2.3.0` being uninstallable on macOS arm64, since no `apache-beam` wheel at the required version exists for that platform. That is environmental and unrelated to this change, so this fixes the first blocker on that path rather than making it green everywhere.

`bash -n` passes on both scripts, and shellcheck reports the same finding set before and after, with nothing landing on the new block.

### API

No API change.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

