### PR TITLE
[hotfix][runtime][python] Close every component when an earlier close fails

### DIFF
--- a/python/flink_agents/runtime/resource_cache.py
+++ b/python/flink_agents/runtime/resource_cache.py
@@ -15,6 +15,8 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 #################################################################################
+import logging
+from collections.abc import Callable
 from typing import Any, Dict
 
 from flink_agents.api.resource import Resource, ResourceType
@@ -23,6 +25,38 @@ from flink_agents.plan.function import JavaFunction
 from flink_agents.plan.resource_provider import JavaResourceProvider, ResourceProvider
 from flink_agents.plan.tools.function_tool import FunctionTool
 from flink_agents.runtime.resource_context import ResourceContextImpl
+
+_LOG = logging.getLogger(__name__)
+
+
+def _failure_of(close: Callable[[], None]) -> Exception | None:
+    """Run ``close``, returning any failure instead of raising it.
+
+    Keeps the caller's cleanup loop free of a ``try`` block so one bad component
+    cannot end the iteration.
+    """
+    try:
+        close()
+    except Exception as e:
+        return e
+    return None
+
+
+def _first_or_logged(
+    failure: Exception | None, previous: Exception | None, what: str
+) -> Exception | None:
+    """Keep the first failure and log any later one.
+
+    The Python analogue of Flink's ``ExceptionUtils.firstOrSuppressed``. Later
+    failures are logged rather than attached, because ``ExceptionGroup`` requires
+    3.11 and this package supports 3.10.
+    """
+    if failure is None:
+        return previous
+    if previous is None:
+        return failure
+    _LOG.warning("Suppressed failure closing %s.", what, exc_info=failure)
+    return previous
 
 
 class ResourceCache:
@@ -100,9 +134,29 @@ class ResourceCache:
         cached ``SkillManager`` (releasing materialized skill temp dirs). This
         is what releases skill resources on operator close, including Flink
         failover when the JVM stays up.
+
+        Every resource is closed even when an earlier one fails, so a single bad
+        resource cannot strand the ones behind it, the cache clear, or the
+        resource context. The first failure is re-raised; later ones are logged.
+
+        This mirrors the Java ``ResourceCache.close()`` contract. Two differences
+        are deliberate. Java catches ``Throwable`` to keep a non-``Exception``
+        failure from stopping the loop; the Python equivalent is ``Exception``,
+        since it already covers what Java calls ``Error`` (``MemoryError`` and
+        friends) while ``BaseException`` would also swallow ``KeyboardInterrupt``
+        and ``SystemExit``, which cleanup must not do. And Java attaches later
+        failures with ``addSuppressed``; ``ExceptionGroup`` needs 3.11 and this
+        package supports 3.10, so later failures are logged instead of attached.
         """
+        first_failure: Exception | None = None
         for typed in self._cache.values():
             for resource in typed.values():
-                resource.close()
+                first_failure = _first_or_logged(
+                    _failure_of(resource.close), first_failure, "resource"
+                )
         self._cache.clear()
-        self._resource_context.close()
+        first_failure = _first_or_logged(
+            _failure_of(self._resource_context.close), first_failure, "resource context"
+        )
+        if first_failure is not None:
+            raise first_failure

--- a/python/flink_agents/runtime/tests/test_resource_cache_close.py
+++ b/python/flink_agents/runtime/tests/test_resource_cache_close.py
@@ -1,0 +1,130 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+"""Close-path contract tests for the Python ResourceCache.
+
+These mirror the Java ``ResourceCacheTest`` close tests: a failing resource must
+not strand the resources behind it, the cache clear, or the resource context.
+"""
+
+import pytest
+
+from flink_agents.api.resource import Resource, ResourceType
+from flink_agents.runtime.resource_cache import ResourceCache
+
+
+class RecordingResource(Resource):
+    """Records whether ``close()`` ran, and optionally fails it."""
+
+    closed: bool = False
+    failure: Exception | None = None
+
+    @classmethod
+    def resource_type(cls) -> ResourceType:
+        return ResourceType.TOOL
+
+    def close(self) -> None:
+        """Record the call, then fail if this resource was configured to."""
+        self.closed = True
+        if self.failure is not None:
+            raise self.failure
+
+
+class RecordingContext:
+    """Stands in for the resource context so its close is observable."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        """Record that the cache reached the resource context."""
+        self.closed = True
+
+
+def _cache_with(*resources: RecordingResource) -> tuple[ResourceCache, RecordingContext]:
+    cache = ResourceCache({})
+    context = RecordingContext()
+    cache._resource_context = context
+    for i, resource in enumerate(resources):
+        cache._cache.setdefault(ResourceType.TOOL, {})[f"r{i}"] = resource
+    return cache, context
+
+
+def test_close_closes_every_resource_when_an_earlier_one_fails() -> None:
+    """A failing resource must not strand the ones behind it.
+
+    The cache clear and the resource context close are on the same straight
+    line behind the failure, so both are asserted rather than assumed.
+    """
+    failure = RuntimeError("resource close failed")
+    failing = RecordingResource(failure=failure)
+    surviving = RecordingResource()
+    cache, context = _cache_with(failing, surviving)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        cache.close()
+
+    # The failure reaches the caller unchanged in identity, not wrapped.
+    assert excinfo.value is failure
+    assert failing.closed
+    assert surviving.closed
+    assert cache._cache == {}
+    assert context.closed
+
+
+def test_close_reports_first_failure_when_several_fail() -> None:
+    """The first failure is the one raised; later ones do not replace it."""
+    first = RuntimeError("first")
+    second = RuntimeError("second")
+    cache, context = _cache_with(
+        RecordingResource(failure=first), RecordingResource(failure=second)
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        cache.close()
+
+    assert excinfo.value is first
+    assert context.closed
+
+
+def test_close_reports_resource_context_failure() -> None:
+    """A resource context failure surfaces when no resource failed before it."""
+    cache, context = _cache_with(RecordingResource())
+    failure = RuntimeError("resource context close failed")
+
+    def failing_close() -> None:
+        context.closed = True
+        raise failure
+
+    context.close = failing_close  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError) as excinfo:
+        cache.close()
+
+    assert excinfo.value is failure
+
+
+def test_close_returns_normally_when_nothing_fails() -> None:
+    """The healthy path stays a plain no-raise close."""
+    surviving = RecordingResource()
+    cache, context = _cache_with(surviving)
+
+    cache.close()
+
+    assert surviving.closed
+    assert cache._cache == {}
+    assert context.closed

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/ResourceCache.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/ResourceCache.java
@@ -25,6 +25,7 @@ import org.apache.flink.agents.plan.resourceprovider.PythonResourceProvider;
 import org.apache.flink.agents.plan.resourceprovider.ResourceProvider;
 import org.apache.flink.agents.plan.tools.FunctionTool;
 import org.apache.flink.agents.runtime.resource.ResourceContextImpl;
+import org.apache.flink.util.ExceptionUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -158,32 +159,32 @@ public class ResourceCache implements AutoCloseable {
 
     @Override
     public void close() throws Exception {
-        Exception firstException = null;
+        // Close every cached resource, then the resource context, even when an earlier close
+        // fails. The first failure is rethrown with the later ones suppressed.
+        //
+        // The ladders catch Throwable, not Exception: ActionExecutionOperator.close() closes this
+        // cache before the Python interpreter because cached resources may hold Python references,
+        // so a non-Exception Throwable escaping here would leave the remaining resources open
+        // while the interpreter behind them is torn down anyway. ExceptionUtils.rethrowException
+        // passes Error and Exception through unchanged, so the caller still sees the original.
+        Throwable firstFailure = null;
         for (Map<String, Resource> resources : cache.values()) {
             for (Resource resource : resources.values()) {
                 try {
                     resource.close();
-                } catch (Exception e) {
-                    if (firstException == null) {
-                        firstException = e;
-                    } else {
-                        firstException.addSuppressed(e);
-                    }
+                } catch (Throwable t) {
+                    firstFailure = ExceptionUtils.firstOrSuppressed(t, firstFailure);
                 }
             }
         }
         cache.clear();
         try {
             resourceContext.close();
-        } catch (Exception e) {
-            if (firstException == null) {
-                firstException = e;
-            } else {
-                firstException.addSuppressed(e);
-            }
+        } catch (Throwable t) {
+            firstFailure = ExceptionUtils.firstOrSuppressed(t, firstFailure);
         }
-        if (firstException != null) {
-            throw firstException;
+        if (firstFailure != null) {
+            ExceptionUtils.rethrowException(firstFailure);
         }
     }
 }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -591,24 +591,38 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
 
     @Override
     public void close() throws Exception {
-        // Must close before pythonInterpreter since cached resources may hold Python references.
-        if (resourceCache != null) {
-            resourceCache.close();
-        }
-        if (contextManager != null) {
-            contextManager.close();
-        }
-        if (pythonBridge != null) {
-            pythonBridge.close();
-        }
-        if (eventLogWriter != null) {
-            eventLogWriter.close();
-        }
-        if (durableExecManager != null) {
-            durableExecManager.close();
+        // Close every component even when an earlier one fails, so a failing close cannot leak
+        // the components behind it or skip super.close(). The first failure is rethrown with
+        // the later ones suppressed. Order is preserved: the resource cache must close before
+        // pythonInterpreter since cached resources may hold Python references.
+        //
+        // The ladder catches Throwable, not Exception, and IOUtils.closeAll is deliberately not
+        // used: both stop at the first non-Exception Throwable without closing what follows,
+        // which is the very leak this method has to avoid.
+        Throwable firstFailure = null;
+        for (AutoCloseable closeable :
+                new AutoCloseable[] {
+                    resourceCache, contextManager, pythonBridge, eventLogWriter, durableExecManager
+                }) {
+            if (closeable == null) {
+                continue;
+            }
+            try {
+                closeable.close();
+            } catch (Throwable t) {
+                firstFailure = ExceptionUtils.firstOrSuppressed(t, firstFailure);
+            }
         }
 
-        super.close();
+        try {
+            super.close();
+        } catch (Throwable t) {
+            firstFailure = ExceptionUtils.firstOrSuppressed(t, firstFailure);
+        }
+
+        if (firstFailure != null) {
+            ExceptionUtils.rethrowException(firstFailure);
+        }
     }
 
     @Override

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionTaskContextManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionTaskContextManager.java
@@ -35,6 +35,7 @@ import org.apache.flink.agents.runtime.python.context.PythonRunnerContextImpl;
 import org.apache.flink.agents.runtime.trace.ExecutionEventSink;
 import org.apache.flink.agents.runtime.trace.ReportedExecutionKey;
 import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.util.ExceptionUtils;
 
 import javax.annotation.Nullable;
 
@@ -350,15 +351,31 @@ class ActionTaskContextManager implements AutoCloseable {
 
     @Override
     public void close() throws Exception {
+        // Close the continuation executor even when the runner context fails to close. The first
+        // failure is rethrown with the later one suppressed.
+        //
+        // The ladder catches Throwable, not Exception, so a non-Exception Throwable from the
+        // runner context cannot strand the executor's thread pool. Neither type implements
+        // AutoCloseable, so the aggregation is spelled out rather than delegated.
+        Throwable firstFailure = null;
         if (runnerContext != null) {
             try {
                 runnerContext.close();
+            } catch (Throwable t) {
+                firstFailure = t;
             } finally {
                 runnerContext = null;
             }
         }
         if (continuationActionExecutor != null) {
-            continuationActionExecutor.close();
+            try {
+                continuationActionExecutor.close();
+            } catch (Throwable t) {
+                firstFailure = ExceptionUtils.firstOrSuppressed(t, firstFailure);
+            }
+        }
+        if (firstFailure != null) {
+            ExceptionUtils.rethrowException(firstFailure);
         }
     }
 }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionTaskContextManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionTaskContextManager.java
@@ -356,13 +356,15 @@ class ActionTaskContextManager implements AutoCloseable {
         //
         // The ladder catches Throwable, not Exception, so a non-Exception Throwable from the
         // runner context cannot strand the executor's thread pool. Neither type implements
-        // AutoCloseable, so the aggregation is spelled out rather than delegated.
+        // AutoCloseable, so the aggregation is spelled out rather than delegated. Both rungs go
+        // through firstOrSuppressed even though the first one cannot yet have a previous failure,
+        // so that a close inserted above it later suppresses rather than overwrites.
         Throwable firstFailure = null;
         if (runnerContext != null) {
             try {
                 runnerContext.close();
             } catch (Throwable t) {
-                firstFailure = t;
+                firstFailure = ExceptionUtils.firstOrSuppressed(t, firstFailure);
             } finally {
                 runnerContext = null;
             }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PythonBridgeManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PythonBridgeManager.java
@@ -36,6 +36,7 @@ import org.apache.flink.agents.runtime.python.utils.PythonResourceAdapterImpl;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.python.env.PythonDependencyInfo;
+import org.apache.flink.util.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pemja.core.PythonInterpreter;
@@ -315,14 +316,29 @@ class PythonBridgeManager implements AutoCloseable {
 
     @Override
     public void close() throws Exception {
-        if (pythonActionExecutor != null) {
-            pythonActionExecutor.close();
+        // Close every component even when an earlier one fails, so a failing action executor
+        // cannot leak the interpreter or the environment manager. The first failure is
+        // rethrown with the later ones suppressed.
+        //
+        // The ladder catches Throwable, not Exception, and IOUtils.closeAll is deliberately not
+        // used: both stop at the first non-Exception Throwable without closing what follows, and
+        // what follows here is the native Python state.
+        Throwable firstFailure = null;
+        for (AutoCloseable closeable :
+                new AutoCloseable[] {
+                    pythonActionExecutor, pythonInterpreter, pythonEnvironmentManager
+                }) {
+            if (closeable == null) {
+                continue;
+            }
+            try {
+                closeable.close();
+            } catch (Throwable t) {
+                firstFailure = ExceptionUtils.firstOrSuppressed(t, firstFailure);
+            }
         }
-        if (pythonInterpreter != null) {
-            pythonInterpreter.close();
-        }
-        if (pythonEnvironmentManager != null) {
-            pythonEnvironmentManager.close();
+        if (firstFailure != null) {
+            ExceptionUtils.rethrowException(firstFailure);
         }
     }
 }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutor.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutor.java
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /** Execute the corresponding Python action in the agent. */
-public class PythonActionExecutor {
+public class PythonActionExecutor implements AutoCloseable {
 
     private static final String PYTHON_IMPORTS =
             "from flink_agents.plan import function\n"
@@ -201,6 +201,7 @@ public class PythonActionExecutor {
         return (boolean) ((Object[]) invokeResult)[0];
     }
 
+    @Override
     public void close() throws Exception {
         if (interpreter != null) {
             if (pythonAsyncThreadPool != null) {

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutor.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutor.java
@@ -25,6 +25,7 @@ import org.apache.flink.agents.plan.AgentPlan;
 import org.apache.flink.agents.plan.PythonFunction;
 import org.apache.flink.agents.runtime.python.context.PythonRunnerContextImpl;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.ExceptionUtils;
 import pemja.core.PythonInterpreter;
 import pemja.core.object.PyObject;
 
@@ -203,18 +204,33 @@ public class PythonActionExecutor implements AutoCloseable {
 
     @Override
     public void close() throws Exception {
-        if (interpreter != null) {
-            if (pythonAsyncThreadPool != null) {
+        // The two Python-side cleanups are independent, so attempt both even when the first
+        // fails. Skipping the runner-context cleanup leaves that context's long-term memory and
+        // resource cache unreleased, and PythonBridgeManager closes the interpreter right behind
+        // us, so there is no later chance to run it. The first failure is rethrown with the later
+        // one suppressed, matching the ladders in the managers above.
+        if (interpreter == null) {
+            return;
+        }
+        Throwable firstFailure = null;
+        if (pythonAsyncThreadPool != null) {
+            try {
                 interpreter.invoke(CLOSE_ASYNC_THREAD_POOL, pythonAsyncThreadPool);
+            } catch (Throwable t) {
+                firstFailure = ExceptionUtils.firstOrSuppressed(t, firstFailure);
             }
-
-            if (pythonRunnerContext != null) {
-                try {
-                    interpreter.invoke(CLOSE_FLINK_RUNNER_CONTEXT, pythonRunnerContext);
-                } finally {
-                    pythonRunnerContext = null;
-                }
+        }
+        if (pythonRunnerContext != null) {
+            try {
+                interpreter.invoke(CLOSE_FLINK_RUNNER_CONTEXT, pythonRunnerContext);
+            } catch (Throwable t) {
+                firstFailure = ExceptionUtils.firstOrSuppressed(t, firstFailure);
+            } finally {
+                pythonRunnerContext = null;
             }
+        }
+        if (firstFailure != null) {
+            ExceptionUtils.rethrowException(firstFailure);
         }
     }
 

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/skill/SkillManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/skill/SkillManager.java
@@ -20,6 +20,7 @@ package org.apache.flink.agents.runtime.skill;
 
 import org.apache.flink.agents.api.skills.SkillSourceSpec;
 import org.apache.flink.agents.api.skills.Skills;
+import org.apache.flink.util.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -211,7 +212,8 @@ public class SkillManager implements AutoCloseable {
      * <p>Mirrors {@code ResourceCache.close()}: the first failure is rethrown after every repo has
      * been attempted, with subsequent failures attached as suppressed exceptions. This surfaces
      * real shutdown bugs (locked files, permission denied, disk full) instead of silently
-     * swallowing them.
+     * swallowing them. As there, a non-{@code Exception} {@code Throwable} does not stop the
+     * remaining repos, and reaches the caller unwrapped.
      */
     @Override
     public void close() throws Exception {
@@ -225,20 +227,20 @@ public class SkillManager implements AutoCloseable {
         // contributes multiple skills.
         Set<SkillRepository> unique = Collections.newSetFromMap(new IdentityHashMap<>());
         unique.addAll(openedRepos);
-        Exception firstException = null;
+        // Catches Throwable, not Exception: a repo failing with an Error would otherwise skip the
+        // repos behind it, and ResourceContextImpl.close() clears its manager reference in a
+        // finally, so nothing can retry the ones that were skipped. This is the nested branch of
+        // the close-all guarantee that ResourceCache.close() makes one level up.
+        Throwable firstFailure = null;
         for (SkillRepository repo : unique) {
             try {
                 repo.close();
-            } catch (Exception e) {
-                if (firstException == null) {
-                    firstException = e;
-                } else {
-                    firstException.addSuppressed(e);
-                }
+            } catch (Throwable t) {
+                firstFailure = ExceptionUtils.firstOrSuppressed(t, firstFailure);
             }
         }
-        if (firstException != null) {
-            throw firstException;
+        if (firstFailure != null) {
+            ExceptionUtils.rethrowException(firstFailure);
         }
     }
 

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/ResourceCacheTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/ResourceCacheTest.java
@@ -34,12 +34,17 @@ import org.apache.flink.agents.api.resource.ResourceType;
 import org.apache.flink.agents.api.resource.SerializableResource;
 import org.apache.flink.agents.api.resource.python.PythonResourceAdapter;
 import org.apache.flink.agents.api.resource.python.PythonResourceWrapper;
+import org.apache.flink.agents.api.skills.SkillSourceSpec;
+import org.apache.flink.agents.api.skills.Skills;
 import org.apache.flink.agents.api.vectorstores.Document;
 import org.apache.flink.agents.api.vectorstores.VectorStoreQuery;
 import org.apache.flink.agents.api.vectorstores.VectorStoreQueryResult;
 import org.apache.flink.agents.plan.AgentPlan;
 import org.apache.flink.agents.runtime.resource.ResourceContextImpl;
+import org.apache.flink.agents.runtime.skill.AgentSkill;
 import org.apache.flink.agents.runtime.skill.SkillManager;
+import org.apache.flink.agents.runtime.skill.SkillRepository;
+import org.apache.flink.agents.runtime.skill.SkillSourceRegistry;
 import org.junit.jupiter.api.Test;
 import pemja.core.object.PyObject;
 
@@ -47,6 +52,7 @@ import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -336,6 +342,87 @@ public class ResourceCacheTest {
                 .containsExactlyInAnyOrder("first", "second");
         assertThat(first.closed).isTrue();
         assertThat(second.closed).isTrue();
+    }
+
+    /**
+     * The close-all guarantee has to reach the nested skill repositories, not stop at {@code
+     * ResourceContextImpl}. Exercised through the real production path — {@code
+     * ResourceCache.close()} → {@code ResourceContextImpl.close()} → {@code SkillManager.close()} →
+     * the repos — because {@code ResourceContextImpl} clears its manager reference in a {@code
+     * finally}, so a repo skipped here can never be retried and leaks its temp directory.
+     */
+    @Test
+    public void closeClosesEverySkillRepositoryWhenAnEarlierRepoThrowsError() throws Exception {
+        // Both repos fail, so the assertions do not depend on the de-dup set's iteration order:
+        // a handler narrowed to Exception anywhere along the chain stops at whichever runs first
+        // and leaves the other unclosed, which fails here either way round.
+        Error firstBoom = new Error("repo close failed");
+        Error secondBoom = new Error("other repo close failed");
+        RecordingRepo failing = new RecordingRepo("alpha", firstBoom);
+        RecordingRepo surviving = new RecordingRepo("beta", secondBoom);
+        AtomicInteger seq = new AtomicInteger();
+        List<RecordingRepo> ordered = List.of(failing, surviving);
+        SkillSourceRegistry.register(
+                "test-resource-cache-close-error",
+                (params, cl) -> ordered.get(seq.getAndIncrement()));
+        Skills skills =
+                new Skills(
+                        List.of(
+                                new SkillSourceSpec("test-resource-cache-close-error", Map.of()),
+                                new SkillSourceSpec("test-resource-cache-close-error", Map.of())));
+
+        ResourceCache cache = new ResourceCache(new HashMap<>());
+        cache.put(Skills.SKILLS_CONFIG, ResourceType.SKILLS, skills);
+        // Force the lazily-cached SkillManager to exist, so close() has repos to release.
+        cache.getResourceContext().getSkillDirs(List.of("alpha"));
+
+        // The Error reaches the caller unwrapped, through both intervening close() methods.
+        Throwable thrown = catchThrowable(cache::close);
+
+        assertThat(thrown).isInstanceOf(Error.class);
+        assertThat(failing.closed).isTrue();
+        assertThat(surviving.closed).isTrue();
+        assertThat(thrown.getSuppressed()).hasSize(1);
+        assertThat(List.of(thrown, thrown.getSuppressed()[0]))
+                .containsExactlyInAnyOrder(firstBoom, secondBoom);
+    }
+
+    /** A skill repository that records its close and can be made to fail it. */
+    private static final class RecordingRepo implements SkillRepository {
+        private final AgentSkill skill;
+        private final Throwable failure;
+        private boolean closed = false;
+
+        private RecordingRepo(String skillName, Throwable failure) {
+            this.skill = new AgentSkill(skillName, "fake", "body", null, null, null);
+            this.failure = failure;
+        }
+
+        @Override
+        public AgentSkill getSkill(String name) {
+            return name.equals(skill.getName()) ? skill : null;
+        }
+
+        @Override
+        public List<AgentSkill> getSkills() {
+            return List.of(skill);
+        }
+
+        @Override
+        public Map<String, String> getResources(String name) {
+            return Map.of();
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+            if (failure instanceof Error) {
+                throw (Error) failure;
+            }
+            if (failure instanceof RuntimeException) {
+                throw (RuntimeException) failure;
+            }
+        }
     }
 
     private static void setSkillManager(ResourceContextImpl context, SkillManager skillManager)

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/ResourceCacheTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/ResourceCacheTest.java
@@ -38,14 +38,21 @@ import org.apache.flink.agents.api.vectorstores.Document;
 import org.apache.flink.agents.api.vectorstores.VectorStoreQuery;
 import org.apache.flink.agents.api.vectorstores.VectorStoreQueryResult;
 import org.apache.flink.agents.plan.AgentPlan;
+import org.apache.flink.agents.runtime.resource.ResourceContextImpl;
+import org.apache.flink.agents.runtime.skill.SkillManager;
 import org.junit.jupiter.api.Test;
 import pemja.core.object.PyObject;
 
+import java.lang.reflect.Field;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /** Tests for {@link ResourceCache}. */
 public class ResourceCacheTest {
@@ -273,5 +280,101 @@ public class ResourceCacheTest {
         // Test that resources are cached (should be the same instance)
         Resource myToolAgain = cache.getResource("myTool", ResourceType.TOOL);
         assertThat(myTool).isSameAs(myToolAgain);
+    }
+
+    /**
+     * A cached resource failing with a non-{@code Exception} {@code Throwable} must not strand the
+     * remaining resources, the cache clear, or the resource context. {@code
+     * ActionExecutionOperator.close()} closes this cache before the Python interpreter precisely
+     * because cached resources may hold Python references, so leaving resources open here while the
+     * interpreter behind them is torn down would break that ordering.
+     */
+    @Test
+    public void closeClosesEveryResourceWhenAnEarlierResourceThrowsError() throws Exception {
+        ResourceCache cache = new ResourceCache(new HashMap<>());
+        OutOfMemoryError failure = new OutOfMemoryError("resource close failed");
+        RecordingResource failing = new RecordingResource(ResourceType.TOOL, failure);
+        RecordingResource surviving = new RecordingResource(ResourceType.CHAT_MODEL, null);
+        cache.put("failing", ResourceType.TOOL, failing);
+        cache.put("surviving", ResourceType.CHAT_MODEL, surviving);
+        // Stands in for the lazily-cached skill manager, so that resourceContext.close() running
+        // is observable rather than merely assumed from its position in the method.
+        SkillManager skillManager = mock(SkillManager.class);
+        setSkillManager(cache.getResourceContext(), skillManager);
+
+        // The Error reaches the caller unchanged rather than wrapped in an Exception.
+        assertThatThrownBy(cache::close).isSameAs(failure);
+
+        assertThat(failing.closed).isTrue();
+        assertThat(surviving.closed).isTrue();
+        // Neither the cache clear nor the resource context is skipped by the Error.
+        assertThat(cachedResources(cache)).isEmpty();
+        verify(skillManager).close();
+    }
+
+    /** The first failure is rethrown and any later one is attached as suppressed, never dropped. */
+    @Test
+    public void closeReportsFirstResourceFailureWithLaterOnesSuppressed() throws Exception {
+        ResourceCache cache = new ResourceCache(new HashMap<>());
+        RecordingResource first =
+                new RecordingResource(ResourceType.TOOL, new IllegalStateException("first"));
+        RecordingResource second =
+                new RecordingResource(ResourceType.TOOL, new IllegalStateException("second"));
+        cache.put("first", ResourceType.TOOL, first);
+        cache.put("second", ResourceType.TOOL, second);
+
+        Throwable thrown = catchThrowable(cache::close);
+
+        // Iteration order over the cache is unspecified, so pin the aggregation rather than which
+        // of the two lands first: one is thrown and the other is suppressed on it.
+        assertThat(thrown).isInstanceOf(IllegalStateException.class);
+        assertThat(thrown.getSuppressed()).hasSize(1);
+        assertThat(new String[] {thrown.getMessage(), thrown.getSuppressed()[0].getMessage()})
+                .containsExactlyInAnyOrder("first", "second");
+        assertThat(first.closed).isTrue();
+        assertThat(second.closed).isTrue();
+    }
+
+    private static void setSkillManager(ResourceContextImpl context, SkillManager skillManager)
+            throws Exception {
+        Field field = ResourceContextImpl.class.getDeclaredField("skillManager");
+        field.setAccessible(true);
+        field.set(context, skillManager);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<ResourceType, Map<String, Resource>> cachedResources(ResourceCache cache)
+            throws Exception {
+        Field field = ResourceCache.class.getDeclaredField("cache");
+        field.setAccessible(true);
+        return (Map<ResourceType, Map<String, Resource>>) field.get(cache);
+    }
+
+    /** Records whether {@code close()} ran, and optionally fails it. */
+    private static final class RecordingResource extends Resource {
+        private final ResourceType type;
+        private final Throwable failure;
+        private boolean closed = false;
+
+        private RecordingResource(ResourceType type, Throwable failure) {
+            this.type = type;
+            this.failure = failure;
+        }
+
+        @Override
+        public ResourceType getResourceType() {
+            return type;
+        }
+
+        @Override
+        public void close() throws Exception {
+            closed = true;
+            if (failure instanceof Error) {
+                throw (Error) failure;
+            }
+            if (failure instanceof Exception) {
+                throw (Exception) failure;
+            }
+        }
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/ResourceCacheTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/ResourceCacheTest.java
@@ -302,8 +302,11 @@ public class ResourceCacheTest {
         SkillManager skillManager = mock(SkillManager.class);
         setSkillManager(cache.getResourceContext(), skillManager);
 
-        // The Error reaches the caller unchanged rather than wrapped in an Exception.
-        assertThatThrownBy(cache::close).isSameAs(failure);
+        // The Error reaches the caller unchanged rather than wrapped in an Exception, and with
+        // nothing attached to it.
+        assertThatThrownBy(cache::close)
+                .isSameAs(failure)
+                .satisfies(thrown -> assertThat(thrown.getSuppressed()).isEmpty());
 
         assertThat(failing.closed).isTrue();
         assertThat(surviving.closed).isTrue();

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperatorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperatorTest.java
@@ -62,6 +62,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorStateHandler;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
@@ -71,6 +73,7 @@ import org.apache.flink.util.ExceptionUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -93,8 +96,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 /** Tests for {@link ActionExecutionOperator}. */
 public class ActionExecutionOperatorTest {
@@ -628,53 +631,159 @@ public class ActionExecutionOperatorTest {
     }
 
     /**
-     * A failing component must not strand the ones behind it. This matters most for {@code
-     * resourceCache}, which closes first and aggregates its own failures, and for {@code
-     * pythonBridge}, which releases the embedded Python interpreter.
+     * Swaps the state handler {@link AbstractStreamOperator} inherits, returning the previous one.
+     *
+     * <p>{@code super.close()} compiles to {@code stateHandler.dispose()} and binds statically, so
+     * a subclass cannot intercept the call. Replacing the inherited handler is what makes the super
+     * call observable, and what lets it be made to fail.
      */
-    @Test
-    void closeClosesEveryComponentWhenAnEarlierCloseFails() throws Exception {
+    private static StreamOperatorStateHandler replaceStateHandler(
+            ActionExecutionOperator<?, ?> operator, StreamOperatorStateHandler handler)
+            throws Exception {
+        Field field = AbstractStreamOperator.class.getDeclaredField("stateHandler");
+        field.setAccessible(true);
+        StreamOperatorStateHandler previous = (StreamOperatorStateHandler) field.get(operator);
+        field.set(operator, handler);
+        return previous;
+    }
+
+    private static KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> openCloseTestHarness()
+            throws Exception {
         KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> testHarness =
                 new KeyedOneInputStreamOperatorTestHarness<>(
                         new ActionExecutionOperatorFactory(TestAgent.getAgentPlan(false), true),
                         (KeySelector<Long, Long>) value -> value,
                         TypeInformation.of(Long.class));
         testHarness.open();
+        return testHarness;
+    }
+
+    /** The operator's five closeable components, stubbed so each close is observable. */
+    private static final class CloseComponents {
+        private final ResourceCache resourceCache = mock(ResourceCache.class);
+        private final ActionTaskContextManager contextManager =
+                mock(ActionTaskContextManager.class);
+        private final PythonBridgeManager pythonBridge = mock(PythonBridgeManager.class);
+        private final EventLogWriter eventLogWriter = mock(EventLogWriter.class);
+        private final DurableExecutionManager durableExecManager =
+                mock(DurableExecutionManager.class);
+
+        private void installInto(ActionExecutionOperator<?, ?> operator) throws Exception {
+            replaceOperatorField(operator, "resourceCache", resourceCache);
+            replaceOperatorField(operator, "contextManager", contextManager);
+            replaceOperatorField(operator, "pythonBridge", pythonBridge);
+            replaceOperatorField(operator, "eventLogWriter", eventLogWriter);
+            replaceOperatorField(operator, "durableExecManager", durableExecManager);
+        }
+
+        /** Detaches the mocks so the harness teardown does not re-trigger the failure. */
+        private void detachFrom(ActionExecutionOperator<?, ?> operator) throws Exception {
+            replaceOperatorField(operator, "resourceCache", null);
+            replaceOperatorField(operator, "contextManager", null);
+            replaceOperatorField(operator, "pythonBridge", null);
+            replaceOperatorField(operator, "eventLogWriter", null);
+            replaceOperatorField(operator, "durableExecManager", null);
+        }
+
+        /**
+         * Verifies every component was released, in the documented order, with {@code
+         * super.close()} last.
+         *
+         * <p>Order is load-bearing rather than incidental: {@code resourceCache} must close before
+         * {@code pythonBridge} because cached resources may hold Python references, and {@code
+         * super.close()} disposes the state backends the components run against.
+         */
+        private void verifyClosedInOrder(StreamOperatorStateHandler stateHandler) throws Exception {
+            InOrder inOrder =
+                    inOrder(
+                            resourceCache,
+                            contextManager,
+                            pythonBridge,
+                            eventLogWriter,
+                            durableExecManager,
+                            stateHandler);
+            inOrder.verify(resourceCache).close();
+            inOrder.verify(contextManager).close();
+            inOrder.verify(pythonBridge).close();
+            inOrder.verify(eventLogWriter).close();
+            inOrder.verify(durableExecManager).close();
+            inOrder.verify(stateHandler).dispose();
+        }
+    }
+
+    /**
+     * A failing component must not strand the ones behind it. This matters most for {@code
+     * resourceCache}, which closes first and aggregates its own failures, and for {@code
+     * pythonBridge}, which releases the embedded Python interpreter.
+     *
+     * <p>Also pins that {@code super.close()} still runs. {@link AbstractStreamOperator#close()}
+     * disposes the state handler, so skipping it strands the state backends.
+     */
+    @Test
+    void closeClosesEveryComponentWhenAnEarlierCloseFails() throws Exception {
+        KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> testHarness =
+                openCloseTestHarness();
         ActionExecutionOperator<Long, Object> operator =
                 (ActionExecutionOperator<Long, Object>) testHarness.getOperator();
 
-        ResourceCache resourceCache = mock(ResourceCache.class);
-        ActionTaskContextManager contextManager = mock(ActionTaskContextManager.class);
-        PythonBridgeManager pythonBridge = mock(PythonBridgeManager.class);
-        EventLogWriter eventLogWriter = mock(EventLogWriter.class);
-        DurableExecutionManager durableExecManager = mock(DurableExecutionManager.class);
+        CloseComponents components = new CloseComponents();
         doThrow(new IllegalStateException("resource cache close failed"))
-                .when(resourceCache)
+                .when(components.resourceCache)
                 .close();
-
-        replaceOperatorField(operator, "resourceCache", resourceCache);
-        replaceOperatorField(operator, "contextManager", contextManager);
-        replaceOperatorField(operator, "pythonBridge", pythonBridge);
-        replaceOperatorField(operator, "eventLogWriter", eventLogWriter);
-        replaceOperatorField(operator, "durableExecManager", durableExecManager);
+        components.installInto(operator);
+        StreamOperatorStateHandler stateHandler = mock(StreamOperatorStateHandler.class);
+        StreamOperatorStateHandler realStateHandler = replaceStateHandler(operator, stateHandler);
 
         try {
             assertThatThrownBy(operator::close)
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("resource cache close failed");
 
-            // The components behind the failing one are still released.
-            verify(contextManager).close();
-            verify(pythonBridge).close();
-            verify(eventLogWriter).close();
-            verify(durableExecManager).close();
+            components.verifyClosedInOrder(stateHandler);
         } finally {
-            // Detach the mocks so the harness teardown does not re-trigger the failure.
-            replaceOperatorField(operator, "resourceCache", null);
-            replaceOperatorField(operator, "contextManager", null);
-            replaceOperatorField(operator, "pythonBridge", null);
-            replaceOperatorField(operator, "eventLogWriter", null);
-            replaceOperatorField(operator, "durableExecManager", null);
+            components.detachFrom(operator);
+            replaceStateHandler(operator, realStateHandler);
+            testHarness.close();
+        }
+    }
+
+    /**
+     * A {@code super.close()} failure must aggregate with the component failures rather than
+     * replace them: the earlier component failure still reaches the caller, with the super failure
+     * attached to it as suppressed.
+     */
+    @Test
+    void closeAggregatesSuperCloseFailureWithComponentFailure() throws Exception {
+        KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> testHarness =
+                openCloseTestHarness();
+        ActionExecutionOperator<Long, Object> operator =
+                (ActionExecutionOperator<Long, Object>) testHarness.getOperator();
+
+        CloseComponents components = new CloseComponents();
+        doThrow(new IllegalStateException("resource cache close failed"))
+                .when(components.resourceCache)
+                .close();
+        components.installInto(operator);
+        StreamOperatorStateHandler stateHandler = mock(StreamOperatorStateHandler.class);
+        doThrow(new IllegalStateException("state handler dispose failed"))
+                .when(stateHandler)
+                .dispose();
+        StreamOperatorStateHandler realStateHandler = replaceStateHandler(operator, stateHandler);
+
+        try {
+            assertThatThrownBy(operator::close)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("resource cache close failed")
+                    .satisfies(
+                            thrown ->
+                                    assertThat(thrown.getSuppressed())
+                                            .extracting(Throwable::getMessage)
+                                            .containsExactly("state handler dispose failed"));
+
+            components.verifyClosedInOrder(stateHandler);
+        } finally {
+            components.detachFrom(operator);
+            replaceStateHandler(operator, realStateHandler);
             testHarness.close();
         }
     }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperatorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperatorTest.java
@@ -737,7 +737,9 @@ public class ActionExecutionOperatorTest {
         try {
             assertThatThrownBy(operator::close)
                     .isInstanceOf(IllegalStateException.class)
-                    .hasMessage("resource cache close failed");
+                    .hasMessage("resource cache close failed")
+                    // Contract 3: with super.close() healthy, nothing is attached to the failure.
+                    .satisfies(thrown -> assertThat(thrown.getSuppressed()).isEmpty());
 
             components.verifyClosedInOrder(stateHandler);
         } finally {

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperatorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperatorTest.java
@@ -48,11 +48,13 @@ import org.apache.flink.agents.plan.actions.ToolCallAction;
 import org.apache.flink.agents.plan.resourceprovider.JavaSerializableResourceProvider;
 import org.apache.flink.agents.plan.resourceprovider.ResourceProvider;
 import org.apache.flink.agents.plan.tools.FunctionTool;
+import org.apache.flink.agents.runtime.ResourceCache;
 import org.apache.flink.agents.runtime.actionstate.ActionState;
 import org.apache.flink.agents.runtime.actionstate.ActionStateSerde;
 import org.apache.flink.agents.runtime.actionstate.ActionStateUtil;
 import org.apache.flink.agents.runtime.actionstate.CallResult;
 import org.apache.flink.agents.runtime.actionstate.InMemoryActionStateStore;
+import org.apache.flink.agents.runtime.eventlog.EventLogWriter;
 import org.apache.flink.agents.runtime.eventlog.FileEventLogger;
 import org.apache.flink.agents.runtime.eventlog.Slf4jEventLogger;
 import org.apache.flink.agents.runtime.memory.Mem0LongTermMemory;
@@ -90,6 +92,9 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /** Tests for {@link ActionExecutionOperator}. */
 public class ActionExecutionOperatorTest {
@@ -613,6 +618,65 @@ public class ActionExecutionOperatorTest {
         Field ltmField = ActionExecutionOperator.class.getDeclaredField("ltm");
         ltmField.setAccessible(true);
         ltmField.set(operator, ltm);
+    }
+
+    private static void replaceOperatorField(
+            ActionExecutionOperator<?, ?> operator, String name, Object value) throws Exception {
+        Field field = ActionExecutionOperator.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(operator, value);
+    }
+
+    /**
+     * A failing component must not strand the ones behind it. This matters most for {@code
+     * resourceCache}, which closes first and aggregates its own failures, and for {@code
+     * pythonBridge}, which releases the embedded Python interpreter.
+     */
+    @Test
+    void closeClosesEveryComponentWhenAnEarlierCloseFails() throws Exception {
+        KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> testHarness =
+                new KeyedOneInputStreamOperatorTestHarness<>(
+                        new ActionExecutionOperatorFactory(TestAgent.getAgentPlan(false), true),
+                        (KeySelector<Long, Long>) value -> value,
+                        TypeInformation.of(Long.class));
+        testHarness.open();
+        ActionExecutionOperator<Long, Object> operator =
+                (ActionExecutionOperator<Long, Object>) testHarness.getOperator();
+
+        ResourceCache resourceCache = mock(ResourceCache.class);
+        ActionTaskContextManager contextManager = mock(ActionTaskContextManager.class);
+        PythonBridgeManager pythonBridge = mock(PythonBridgeManager.class);
+        EventLogWriter eventLogWriter = mock(EventLogWriter.class);
+        DurableExecutionManager durableExecManager = mock(DurableExecutionManager.class);
+        doThrow(new IllegalStateException("resource cache close failed"))
+                .when(resourceCache)
+                .close();
+
+        replaceOperatorField(operator, "resourceCache", resourceCache);
+        replaceOperatorField(operator, "contextManager", contextManager);
+        replaceOperatorField(operator, "pythonBridge", pythonBridge);
+        replaceOperatorField(operator, "eventLogWriter", eventLogWriter);
+        replaceOperatorField(operator, "durableExecManager", durableExecManager);
+
+        try {
+            assertThatThrownBy(operator::close)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("resource cache close failed");
+
+            // The components behind the failing one are still released.
+            verify(contextManager).close();
+            verify(pythonBridge).close();
+            verify(eventLogWriter).close();
+            verify(durableExecManager).close();
+        } finally {
+            // Detach the mocks so the harness teardown does not re-trigger the failure.
+            replaceOperatorField(operator, "resourceCache", null);
+            replaceOperatorField(operator, "contextManager", null);
+            replaceOperatorField(operator, "pythonBridge", null);
+            replaceOperatorField(operator, "eventLogWriter", null);
+            replaceOperatorField(operator, "durableExecManager", null);
+            testHarness.close();
+        }
     }
 
     /** Java-side stand-in for the Python-backed LTM wrapper used to observe the failure path. */

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionTaskContextManagerTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionTaskContextManagerTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.agents.plan.actions.Action;
 import org.apache.flink.agents.runtime.ResourceCache;
 import org.apache.flink.agents.runtime.actionstate.ActionState;
 import org.apache.flink.agents.runtime.actionstate.InMemoryActionStateStore;
+import org.apache.flink.agents.runtime.async.ContinuationActionExecutor;
 import org.apache.flink.agents.runtime.async.ContinuationContext;
 import org.apache.flink.agents.runtime.context.JavaRunnerContextImpl;
 import org.apache.flink.agents.runtime.context.RunnerContextImpl;
@@ -40,6 +41,7 @@ import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -50,12 +52,43 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 /** Contract tests for {@link ActionTaskContextManager}. */
 class ActionTaskContextManagerTest {
+
+    /**
+     * A failing runner context must not strand the continuation executor, which owns the async
+     * thread pool and would otherwise keep non-daemon threads alive after the operator closes.
+     */
+    @Test
+    void closeClosesContinuationExecutorWhenRunnerContextFails() throws Exception {
+        ActionTaskContextManager mgr = new ActionTaskContextManager(1);
+        RunnerContextImpl failingContext = mock(RunnerContextImpl.class);
+        ContinuationActionExecutor continuationExecutor = mock(ContinuationActionExecutor.class);
+        doThrow(new IllegalStateException("runner context close failed"))
+                .when(failingContext)
+                .close();
+
+        setField(mgr, "runnerContext", failingContext);
+        setField(mgr, "continuationActionExecutor", continuationExecutor);
+
+        assertThatThrownBy(mgr::close)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("runner context close failed");
+
+        verify(continuationExecutor).close();
+    }
+
+    private static void setField(ActionTaskContextManager mgr, String name, Object value)
+            throws Exception {
+        Field field = ActionTaskContextManager.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(mgr, value);
+    }
 
     @Test
     void perTaskMapsAreIsolatedAcrossPutGetRemove() throws Exception {

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionTaskContextManagerTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionTaskContextManagerTest.java
@@ -78,9 +78,37 @@ class ActionTaskContextManagerTest {
 
         assertThatThrownBy(mgr::close)
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("runner context close failed");
+                .hasMessage("runner context close failed")
+                // Contract 3: a lone failure arrives with nothing attached to it.
+                .satisfies(thrown -> assertThat(thrown.getSuppressed()).isEmpty());
 
         verify(continuationExecutor).close();
+    }
+
+    /** The first failure is rethrown and the later one is attached as suppressed, never dropped. */
+    @Test
+    void closeReportsFirstFailureWithLaterOneSuppressed() throws Exception {
+        ActionTaskContextManager mgr = new ActionTaskContextManager(1);
+        RunnerContextImpl failingContext = mock(RunnerContextImpl.class);
+        ContinuationActionExecutor failingExecutor = mock(ContinuationActionExecutor.class);
+        doThrow(new IllegalStateException("runner context close failed"))
+                .when(failingContext)
+                .close();
+        doThrow(new IllegalStateException("continuation executor close failed"))
+                .when(failingExecutor)
+                .close();
+
+        setField(mgr, "runnerContext", failingContext);
+        setField(mgr, "continuationActionExecutor", failingExecutor);
+
+        assertThatThrownBy(mgr::close)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("runner context close failed")
+                .satisfies(
+                        thrown ->
+                                assertThat(thrown.getSuppressed())
+                                        .extracting(Throwable::getMessage)
+                                        .containsExactly("continuation executor close failed"));
     }
 
     private static void setField(ActionTaskContextManager mgr, String name, Object value)

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/PythonBridgeManagerTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/PythonBridgeManagerTest.java
@@ -94,7 +94,9 @@ class PythonBridgeManagerTest {
 
         assertThatThrownBy(bridge::close)
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("action executor close failed");
+                .hasMessage("action executor close failed")
+                // Contract 3: a lone failure arrives with nothing attached to it.
+                .satisfies(thrown -> assertThat(thrown.getSuppressed()).isEmpty());
 
         InOrder inOrder = inOrder(actionExecutor, interpreter, environmentManager);
         inOrder.verify(actionExecutor).close();
@@ -150,8 +152,11 @@ class PythonBridgeManagerTest {
         setField(bridge, "pythonInterpreter", interpreter);
         setField(bridge, "pythonEnvironmentManager", environmentManager);
 
-        // The Error reaches the caller unchanged rather than wrapped in an Exception.
-        assertThatThrownBy(bridge::close).isSameAs(failure);
+        // The Error reaches the caller unchanged rather than wrapped in an Exception, and with
+        // nothing attached to it.
+        assertThatThrownBy(bridge::close)
+                .isSameAs(failure)
+                .satisfies(thrown -> assertThat(thrown.getSuppressed()).isEmpty());
 
         verify(interpreter).close();
         verify(environmentManager).close();

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/PythonBridgeManagerTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/PythonBridgeManagerTest.java
@@ -20,14 +20,22 @@ package org.apache.flink.agents.runtime.operator;
 import org.apache.flink.agents.api.InputEvent;
 import org.apache.flink.agents.plan.AgentPlan;
 import org.apache.flink.agents.plan.actions.Action;
+import org.apache.flink.agents.runtime.env.PythonEnvironmentManager;
+import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.junit.jupiter.api.Test;
+import pemja.core.PythonInterpreter;
 
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /** Contract tests for {@link PythonBridgeManager}. */
 class PythonBridgeManagerTest {
@@ -58,5 +66,93 @@ class PythonBridgeManagerTest {
             assertThat(bridge.getPythonActionExecutor()).isNull();
             assertThat(bridge.getPythonRunnerContext()).isNull();
         }
+    }
+
+    /**
+     * A failing action executor must not strand the interpreter or the environment manager: both
+     * hold native Python state that leaks for the lifetime of the TaskManager if never closed.
+     */
+    @Test
+    void closeReleasesInterpreterAndEnvironmentWhenActionExecutorFails() throws Exception {
+        PythonBridgeManager bridge = new PythonBridgeManager();
+        PythonActionExecutor actionExecutor = mock(PythonActionExecutor.class);
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        PythonEnvironmentManager environmentManager = mock(PythonEnvironmentManager.class);
+        doThrow(new IllegalStateException("action executor close failed"))
+                .when(actionExecutor)
+                .close();
+
+        setField(bridge, "pythonActionExecutor", actionExecutor);
+        setField(bridge, "pythonInterpreter", interpreter);
+        setField(bridge, "pythonEnvironmentManager", environmentManager);
+
+        assertThatThrownBy(bridge::close)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("action executor close failed");
+
+        verify(interpreter).close();
+        verify(environmentManager).close();
+    }
+
+    /** The first failure is rethrown and any later one is attached as suppressed, never dropped. */
+    @Test
+    void closeReportsFirstFailureWithLaterOnesSuppressed() throws Exception {
+        PythonBridgeManager bridge = new PythonBridgeManager();
+        PythonActionExecutor actionExecutor = mock(PythonActionExecutor.class);
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        PythonEnvironmentManager environmentManager = mock(PythonEnvironmentManager.class);
+        doThrow(new IllegalStateException("action executor close failed"))
+                .when(actionExecutor)
+                .close();
+        doThrow(new IllegalStateException("environment manager close failed"))
+                .when(environmentManager)
+                .close();
+
+        setField(bridge, "pythonActionExecutor", actionExecutor);
+        setField(bridge, "pythonInterpreter", interpreter);
+        setField(bridge, "pythonEnvironmentManager", environmentManager);
+
+        assertThatThrownBy(bridge::close)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("action executor close failed")
+                .satisfies(
+                        thrown ->
+                                assertThat(thrown.getSuppressed())
+                                        .extracting(Throwable::getMessage)
+                                        .containsExactly("environment manager close failed"));
+
+        verify(interpreter).close();
+    }
+
+    /**
+     * Pins the handler to {@code Throwable}. A non-{@code Exception} failure from the action
+     * executor must still release the native Python state; a {@code catch (Exception)} ladder or
+     * {@code IOUtils.closeAll} would stop here and leak it.
+     */
+    @Test
+    void closeReleasesInterpreterAndEnvironmentWhenActionExecutorThrowsError() throws Exception {
+        PythonBridgeManager bridge = new PythonBridgeManager();
+        PythonActionExecutor actionExecutor = mock(PythonActionExecutor.class);
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        PythonEnvironmentManager environmentManager = mock(PythonEnvironmentManager.class);
+        OutOfMemoryError failure = new OutOfMemoryError("action executor close failed");
+        doThrow(failure).when(actionExecutor).close();
+
+        setField(bridge, "pythonActionExecutor", actionExecutor);
+        setField(bridge, "pythonInterpreter", interpreter);
+        setField(bridge, "pythonEnvironmentManager", environmentManager);
+
+        // The Error reaches the caller unchanged rather than wrapped in an Exception.
+        assertThatThrownBy(bridge::close).isSameAs(failure);
+
+        verify(interpreter).close();
+        verify(environmentManager).close();
+    }
+
+    private static void setField(PythonBridgeManager bridge, String name, Object value)
+            throws Exception {
+        Field field = PythonBridgeManager.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(bridge, value);
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/PythonBridgeManagerTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/PythonBridgeManagerTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import pemja.core.PythonInterpreter;
 
 import java.lang.reflect.Field;
@@ -34,6 +35,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -71,6 +73,10 @@ class PythonBridgeManagerTest {
     /**
      * A failing action executor must not strand the interpreter or the environment manager: both
      * hold native Python state that leaks for the lifetime of the TaskManager if never closed.
+     *
+     * <p>Also pins the close order documented on the class, which is load-bearing rather than
+     * incidental: {@link PythonActionExecutor#close()} calls back into the interpreter, so it has
+     * to run before the interpreter is closed.
      */
     @Test
     void closeReleasesInterpreterAndEnvironmentWhenActionExecutorFails() throws Exception {
@@ -90,8 +96,10 @@ class PythonBridgeManagerTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("action executor close failed");
 
-        verify(interpreter).close();
-        verify(environmentManager).close();
+        InOrder inOrder = inOrder(actionExecutor, interpreter, environmentManager);
+        inOrder.verify(actionExecutor).close();
+        inOrder.verify(interpreter).close();
+        inOrder.verify(environmentManager).close();
     }
 
     /** The first failure is rethrown and any later one is attached as suppressed, never dropped. */

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutorTest.java
@@ -20,6 +20,9 @@ package org.apache.flink.agents.runtime.python.utils;
 import org.apache.flink.types.Row;
 import org.junit.jupiter.api.Test;
 import pemja.core.PythonInterpreter;
+import pemja.core.object.PyObject;
+
+import java.lang.reflect.Field;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -85,6 +88,88 @@ class PythonActionExecutorTest {
         assertThatThrownBy(() -> executor.resolveKeyText(Row.of(malformedKey), true))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("bad pickle");
+    }
+
+    /**
+     * A failing thread-pool shutdown must not skip the runner-context cleanup. That cleanup
+     * releases the Python context's long-term memory and resource cache, and {@code
+     * PythonBridgeManager} closes the interpreter immediately behind this call, so a skipped
+     * cleanup never runs at all.
+     */
+    @Test
+    void closeCleansRunnerContextWhenThreadPoolShutdownFails() throws Exception {
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        PythonActionExecutor executor = newExecutor(interpreter);
+        PyObject threadPool = mock(PyObject.class);
+        PyObject runnerContext = mock(PyObject.class);
+        setField(executor, "pythonAsyncThreadPool", threadPool);
+        setField(executor, "pythonRunnerContext", runnerContext);
+        when(interpreter.invoke("flink_runner_context.close_async_thread_pool", threadPool))
+                .thenThrow(new RuntimeException("thread pool shutdown failed"));
+
+        assertThatThrownBy(executor::close)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("thread pool shutdown failed")
+                // A lone failure arrives with nothing attached to it.
+                .satisfies(thrown -> assertThat(thrown.getSuppressed()).isEmpty());
+
+        verify(interpreter)
+                .invoke("flink_runner_context.close_flink_runner_context", runnerContext);
+        // The handle is released even on the failing path, so a repeated close cannot double-free.
+        assertThat(executor.getPythonRunnerContext()).isNull();
+    }
+
+    /** The first failure is rethrown and the later one is attached as suppressed, never dropped. */
+    @Test
+    void closeReportsFirstFailureWithLaterOneSuppressed() throws Exception {
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        PythonActionExecutor executor = newExecutor(interpreter);
+        PyObject threadPool = mock(PyObject.class);
+        PyObject runnerContext = mock(PyObject.class);
+        setField(executor, "pythonAsyncThreadPool", threadPool);
+        setField(executor, "pythonRunnerContext", runnerContext);
+        when(interpreter.invoke("flink_runner_context.close_async_thread_pool", threadPool))
+                .thenThrow(new RuntimeException("thread pool shutdown failed"));
+        when(interpreter.invoke("flink_runner_context.close_flink_runner_context", runnerContext))
+                .thenThrow(new RuntimeException("runner context cleanup failed"));
+
+        assertThatThrownBy(executor::close)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("thread pool shutdown failed")
+                .satisfies(
+                        thrown ->
+                                assertThat(thrown.getSuppressed())
+                                        .extracting(Throwable::getMessage)
+                                        .containsExactly("runner context cleanup failed"));
+    }
+
+    /**
+     * Pins the handler to {@code Throwable}: a non-{@code Exception} failure from the thread-pool
+     * shutdown must still release the runner context, and must reach the caller unwrapped.
+     */
+    @Test
+    void closeCleansRunnerContextWhenThreadPoolShutdownThrowsError() throws Exception {
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        PythonActionExecutor executor = newExecutor(interpreter);
+        PyObject threadPool = mock(PyObject.class);
+        PyObject runnerContext = mock(PyObject.class);
+        setField(executor, "pythonAsyncThreadPool", threadPool);
+        setField(executor, "pythonRunnerContext", runnerContext);
+        OutOfMemoryError failure = new OutOfMemoryError("thread pool shutdown failed");
+        when(interpreter.invoke("flink_runner_context.close_async_thread_pool", threadPool))
+                .thenThrow(failure);
+
+        assertThatThrownBy(executor::close).isSameAs(failure);
+
+        verify(interpreter)
+                .invoke("flink_runner_context.close_flink_runner_context", runnerContext);
+    }
+
+    private static void setField(PythonActionExecutor executor, String name, Object value)
+            throws Exception {
+        Field field = PythonActionExecutor.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(executor, value);
     }
 
     private static PythonActionExecutor newExecutor(PythonInterpreter interpreter)

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/skill/SkillManagerTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/skill/SkillManagerTest.java
@@ -455,8 +455,9 @@ class SkillManagerTest {
         // fails its registration with one Error and then its close() with another: a load guard
         // narrowed to Exception would skip the cleanup entirely, and a cleanup guard narrowed to
         // Exception would let the close() Error escape and replace the registration failure.
-        // One source keeps the assertions deterministic — closeRepos() catches only Exception per
-        // repo, so an Error from any repo's close() ends the iteration over the remaining ones.
+        // One source keeps the assertions deterministic: with a single repo there is no iteration
+        // order to depend on. closeRepos() now continues past an Error too — see
+        // closeAttemptsEveryRepoWhenAnEarlierRepoThrowsError.
         Error registrationBoom = new Error("registration-error");
         Error closeBoom = new Error("close-error");
         FakeRepo repo = new FakeRepo("alpha", closeBoom, registrationBoom);
@@ -509,6 +510,46 @@ class SkillManagerTest {
         }
         assertTrue(all.contains(badBoom), "bad-close must surface");
         assertTrue(all.contains(good2Boom), "good2-close must surface");
+    }
+
+    @Test
+    void closeAttemptsEveryRepoWhenAnEarlierRepoThrowsError() throws Exception {
+        // An Error from one repo's close() must not strand the repos behind it. Nothing can retry
+        // them: ResourceContextImpl.close() clears its SkillManager reference in a finally, so a
+        // skipped repo leaks its materialized temp directory for the life of the JVM.
+        //
+        // Both repos fail so the assertions do not depend on the de-dup set's iteration order,
+        // which is unspecified. With a handler narrowed to Exception, whichever repo runs first
+        // ends the iteration and the other is left unclosed — that fails here either way round.
+        Error firstBoom = new Error("close-error-1");
+        Error secondBoom = new Error("close-error-2");
+        FakeRepo first = new FakeRepo("alpha", firstBoom);
+        FakeRepo second = new FakeRepo("beta", secondBoom);
+
+        AtomicInteger seq = new AtomicInteger();
+        List<FakeRepo> ordered = List.of(first, second);
+        SkillSourceRegistry.register(
+                "test-close-error", (params, cl) -> ordered.get(seq.getAndIncrement()));
+
+        Skills config =
+                new Skills(
+                        List.of(
+                                new SkillSourceSpec("test-close-error", Map.of()),
+                                new SkillSourceSpec("test-close-error", Map.of())));
+
+        SkillManager manager = new SkillManager(config);
+        // The Error reaches the caller unwrapped rather than boxed in an Exception.
+        Error thrown = assertThrows(Error.class, manager::close);
+
+        assertTrue(first.closed.get(), "the first repo must be attempted");
+        assertTrue(second.closed.get(), "the repo behind the Error must still be closed");
+        List<Throwable> all = new ArrayList<>();
+        all.add(thrown);
+        for (Throwable s : thrown.getSuppressed()) {
+            all.add(s);
+        }
+        assertTrue(all.contains(firstBoom), "the first Error must surface");
+        assertTrue(all.contains(secondBoom), "the second Error must surface");
     }
 
     @Test


### PR DESCRIPTION
Linked issue: none (hotfix)

### Purpose of change

Six Java `close()` methods and one Python one in the operator shutdown chain closed
their components as
sequential statements with no per-call guard, so the first failure skipped
everything behind it.

| Site | Stranded when an earlier close fails |
|---|---|
| `ActionExecutionOperator.close()` | `contextManager`, `pythonBridge`, `eventRouter`, `durableExecManager`, `super.close()` |
| `PythonBridgeManager.close()` | the Pemja `PythonInterpreter` and the `PythonEnvironmentManager` |
| `ActionTaskContextManager.close()` | the `ContinuationActionExecutor` thread pool |
| `ResourceCache.close()` | the remaining cached resources, `cache.clear()`, and `resourceContext.close()` — for a non-`Exception` `Throwable` only |
| `PythonActionExecutor.close()` | the Python runner-context cleanup, which releases that context's long-term memory and resource cache |
| `SkillManager.closeRepos()` | the remaining skill repositories and their materialized temp directories — for a non-`Exception` `Throwable` only |
| Python `ResourceCache.close()` | the remaining resources, `_cache.clear()`, and `_resource_context.close()` |

The last three were found in review by @wenjin272, each a place the guarantee the
first four establish did not actually reach. `PythonActionExecutor` sits directly
under `PythonBridgeManager`, which closes the interpreter on the next rung, so its
skipped cleanup never runs at all. `SkillManager` is the nested branch below
`ResourceCache` → `ResourceContextImpl`, which clears its manager reference in a
`finally`, so a skipped repository can never be retried. The Python cache is the
cross-language counterpart of the Java one and had diverged from it.

#### Runtime flow

`ActionExecutionOperator.close()` is the entry point and the sharpest case. It
closes `resourceCache` first, and `ResourceCache.close()` aggregates its own
component failures and rethrows them by design. So the exception `ResourceCache`
propagates is precisely the one that skipped the rest of the chain, including
`pythonBridge.close()` — the call that releases the embedded Python interpreter
and its environment manager. A single resource failing to close could leak native
Python state for the lifetime of the TaskManager JVM.

`PythonBridgeManager.close()` and `ActionTaskContextManager.close()` are reached
from that same chain and had the same shape.

`ResourceCache.close()` was added to this list during review. It already
aggregated `Exception`s, but caught only `Exception`, so a non-`Exception`
`Throwable` out of a cached `Resource.close()` propagated immediately. That gap
matters *more* after the rest of this patch, not less: the operator ladder now
continues past the failure and closes the Python interpreter, while cached
resources that may hold Python references are still open — which inverts the
ordering the ladder exists to preserve. Thanks to @weiqingy for catching it.

#### Key decisions

Capture and rethrow, rather than closing later components in a `finally`. A
`finally` that completes abruptly discards the in-flight exception (JLS 14.20.2),
which is the defect #974 is fixing in `FlussActionStateStore`. The shape here
matches `KafkaActionStateStore.close()` (#948), and `ResourceCache.close()`
already aggregated this way before this patch widened it.

The ladders catch `Throwable`, not `Exception`. A `catch (Exception)` ladder
stops at a non-`Exception` `Throwable` and skips the remaining closes, which is
the same leak with a narrower trigger. `ExceptionUtils.rethrowException` then
rethrows `Error` and `Exception` unchanged, so the caller sees the original type
and instance rather than a wrapper.

`IOUtils.closeAll` was considered and rejected, for the reason already set out in
#974: with the default `Exception.class` it rethrows a non-`Exception`
`Throwable` immediately without closing the remaining resources. I verified this
against `flink-core-2.3.0` rather than assuming — with an `Error` thrown from the
first closeable, the second is never closed, while a plain `Exception` closes all
three. An earlier revision of this patch used `closeAll` and the `Error` test
below is what caught it. The same finding is recorded on #944, which takes the
`closeAll` path over these same files.

`ActionTaskContextManager` spells the aggregation out rather than delegating:
neither `RunnerContextImpl` nor `ContinuationActionExecutor` implements
`AutoCloseable`, and `ContinuationActionExecutor` has separate `java/` and
`java21/` implementations, so making it closeable would touch a source set the
JDK 11 profile does not compile.

#### Behavioral contracts

1. Every component close is attempted on every call, in the existing order.
2. A null component is skipped rather than raising.
3. When one close fails, its exception reaches the caller unchanged in type and
   identity, with nothing suppressed. Both halves are asserted, on every
   single-failure path rather than only the identity half.
4. When several fail, the first is thrown and the later ones are attached to it
   via `addSuppressed`.
5. A non-`Exception` `Throwable` does not prevent the remaining closes, and
   reaches the caller as itself rather than wrapped.
6. When nothing fails, `close()` returns normally.
7. `ActionExecutionOperator` still calls `super.close()`, and a `super.close()`
   failure aggregates with component failures rather than replacing them.
8. `ResourceCache.close()` holds contracts 1, 4, and 5 for a non-`Exception`
   `Throwable` too: the remaining cached resources, the cache clear, and
   `resourceContext.close()` all still run.

Contract 1's ordering clause is pinned with `InOrder`, not left implicit. Order
is load-bearing: `resourceCache` must close before `pythonBridge` because cached
resources may hold Python references, `PythonActionExecutor.close()` calls back
into the interpreter, and `super.close()` must come last.

### Tests

| Test | Contract |
|---|---|
| `PythonBridgeManagerTest.closeReleasesInterpreterAndEnvironmentWhenActionExecutorFails` | 1, 3 |
| `PythonBridgeManagerTest.closeReportsFirstFailureWithLaterOnesSuppressed` | 4 |
| `PythonBridgeManagerTest.closeReleasesInterpreterAndEnvironmentWhenActionExecutorThrowsError` | 5 |
| `ActionTaskContextManagerTest.closeClosesContinuationExecutorWhenRunnerContextFails` | 1, 3 |
| `ActionExecutionOperatorTest.closeClosesEveryComponentWhenAnEarlierCloseFails` | 1, 7 |
| `ActionExecutionOperatorTest.closeAggregatesSuperCloseFailureWithComponentFailure` | 7 |
| `ResourceCacheTest.closeClosesEveryResourceWhenAnEarlierResourceThrowsError` | 8 |
| `ResourceCacheTest.closeReportsFirstResourceFailureWithLaterOnesSuppressed` | 4 |
| `ActionTaskContextManagerTest.closeReportsFirstFailureWithLaterOneSuppressed` | 4 |
| `PythonActionExecutorTest.closeCleansRunnerContextWhenThreadPoolShutdownFails` | 1, 3 |
| `PythonActionExecutorTest.closeReportsFirstFailureWithLaterOneSuppressed` | 4 |
| `PythonActionExecutorTest.closeCleansRunnerContextWhenThreadPoolShutdownThrowsError` | 5 |
| `SkillManagerTest.closeAttemptsEveryRepoWhenAnEarlierRepoThrowsError` | 1, 5 |
| `ResourceCacheTest.closeClosesEverySkillRepositoryWhenAnEarlierRepoThrowsError` | 1, 5 (through the production path) |
| Python `test_resource_cache_close.py` — four cases | 1, 3, 4, 6 |

Each assertion was checked against a mutation that should break it, rather than
merely observed green. All of these fail the listed tests:

| Mutation | Fails |
|---|---|
| the original `close()` restored in place | the first five tests, four with Mockito's `Wanted but not invoked` |
| `IOUtils.closeAll` substituted into `PythonBridgeManager.close()` | only the `Error` test — the discriminating case for the `Throwable` decision |
| `ResourceCache` catch narrowed back to `Exception` | `closeClosesEveryResourceWhenAnEarlierResourceThrowsError` |
| the `super.close()` try/catch deleted | both `ActionExecutionOperatorTest` close tests |
| `if (firstFailure == null) super.close();` — a partial revert of the fix | both `ActionExecutionOperatorTest` close tests |
| operator close order swapped (`resourceCache` ↔ `pythonBridge`) | both `ActionExecutionOperatorTest` close tests |
| `PythonBridgeManager` close order swapped | `closeReleasesInterpreterAndEnvironmentWhenActionExecutorFails` |
| `ActionTaskContextManager`'s second rung overwrites instead of suppressing | `closeReportsFirstFailureWithLaterOneSuppressed` |
| `PythonActionExecutor.close()` restored to its sequential shape | all three new `PythonActionExecutorTest` cases |
| `SkillManager.closeRepos()` catch narrowed back to `Exception` | the `SkillManager` and `ResourceCache` repo tests |
| Python `close()` restored to its sequential shape | both Python failure-path tests |

One mutation check found a flaw in the new tests rather than in the code. The
`SkillManager` and `ResourceCache` repository tests first used one failing and one
healthy repo, and the `SkillManager` one *passed* against the narrowed catch: the
de-dup set is an `IdentityHashMap`, so when the healthy repo happened to iterate
first, both were closed even with the bug present. Both now use two failing repos
and fail deterministically whichever runs first, confirmed over three runs.

Three things are deliberately not mutation-covered, flagged rather than left
implied:

- `closeReportsFirstResourceFailureWithLaterOnesSuppressed` — `ResourceCache`
  already aggregated `Exception`s correctly, so this characterizes that behavior
  through the rewrite rather than guarding a live defect.
- the `getSuppressed()).isEmpty()` assertions added for contract 3's "nothing
  suppressed" clause. No mutation of the current ladders produces a spurious
  suppressed entry on a single-failure path.
- the `firstOrSuppressed` call at `ActionTaskContextManager`'s first rung.
  Reverting it leaves all ten tests in that file green; it is a fail-open guard
  for a close inserted above it later, not a fix.

All three align the tests with what the contracts already claimed.

Every aggregation point routes through `ExceptionUtils.firstOrSuppressed`,
including the one rung where a previous failure is not yet possible, so that
inserting a close above it cannot silently overwrite.

`./tools/ut.sh -j` passes: 1374 tests, 0 failures, 0 errors (38 skipped, all
pre-existing integration tests that need external services). Python unit tests:
816 passed, 13 skipped. Ruff, `spotless:check` and RAT are clean.

### API

No public API change. All six Java `close()` methods keep their
`@Override public void close() throws Exception` signature.

`PythonActionExecutor` gains `implements AutoCloseable`; it already declared a
matching `close() throws Exception`, so this is additive and no call site
changes.

Caller-visible behavior changes:

- When several closes fail, the exception received is now the first failure
  rather than the last, and `getSuppressed()` is non-empty.
- `ResourceCache.close()` now finishes the remaining closes before propagating a
  non-`Exception` `Throwable`, instead of propagating it immediately. The
  `Throwable` still reaches the caller as itself.

- Python `ResourceCache.close()` likewise finishes the remaining closes before
  re-raising the first failure. Later failures are logged rather than attached,
  since `ExceptionGroup` requires 3.11 and this package supports 3.10; the catch
  is `Exception` rather than the literal analogue of `Throwable`, because
  Python's `Exception` already covers what Java calls `Error` while
  `BaseException` would swallow `KeyboardInterrupt` and `SystemExit`.

No code in the repo catches these by type, unwraps a cause, or reads
`getSuppressed()`. `ResourceCache.close()`'s only production caller is the
`ActionExecutionOperator` ladder, which catches `Throwable`.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

`Generated-by: Claude Code (claude-opus-5)`, also present in the commit messages.

---

Overlap note: #944 rewrites three of these same `close()` methods with
`IOUtils.closeAll` and touches a superset of these files. The `Error` finding is
recorded there so the two do not land opposite decisions on that case;
sequencing is under discussion on that PR.

Same defect class, left out to keep this to one module and one call path, happy
to follow up separately:

- `OpenSearchVectorStore.close()` — `httpClient.close()` failing strands
  `credentialsProvider`
- `BedrockEmbeddingModelConnection.close()` — `embedPool.shutdown()` failing
  strands `client`


