### PR TITLE
[e2e] Add a checkpoint-recovery test for restored Python state

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -79,3 +79,52 @@ jobs:
           name: flink-logs-${{ matrix.flink-version }}
           path: flink-logs-*.tar.gz
           if-no-files-found: ignore
+
+  checkpoint-recovery:
+    runs-on: ubuntu-latest
+    # Scheduled and manual runs only. The pull_request trigger above exists for the
+    # examples job; extending it to this one would spend a second full
+    # download-and-build on every PR matching those paths, and nothing in this
+    # repository caches either. Accepted consequence: no pre-merge signal.
+    if: github.event_name != 'pull_request'
+    # Budget. Typical: Flink download ~5m, tools/build.sh ~15m, plus the wheel and
+    # PyFlink install; the last two are unbounded. Worst case is dominated by the
+    # download: install.sh runs `curl --max-time 900 --retry 3` with no
+    # --retry-max-time and each retry restarts that clock, so four attempts take
+    # ~60m of the 75 below on their own — FLINK_BASE_URL defaults to the Apache
+    # CDN, which makes that tail unlikely. The script's own waits add up to roughly
+    # 22m on top, if every one runs to its deadline (its *_TIMEOUT block).
+    timeout-minutes: 75
+    env:
+      # Null on a scheduled run, so the literal is what runs then; keep it in step
+      # with the workflow_dispatch input default above. Leaving the version to the
+      # script's own default instead would still run, but the log-artifact name
+      # below reads this variable and would lose its version suffix.
+      FLINK_VERSION: ${{ github.event.inputs.flink-version || '2.3.0' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Install python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/0.11.0/install.sh | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      # No model server env: the payload agent answers from a deterministic mock
+      # chat model. The script sets SKIP_SPOTLESS_CHECK around its own
+      # tools/build.sh call, so no job-level env is needed for that either.
+      - name: Run checkpoint-recovery E2E test
+        run: bash e2e-test/test-scripts/test_checkpoint_recovery.sh
+      - name: Upload Flink logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flink-logs-checkpoint-recovery-${{ env.FLINK_VERSION }}
+          path: flink-logs-*.tar.gz
+          if-no-files-found: ignore

--- a/e2e-test/test-scripts/test_checkpoint_recovery.sh
+++ b/e2e-test/test-scripts/test_checkpoint_recovery.sh
@@ -123,11 +123,58 @@ CHECKPOINT_DIR=""
 INPUT_DIR=""
 INPUT_FILE=""
 FLINK_CONF=""
+FLINK_CONF_BACKUP=""
 TM_PID_BEFORE=""
 TM_RESOURCE_ID_BEFORE=""
 RESTORED_BEFORE=""
 RELEASE_DEADLINE_S=""
 HANDSHAKE_DEADLINE_AT=""
+
+# ---------------------------------------------------------------------------
+# A reused Flink home carries someone's own config.yaml. set_config_key deletes any
+# line already present for a key before appending ours, so reverting key by key
+# cannot put back a value the installation already had: the whole file is copied
+# aside before the first edit and copied back at exit. config.yaml is the only
+# thing copied aside — the jars this run stages into lib/ are not.
+#
+# The copy carries mode as well as content. delete_config_key rewrites through
+# mktemp and mv, which replaces the file with a 0600 temp file, so restoring the
+# bytes alone would leave the installation's config readable only by this user.
+#
+# The copy lives under TMPDIR rather than in WORK_DIR or in the installation:
+# WORK_DIR does not exist yet when the copy is taken and is removed on a clean
+# exit, and writing into conf/ mutates the directory being protected.
+# ---------------------------------------------------------------------------
+backup_flink_conf() {
+    FLINK_CONF_BACKUP="$(mktemp "${TMPDIR:-/tmp}/flink-agents-config.yaml.XXXXXX")" || {
+        log_error "Could not create a temporary file to copy $FLINK_CONF aside"
+        exit 1
+    }
+    # `if !` rather than a bare cp: set -e would abort before the diagnostic prints.
+    if ! cp -p "$FLINK_CONF" "$FLINK_CONF_BACKUP"; then
+        rm -f "$FLINK_CONF_BACKUP"
+        FLINK_CONF_BACKUP=""
+        log_error "Could not copy $FLINK_CONF aside. Refusing to edit an installation that cannot be put back."
+        exit 1
+    fi
+    log_info "Copied $FLINK_CONF aside for restore at exit"
+}
+
+restore_flink_conf() {
+    # Guarded on the copy, not on the destination: a config.yaml that went missing
+    # mid-run is exactly when the restore is needed, and cp recreates it. The
+    # explicit `|| return 0` is load-bearing under bash 3, where a bare [[ ]] as a
+    # non-final command does not trigger errexit.
+    [[ -n "$FLINK_CONF" && -n "$FLINK_CONF_BACKUP" && -f "$FLINK_CONF_BACKUP" ]] || return 0
+    if cp -p "$FLINK_CONF_BACKUP" "$FLINK_CONF"; then
+        log_info "Restored $FLINK_CONF from the pre-run copy"
+        rm -f "$FLINK_CONF_BACKUP"
+    else
+        # Keep the only surviving original and say where it is.
+        log_warn "Could not restore $FLINK_CONF; the pre-run copy is kept at $FLINK_CONF_BACKUP"
+        return 1
+    fi
+}
 
 cleanup() {
     local exit_code=$?
@@ -159,16 +206,18 @@ cleanup() {
         fi
     fi
 
-    # Strip the keys we appended. A second run against a reused Flink home would
-    # otherwise append them twice, and a duplicate key is a hard YAML parse failure
-    # that stops the cluster from starting at all.
-    if [[ -n "$FLINK_CONF" && -f "$FLINK_CONF" ]]; then
-        local key
-        for key in "${CONFIG_KEYS_SET[@]:-}"; do
-            [[ -n "$key" ]] || continue
-            delete_config_key "$key"
-        done
-        log_info "Reverted ${#CONFIG_KEYS_SET[@]} appended config key(s)"
+    # Put the installation's config.yaml back exactly as it was, mode included.
+    # Restoring the whole file also drops the keys this run appended, so a second
+    # run against a reused Flink home finds no duplicate top-level key — which
+    # would be a hard YAML parse failure that stops the cluster from starting at
+    # all.
+    #
+    # Tested inside the `if` so a failure cannot trip errexit here: aborting the
+    # trap would skip print_summary, which is what reports the results and settles
+    # the exit status. A run that left the installation mutated is not a success,
+    # so a restore failure with nothing else to report becomes the exit code.
+    if ! restore_flink_conf && (( exit_code == 0 )); then
+        exit_code=1
     fi
 
     # The killed TaskManager's entry stays in /tmp/flink-*-taskexecutor.pid, which
@@ -542,6 +591,10 @@ install_flink() {
         log_error "Flink config not found: $FLINK_CONF"
         exit 1
     fi
+
+    # Adjacent to the assignment on purpose, so FLINK_CONF is never set without a
+    # copy of the file existing and every later edit is reversible.
+    backup_flink_conf
 }
 
 # The wheel this run must exercise is the one tools/build.sh just produced, so it is
@@ -791,16 +844,19 @@ start_cluster() {
     "$FLINK_HOME/bin/start-cluster.sh"
 
     log_info "Waiting for JobManager REST API at $REST_URL ..."
-    local deadline=$((SECONDS + CLUSTER_TIMEOUT))
+    local start=$SECONDS
+    local deadline=$((start + CLUSTER_TIMEOUT))
+    # The deadline is tested at the top of the iteration, so the last probe and its
+    # sleep run past it. The message reports the time waited rather than the budget.
     while (( SECONDS < deadline )); do
-        if curl -fsS "$REST_URL/overview" >/dev/null 2>&1; then
+        if rest_get "/overview" >/dev/null; then
             log_ok "Flink cluster is up"
             return 0
         fi
         sleep "$POLL_INTERVAL"
     done
 
-    log_error "Flink cluster did not become ready within ${CLUSTER_TIMEOUT}s. A duplicate key in $FLINK_CONF is the usual cause; check the JobManager log for a YAML parse error."
+    log_error "Flink cluster did not become ready within $((SECONDS - start))s. A duplicate key in $FLINK_CONF is the usual cause; check the JobManager log for a YAML parse error."
     exit 1
 }
 

--- a/e2e-test/test-scripts/test_checkpoint_recovery.sh
+++ b/e2e-test/test-scripts/test_checkpoint_recovery.sh
@@ -1,0 +1,1307 @@
+#!/usr/bin/env bash
+#
+#   Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# Verifies that Python agent memory survives the loss of a TaskManager process.
+#
+# Submits checkpoint_recovery_job.py to a local Flink standalone cluster. The job
+# parks itself inside a tool call that blocks on a file this script creates, so a
+# completed checkpoint provably holds the agent's memory before anything is killed.
+# The script then hard-kills the TaskManager, restarts it, waits for a real restore,
+# releases the tool and reads the verdict the job publishes.
+#
+# Unlike its sibling test_submit_examples_to_flink.sh, a successful submission is
+# NOT a pass: the only pass is a verdict file that says so.
+#
+# Env: FLINK_VERSION (default 2.3.0), FLINK_HOME (reuse existing install),
+#      VERBOSE=1 (set -x), plus the *_TIMEOUT overrides below.
+#
+# A FLINK_HOME passed in has to be that same FLINK_VERSION. The run copies
+# opt/flink-python-<FLINK_VERSION>.jar into its lib/ and stops when that file is
+# not there, so point FLINK_VERSION at whatever installation FLINK_HOME names.
+
+set -euo pipefail
+
+if [[ "${VERBOSE:-0}" == "1" ]]; then
+    set -x
+fi
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()    { printf "${BLUE}[INFO]${NC}  %s\n"  "$*" >&2; }
+log_ok()      { printf "${GREEN}[OK]${NC}    %s\n" "$*" >&2; }
+log_warn()    { printf "${YELLOW}[WARN]${NC}  %s\n" "$*" >&2; }
+log_error()   { printf "${RED}[ERROR]${NC} %s\n"   "$*" >&2; }
+log_section() {
+    printf "\n${BLUE}==============================================================${NC}\n" >&2
+    printf "${BLUE}>>> %s${NC}\n" "$*" >&2
+    printf   "${BLUE}==============================================================${NC}\n" >&2
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.."; pwd)"
+log_info "Project root: $ROOT_DIR"
+
+FLINK_VERSION="${FLINK_VERSION:-2.3.0}"
+FLINK_MAJOR_MINOR="${FLINK_VERSION%.*}"
+REST_URL="${REST_URL:-http://localhost:8081}"
+
+JOB_MODULE="flink_agents/e2e_tests/e2e_tests_integration/checkpoint_recovery_job.py"
+EXPECTED_AGENTS_VERSION="${EXPECTED_AGENTS_VERSION:-0.3.dev0}"
+
+# Checkpoint interval is deliberately short: the run is parked while we wait for two
+# checkpoints to complete, and that wait is charged against the tool's own deadline.
+# Held in milliseconds because that is the unit the checkpoint-config endpoint reports,
+# so the value written and the value asserted are the same number.
+CHECKPOINT_INTERVAL_MS="${CHECKPOINT_INTERVAL_MS:-5000}"
+RESTART_ATTEMPTS="${RESTART_ATTEMPTS:-3}"
+# Unset, this falls back to slot.request.timeout (5 min), after which a pending slot
+# request is failed and one restart attempt is burned while the TM is being replaced.
+STANDALONE_STARTUP_TIME="${STANDALONE_STARTUP_TIME:-600s}"
+
+# Budgets. Setup waits are unconstrained; the four marked ones run after the tool has
+# parked and are therefore charged against the tool's own release deadline. They are
+# clamped at runtime to the time actually remaining (see charged_timeout), so these
+# numbers are ceilings rather than guarantees.
+CLUSTER_TIMEOUT="${CLUSTER_TIMEOUT:-120}"
+SUBMIT_TIMEOUT="${SUBMIT_TIMEOUT:-300}"
+JOB_RUNNING_TIMEOUT="${JOB_RUNNING_TIMEOUT:-180}"
+IDENTITY_TIMEOUT="${IDENTITY_TIMEOUT:-180}"
+TOOL_ENTERED_TIMEOUT="${TOOL_ENTERED_TIMEOUT:-300}"
+CHECKPOINT_TIMEOUT="${CHECKPOINT_TIMEOUT:-30}"    # charged against the tool deadline
+TM_GONE_TIMEOUT="${TM_GONE_TIMEOUT:-45}"          # charged against the tool deadline
+TM_UP_TIMEOUT="${TM_UP_TIMEOUT:-30}"              # charged against the tool deadline
+RESTORE_TIMEOUT="${RESTORE_TIMEOUT:-30}"          # charged against the tool deadline
+VERDICT_TIMEOUT="${VERDICT_TIMEOUT:-120}"
+POLL_INTERVAL="${POLL_INTERVAL:-2}"
+
+# Every REST call is bounded. This is charged in the budget arithmetic, so keep the
+# two in step: a healthy local JobManager answers in milliseconds, and a large value
+# here buys nothing while inflating the worst-case overrun of every wait.
+CURL_MAX_TIME="${CURL_MAX_TIME:-5}"
+
+# Wall-clock costs inside the charged window that belong to no single wait: the
+# individual REST reads between the waits, two jps invocations, the SIGKILL grace and
+# starting the replacement TaskManager. This is an estimate, and deliberately only
+# feeds the pre-flight feasibility check — the runtime clamp is what actually holds
+# the guarantee, so being wrong here cannot let the tool self-release.
+HANDSHAKE_FIXED_COST_S="${HANDSHAKE_FIXED_COST_S:-45}"
+
+# Kept in hand so `release` is written comfortably before the tool gives up, covering
+# the tool's own poll interval and the one-second granularity of SECONDS.
+HANDSHAKE_SAFETY_S="${HANDSHAKE_SAFETY_S:-15}"
+
+# Bash 3 (default on macOS) lacks associative arrays.
+RESULT_NAMES=()
+RESULT_STATES=()
+SUBMITTED_JOB_IDS=()
+CONFIG_KEYS_SET=()
+JOB_ID=""
+WORK_DIR=""
+HANDSHAKE_DIR=""
+VERDICT_DIR=""
+CHECKPOINT_DIR=""
+INPUT_DIR=""
+INPUT_FILE=""
+FLINK_CONF=""
+TM_PID_BEFORE=""
+TM_RESOURCE_ID_BEFORE=""
+RESTORED_BEFORE=""
+RELEASE_DEADLINE_S=""
+HANDSHAKE_DEADLINE_AT=""
+
+cleanup() {
+    local exit_code=$?
+    log_section "Cleanup"
+
+    if [[ -n "${FLINK_HOME:-}" && -x "$FLINK_HOME/bin/flink" ]]; then
+        for jid in "${SUBMITTED_JOB_IDS[@]:-}"; do
+            [[ -n "$jid" ]] || continue
+            log_info "Cancelling job $jid"
+            "$FLINK_HOME/bin/flink" cancel "$jid" >/dev/null 2>&1 || true
+        done
+
+        if [[ -x "$FLINK_HOME/bin/stop-cluster.sh" ]]; then
+            # If the TaskManager was killed and never replaced, this prints
+            # "No taskexecutor daemon (pid: N) is running anymore" into the archive.
+            # That line is expected here and is not the failure.
+            log_info "Stopping Flink cluster"
+            "$FLINK_HOME/bin/stop-cluster.sh" >/dev/null 2>&1 || true
+        fi
+
+        # Archive the whole log directory, never named files: `kill -9` leaves the
+        # dead TaskManager's pid in the pid file, so the replacement writes to a
+        # higher log index and a named copy would miss the post-restore TaskManager.
+        if [[ -d "$FLINK_HOME/log" ]]; then
+            local log_archive="$ROOT_DIR/flink-logs-$(date +%Y%m%d-%H%M%S).tar.gz"
+            tar -czf "$log_archive" -C "$FLINK_HOME" log >/dev/null 2>&1 \
+                && log_info "Flink logs archived to: $log_archive" \
+                || log_warn "Failed to archive Flink logs"
+        fi
+    fi
+
+    # Strip the keys we appended. A second run against a reused Flink home would
+    # otherwise append them twice, and a duplicate key is a hard YAML parse failure
+    # that stops the cluster from starting at all.
+    if [[ -n "$FLINK_CONF" && -f "$FLINK_CONF" ]]; then
+        local key
+        for key in "${CONFIG_KEYS_SET[@]:-}"; do
+            [[ -n "$key" ]] || continue
+            delete_config_key "$key"
+        done
+        log_info "Reverted ${#CONFIG_KEYS_SET[@]} appended config key(s)"
+    fi
+
+    # The killed TaskManager's entry stays in /tmp/flink-*-taskexecutor.pid, which
+    # only nudges the next local run's log-file index upward. That file is shared by
+    # any Flink cluster this user runs, so it is left alone rather than risking a
+    # concurrent cluster's shutdown for a cosmetic gain.
+
+    # The work directory holds the verdict file, the handshake markers and the
+    # checkpoints — everything needed to explain a failure. Remove it only when the
+    # run both recorded assertions and is exiting cleanly; otherwise keep it and say
+    # where it is. A non-zero exit code is its own reason to keep: the setup steps and
+    # several assertions abort under set -e without recording anything, so judging by
+    # the recorded results alone would delete the diagnostics for exactly those.
+    if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
+        local keep=0 state
+        for state in "${RESULT_STATES[@]:-}"; do
+            [[ "$state" == "FAIL" ]] && keep=1
+        done
+        (( ${#RESULT_STATES[@]} == 0 )) && keep=1
+        (( exit_code != 0 )) && keep=1
+        if (( keep == 1 )); then
+            log_warn "Keeping diagnostics in $WORK_DIR (verdict, handshake markers, checkpoints)"
+        else
+            rm -rf "$WORK_DIR"
+        fi
+    fi
+
+    print_summary
+    exit "$exit_code"
+}
+trap cleanup EXIT
+
+print_summary() {
+    log_section "Test summary"
+    local total=${#RESULT_NAMES[@]}
+    if (( total == 0 )); then
+        # Exit non-zero rather than return: a run that recorded no assertion verified
+        # nothing, and reporting that as success is the precise failure this whole
+        # script exists to make impossible.
+        log_error "No assertion was recorded, so nothing was verified"
+        exit 1
+    fi
+    local passed=0
+    local failed=0
+    local i
+    for (( i = 0; i < total; i++ )); do
+        local name="${RESULT_NAMES[$i]}"
+        local state="${RESULT_STATES[$i]}"
+        if [[ "$state" == "PASS" ]]; then
+            printf "  ${GREEN}PASS${NC}  %s\n" "$name"
+            passed=$((passed + 1))
+        else
+            printf "  ${RED}FAIL${NC}  %s\n" "$name"
+            failed=$((failed + 1))
+        fi
+    done
+    printf "\nTotal: %d   Passed: %d   Failed: %d\n" "$total" "$passed" "$failed"
+
+    if (( failed > 0 )); then
+        log_error "$failed assertion(s) failed"
+        exit 1
+    fi
+}
+
+record_result() {
+    RESULT_NAMES+=("$1")
+    RESULT_STATES+=("$2")
+}
+
+# ---------------------------------------------------------------------------
+# JSON extraction. python3 rather than jq, whose presence on the runner is not
+# guaranteed.
+#
+# Exit 1 means "I could not read this": empty body, unparsable JSON, a path that
+# does not exist, or a leaf of the wrong type. Callers MUST keep that distinct
+# from "I read a value and did not like it yet" — reporting the first as the
+# second turns a wrong field name into a phantom timeout.
+# ---------------------------------------------------------------------------
+json_query() {
+    local mode="$1" path="$2"
+    python3 -c '
+import json
+import sys
+
+mode, path = sys.argv[1], sys.argv[2]
+raw = sys.stdin.read()
+if not raw.strip():
+    sys.exit(1)
+try:
+    doc = json.loads(raw)
+except ValueError:
+    sys.exit(1)
+
+# The cluster config endpoint answers with a list of {"key":..,"value":..} pairs,
+# and its keys contain dots, so it cannot go through the path walker below.
+if mode == "conf":
+    if not isinstance(doc, list):
+        sys.exit(1)
+    for item in doc:
+        if isinstance(item, dict) and item.get("key") == path:
+            value = item.get("value")
+            print("" if value is None else value)
+            sys.exit(0)
+    sys.exit(1)
+
+node = doc
+for part in path.split("."):
+    if isinstance(node, list) and part.isdigit() and int(part) < len(node):
+        node = node[int(part)]
+    elif isinstance(node, dict) and part in node:
+        node = node[part]
+    else:
+        sys.exit(1)
+
+if mode == "nullable":
+    # The key must be present; only its value may be null. A missing key is a
+    # read failure, so a misspelled field cannot masquerade as "not yet".
+    print("null" if node is None else "present")
+elif mode == "len":
+    if not isinstance(node, list):
+        sys.exit(1)
+    print(len(node))
+elif mode == "int":
+    if isinstance(node, bool) or not isinstance(node, int):
+        sys.exit(1)
+    print(node)
+elif mode == "str":
+    if not isinstance(node, str):
+        sys.exit(1)
+    print(node)
+else:
+    sys.exit(2)
+' "$mode" "$path"
+}
+
+rest_get() {
+    curl -fsS --max-time "$CURL_MAX_TIME" "$REST_URL$1" 2>/dev/null
+}
+
+rest_field() {
+    local path="$1" mode="$2" field="$3"
+    rest_get "$path" | json_query "$mode" "$field"
+}
+
+# ---------------------------------------------------------------------------
+# Compare an observed value against a spec: eq:V, ge:N, nonnull.
+#
+# Returns 0 on a match, 1 on a mismatch, and 2 when the comparison cannot be
+# evaluated at all — an unknown operator, or a non-integer operand for ge. Callers
+# must keep 2 apart from 1: the first means the spec is wrong, the second means the
+# condition is not satisfied yet.
+# ---------------------------------------------------------------------------
+value_matches() {
+    local observed="$1" spec="$2"
+    local op="${spec%%:*}" want="${spec#*:}"
+    case "$op" in
+        eq)      [[ "$observed" == "$want" ]] ;;
+        ge)
+            # (( )) evaluates its operands as shell arithmetic, so a non-numeric
+            # observation would be treated as a variable name and abort the script
+            # under set -u instead of simply not matching. Return 2 so the caller can
+            # tell "cannot compare" from "does not match".
+            if [[ ! "$observed" =~ ^-?[0-9]+$ ]] || [[ ! "$want" =~ ^-?[0-9]+$ ]]; then
+                log_error "value_matches: 'ge' needs two integers, got observed='$observed' want='$want'"
+                return 2
+            fi
+            (( observed >= want ))
+            ;;
+        nonnull) [[ "$observed" == "present" ]] ;;
+        *)       log_error "value_matches: unknown comparison '$spec'"; return 2 ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Poll a REST field until it satisfies a spec.
+#
+#   $1 label        human name of the step, used in both failure messages
+#   $2 path         REST path, e.g. /jobs/<id>/checkpoints
+#   $3 probe        "mode:field" that must ALWAYS parse on a healthy endpoint
+#   $4 target       "mode:field" being tested
+#   $5 spec         comparison, see value_matches
+#   $6 timeout      seconds
+#
+# The probe is what separates the two failure modes. If the probe never parses we
+# are not talking to the endpoint we think we are; if the probe parses but the
+# target never does, the target's field name is wrong (or this Flink build omits
+# it) — neither is evidence that the condition was false.
+# ---------------------------------------------------------------------------
+wait_for_rest() {
+    local label="$1" path="$2" probe="$3" target="$4" spec="$5" timeout="$6"
+    local probe_mode="${probe%%:*}" probe_field="${probe#*:}"
+    local target_mode="${target%%:*}" target_field="${target#*:}"
+
+    local probe_seen=0 target_seen=0 last=""
+    local body value rc
+    # Deadline, not accumulated sleeps: curl and the two python3 spawns per iteration
+    # are not free, so counting only the sleeps would let a nominal budget overrun by
+    # several times against a slow endpoint — and these budgets are what keep the
+    # recovery inside the tool's own release deadline.
+    local deadline=$((SECONDS + timeout))
+    log_info "$label: polling GET $path for $target_field ($spec), budget ${timeout}s"
+    while (( SECONDS < deadline )); do
+        body=$(rest_get "$path") || body=""
+        if [[ -n "$body" ]]; then
+            if printf '%s' "$body" | json_query "$probe_mode" "$probe_field" >/dev/null; then
+                probe_seen=1
+            fi
+            if value=$(printf '%s' "$body" | json_query "$target_mode" "$target_field"); then
+                target_seen=1
+                last="$value"
+                rc=0
+                value_matches "$value" "$spec" || rc=$?
+                if (( rc == 0 )); then
+                    log_ok "$label: $target_field is $value"
+                    return 0
+                elif (( rc > 1 )); then
+                    log_error "$label: comparison '$spec' cannot be evaluated against '$value'"
+                    return 1
+                fi
+            fi
+        fi
+        sleep "$POLL_INTERVAL"
+    done
+
+    # Order matters: an observed target is reported even when the probe never parsed,
+    # because in that state the condition really was evaluated and really was false,
+    # and claiming otherwise would withhold the one value a reader needs.
+    if (( target_seen == 1 )); then
+        log_error "$label: '$target_field' from GET $REST_URL$path was last '$last' after ${timeout}s and never satisfied '$spec'."
+        if (( probe_seen == 0 )); then
+            log_warn "$label: the probe field '$probe_field' never parsed, so the response shape is only partly as expected."
+        fi
+    elif (( probe_seen == 1 )); then
+        log_error "$label: parsed '$probe_field' from GET $REST_URL$path, so the endpoint is right, but never parsed '$target_field' in ${timeout}s. Either the field name is wrong or this Flink build omits it. This is NOT evidence that the condition was false."
+    else
+        log_error "$label: never parsed '$probe_field' or '$target_field' from GET $REST_URL$path in ${timeout}s. The endpoint did not answer, or its response shape is not what this script expects. This is NOT evidence that the condition was false."
+    fi
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Wait for an exact filename. Never a glob: every file the job publishes is
+# written to "<name>.tmp" and renamed, so a crash between the two steps leaves a
+# permanent ".tmp" twin that a glob would happily read as the real thing.
+# ---------------------------------------------------------------------------
+wait_for_file() {
+    local label="$1" file="$2" timeout="$3"
+    local deadline=$((SECONDS + timeout))
+    log_info "$label: waiting for $file, budget ${timeout}s"
+    while (( SECONDS < deadline )); do
+        if [[ -f "$file" ]]; then
+            log_ok "$label: $file appeared"
+            return 0
+        fi
+        sleep "$POLL_INTERVAL"
+    done
+    local dir
+    dir="$(dirname "$file")"
+    log_error "$label: $file did not appear within ${timeout}s"
+    if [[ -f "$file.tmp" ]]; then
+        log_error "$label: found a leftover $file.tmp — the writer was interrupted between write and rename"
+    fi
+    if [[ -d "$dir" ]]; then
+        local listing
+        listing=$(find "$dir" -maxdepth 1 -mindepth 1 2>/dev/null | sed 's|.*/||' | sort | tr '\n' ' ')
+        log_info "$label: $dir currently holds: $listing"
+    else
+        log_error "$label: the directory $dir does not exist"
+    fi
+    return 1
+}
+
+install_flink_distribution() {
+    local install_dir="$1"
+
+    # Reuse install.sh's download, archive validation and extraction logic, but
+    # stop before it installs a *released* Flink Agents JAR. That step derives its
+    # download URL from the Flink version, and no such artifact is published for
+    # every Flink version this test runs against — asking for one that does not
+    # exist would abort the install. This test must run the artifacts built from
+    # the current checkout anyway, which stage_dist_jars puts in place below.
+    FLINK_AGENTS_INSTALL_SH_NO_RUN=1 \
+        FLINK_VERSION="$FLINK_VERSION" \
+        INSTALL_FLINK=Yes \
+        INSTALL_DIR="$install_dir" \
+        NO_PROMPT=1 \
+        bash -c '
+            source "$1"
+            plan_flink
+            install_flink_if_needed
+        ' _ "$ROOT_DIR/tools/install.sh"
+}
+
+# Replaces install.sh's setup_python_env, which would populate the venv with a
+# released flink-agents. This creates a plain venv and nothing more; the packages
+# arrive later, from tools/build.sh's `uv pip install dist/*.whl` and from
+# install_built_python_package.
+prepare_python_venv() {
+    if [[ -f "$VENV_DIR/pyvenv.cfg" && -x "$VENV_DIR/bin/python" ]]; then
+        # Reuse is unconditional on the interpreter: unlike install.sh, this accepts
+        # a venv built by a Python outside the range python/pyproject.toml declares.
+        log_info "Reusing Python venv: $VENV_DIR"
+        return
+    fi
+    if [[ -e "$VENV_DIR" ]] \
+        && [[ ! -d "$VENV_DIR" \
+            || -n "$(find "$VENV_DIR" -mindepth 1 -print -quit 2>/dev/null)" ]]; then
+        log_error "VENV_DIR is not an empty directory or a valid venv: $VENV_DIR"
+        return 1
+    fi
+
+    local python_bin="${PYTHON_BIN:-python3}"
+    log_info "Creating Python venv: $VENV_DIR"
+    "$python_bin" -m venv "$VENV_DIR"
+}
+
+install_flink() {
+    log_section "Install Flink standalone (version $FLINK_VERSION)"
+
+    # Anchor VENV_DIR to the repo so a fresh and a reused Flink installation share
+    # one Python environment, and so later steps can address it by path.
+    export VENV_DIR="${VENV_DIR:-$ROOT_DIR/.flink-agents-env}"
+
+    if [[ -n "${FLINK_HOME:-}" && -x "$FLINK_HOME/bin/flink" ]]; then
+        log_info "Reusing existing FLINK_HOME: $FLINK_HOME"
+        export FLINK_HOME
+    else
+        local install_dir="${INSTALL_DIR:-$HOME/.local/flink}"
+        log_info "Installing the Flink distribution with tools/install.sh helpers"
+        install_flink_distribution "$install_dir"
+        export FLINK_HOME="${install_dir}/flink-${FLINK_VERSION}"
+
+        if [[ ! -x "$FLINK_HOME/bin/flink" ]]; then
+            log_error "Flink installation not found at expected path: $FLINK_HOME"
+            exit 1
+        fi
+        log_ok "Flink installed at: $FLINK_HOME"
+    fi
+
+    # The distribution ships the PyFlink jar under opt/, outside the lib/ directory
+    # the cluster loads. install.sh copies it across as part of --enable-pyflink,
+    # which is no longer reached from here, so the copy happens here — on both branches
+    # above, since a reused FLINK_HOME need not have been prepared by install.sh.
+    local pyflink_jar="$FLINK_HOME/opt/flink-python-${FLINK_VERSION}.jar"
+    if [[ ! -f "$pyflink_jar" ]]; then
+        log_error "PyFlink JAR not found in Flink distribution: $pyflink_jar"
+        exit 1
+    fi
+    cp "$pyflink_jar" "$FLINK_HOME/lib/"
+
+    prepare_python_venv
+
+    # Both branches above fall through to here, so the venv is activated whether
+    # FLINK_HOME was reused or freshly installed. That is load-bearing: the
+    # TaskManager daemon inherits this shell's PATH and resolves a bare `python`
+    # from it, and this script restarts the TaskManager mid-test — so an
+    # unactivated shell would give the replacement TaskManager a different
+    # interpreter from the original. Activation settles which interpreter that is
+    # and nothing more — what is installed in it is install_built_python_package's
+    # business, and that runs later.
+    if [[ ! -x "$VENV_DIR/bin/python" ]]; then
+        log_error "Expected Python venv not found at: $VENV_DIR"
+        exit 1
+    fi
+    # shellcheck disable=SC1091
+    source "$VENV_DIR/bin/activate"
+    log_ok "Activated Python venv: $VENV_DIR"
+
+    FLINK_CONF="$FLINK_HOME/conf/config.yaml"
+    if [[ ! -f "$FLINK_CONF" ]]; then
+        log_error "Flink config not found: $FLINK_CONF"
+        exit 1
+    fi
+}
+
+# The wheel this run must exercise is the one tools/build.sh just produced, so it is
+# installed from python/dist rather than from PyPI. apache-flink is pinned to the
+# Flink version the cluster runs, because the submitting client and the TaskManager
+# both execute this same interpreter.
+install_built_python_package() {
+    local wheel
+    wheel=$(find "$ROOT_DIR/python/dist" -maxdepth 1 -name '*.whl' | head -n 1)
+    if [[ -z "$wheel" ]]; then
+        log_error "Python wheel not found after build in: $ROOT_DIR/python/dist"
+        return 1
+    fi
+
+    log_info "Installing $(basename "$wheel") and apache-flink==$FLINK_VERSION into $VENV_DIR"
+    "$VENV_DIR/bin/python" -m pip install --quiet \
+        "$wheel" "apache-flink==$FLINK_VERSION"
+
+    if ! "$VENV_DIR/bin/python" -c 'import flink_agents, pyflink' >/dev/null 2>&1; then
+        log_error "The built Flink Agents wheel or PyFlink is not importable from: $VENV_DIR/bin/python"
+        return 1
+    fi
+
+    export PYFLINK_CLIENT_EXECUTABLE="$VENV_DIR/bin/python"
+    log_ok "Installed the built wheel and PyFlink into: $VENV_DIR"
+}
+
+build_project() {
+    log_section "Build flink-agents (Java + Python)"
+    (
+        cd "$ROOT_DIR"
+        SKIP_SPOTLESS_CHECK=true bash tools/build.sh
+    )
+    install_built_python_package
+    log_ok "Build completed"
+}
+
+stage_dist_jars() {
+    log_section "Stage dist uber jar into \$FLINK_HOME/lib"
+
+    local project_version
+    project_version=$(sed -n 's/.*<version>\(.*\)<\/version>.*/\1/p' \
+        "$ROOT_DIR/pom.xml" | head -n 2 | tail -n 1)
+    log_info "Detected project version: $project_version"
+
+    # The flink-version uber jar already bundles the common deps.
+    local flink_jar="$ROOT_DIR/dist/flink-${FLINK_MAJOR_MINOR}/target/flink-agents-dist-flink-${FLINK_MAJOR_MINOR}-${project_version}.jar"
+
+    if [[ ! -f "$flink_jar" ]]; then
+        log_error "Flink dist jar not found: $flink_jar"
+        exit 1
+    fi
+
+    # Drop any flink-agents-dist jar already in lib/ before copying. A reused
+    # FLINK_HOME may still carry one — from an earlier tools/install.sh run, or from
+    # an earlier run of this test at a different project version — and a jar of a
+    # different version has a different filename, so the copy below would not
+    # replace it and both would sit on the classpath.
+    rm -f "$FLINK_HOME/lib/"/flink-agents-dist-*.jar
+    cp "$flink_jar"  "$FLINK_HOME/lib/"
+    log_ok "Staged: $(basename "$flink_jar")"
+}
+
+prepare_work_dirs() {
+    log_section "Create input, handshake, verdict and checkpoint directories"
+    WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/flink-agents-recovery.XXXXXX")"
+    HANDSHAKE_DIR="$WORK_DIR/handshake"
+    VERDICT_DIR="$WORK_DIR/verdict"
+    CHECKPOINT_DIR="$WORK_DIR/checkpoints"
+    INPUT_DIR="$WORK_DIR/input"
+    # The name is load-bearing. Flink's default file filter skips any name beginning
+    # with '.' or '_', and applies that even to a path the source was handed directly,
+    # which would leave the job running with nothing to read and nothing logged.
+    INPUT_FILE="$INPUT_DIR/trigger.txt"
+    # The job must never create these itself: a tool that provisions its own
+    # handshake directory cannot tell "the harness set me up" from "my path is wrong".
+    mkdir -p "$HANDSHAKE_DIR" "$VERDICT_DIR" "$CHECKPOINT_DIR" "$INPUT_DIR"
+
+    # One line is all the source needs: the job builds the record from a constant it
+    # shares with the assertion and ignores this content. Written under a temporary
+    # name and renamed, so the file is whole the instant it appears under the name the
+    # source reads. Submission is several steps away, and that distance is what
+    # actually orders the two — the rename is redundancy, not the ordering mechanism.
+    printf 'trigger\n' > "$INPUT_FILE.tmp"
+    mv "$INPUT_FILE.tmp" "$INPUT_FILE"
+    # An empty file produces no record and no error. Nothing that depends on a record
+    # then runs, the agent's identity report included, so the run surfaces as the
+    # runtime-identity wait expiring with nothing pointing at the input. A wrong path
+    # needs no guard here: enumeration is eager, so the job fails within seconds with
+    # "Could not enumerate file splits".
+    if [[ ! -s "$INPUT_FILE" ]]; then
+        log_error "Trigger file is missing or empty: $INPUT_FILE"
+        return 1
+    fi
+
+    log_ok "Work directory: $WORK_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# Config editing. Delete-then-append, so applying the same key twice is a no-op
+# rather than a duplicate YAML key.
+#
+# A flat dotted key at column 0 is read correctly regardless of the nested blocks
+# the shipped file uses, because Flink flattens the parsed document before
+# building its Configuration. Appending (never prepending) also means our value
+# wins any collision with a nested block, since the flattened map is populated in
+# document order.
+# ---------------------------------------------------------------------------
+delete_config_key() {
+    local config_key="$1"
+    local tmp
+    tmp="$(mktemp)"
+    # grep -v exits 1 when it filters everything out, which set -e would treat as
+    # fatal. The dots in the key are regex "any char"; harmless for these keys.
+    grep -v "^${config_key}: " "$FLINK_CONF" > "$tmp" || true
+    mv "$tmp" "$FLINK_CONF"
+}
+
+set_config_key() {
+    local config_key="$1" value="$2"
+    delete_config_key "$config_key"
+    printf '%s: %s\n' "$config_key" "$value" >> "$FLINK_CONF"
+    CONFIG_KEYS_SET+=("$config_key")
+}
+
+configure_flink() {
+    log_section "Configure checkpointing and restart strategy"
+
+    # Without an interval, checkpointing is simply off — the option has no default.
+    # That is the one misconfiguration that would let this whole test pass having
+    # verified nothing, which is why the effective value is read back below.
+    set_config_key "execution.checkpointing.interval" "${CHECKPOINT_INTERVAL_MS}ms"
+    set_config_key "execution.checkpointing.dir" "file://$CHECKPOINT_DIR"
+    # Every other Python e2e test in this repo disables restarts. This one must not:
+    # without a restart strategy the job dies on the TaskManager loss instead of
+    # recovering from its checkpoint.
+    set_config_key "restart-strategy.type" "fixed-delay"
+    set_config_key "restart-strategy.fixed-delay.attempts" "$RESTART_ATTEMPTS"
+    set_config_key "resourcemanager.standalone.start-up-time" "$STANDALONE_STARTUP_TIME"
+
+    log_ok "Appended ${#CONFIG_KEYS_SET[@]} config key(s) to $FLINK_CONF"
+}
+
+# ---------------------------------------------------------------------------
+# Read the keys back from the running JobManager. Writing to a file only proves
+# we wrote to a file.
+#
+# What this does and does not establish: /jobmanager/config echoes the loaded
+# configuration including keys Flink does not recognize, so a value matching here
+# proves the append reached the configuration the JobManager parsed — not that the
+# option has any effect. The one key where that distinction matters is the
+# checkpoint interval, and it is asserted separately and authoritatively by
+# assert_checkpointing_enabled once a job exists.
+# ---------------------------------------------------------------------------
+assert_effective_config() {
+    log_section "Verify the JobManager loaded the config we wrote"
+
+    local exact_keys=(
+        "execution.checkpointing.dir=file://$CHECKPOINT_DIR"
+        "restart-strategy.type=fixed-delay"
+        "restart-strategy.fixed-delay.attempts=$RESTART_ATTEMPTS"
+        "resourcemanager.standalone.start-up-time=$STANDALONE_STARTUP_TIME"
+    )
+
+    local body
+    body=$(rest_get "/jobmanager/config") || body=""
+    if [[ -z "$body" ]]; then
+        log_error "Could not read GET $REST_URL/jobmanager/config"
+        record_result "effective-config" "FAIL"
+        return 1
+    fi
+
+    local ok=1 entry key want got
+    for entry in "${exact_keys[@]}"; do
+        key="${entry%%=*}"; want="${entry#*=}"
+        if got=$(printf '%s' "$body" | json_query conf "$key"); then
+            if [[ "$got" == "$want" ]]; then
+                log_ok "config $key = $got"
+            else
+                log_error "config $key is '$got', expected '$want'"
+                ok=0
+            fi
+        else
+            log_error "config $key is absent from the cluster configuration — the append did not take effect"
+            ok=0
+        fi
+    done
+
+    if (( ok == 0 )); then
+        record_result "effective-config" "FAIL"
+        return 1
+    fi
+    record_result "effective-config" "PASS"
+}
+
+# ---------------------------------------------------------------------------
+# The authoritative check that checkpointing is actually on for this job.
+#
+# /jobs/{id}/checkpoints/config is served from the job's own CheckpointCoordinator
+# configuration rather than from the raw config file, so unlike /jobmanager/config
+# it cannot echo a key back that Flink ignored. It 404s outright when the job has
+# no checkpointing, and reports the interval in exact milliseconds.
+#
+# This is the guard on the one misconfiguration that would let the whole test pass
+# having verified nothing.
+# ---------------------------------------------------------------------------
+assert_checkpointing_enabled() {
+    log_section "Verify checkpointing is enabled for this job"
+
+    local body
+    body=$(rest_get "/jobs/$JOB_ID/checkpoints/config") || body=""
+    if [[ -z "$body" ]]; then
+        log_error "Could not read GET $REST_URL/jobs/$JOB_ID/checkpoints/config. This endpoint answers only when the job has checkpointing configured, so an empty or 404 response means checkpointing is off and nothing would be captured to recover."
+        record_result "checkpointing-enabled" "FAIL"
+        return 1
+    fi
+
+    local interval
+    if ! interval=$(printf '%s' "$body" | json_query int "interval"); then
+        log_error "Could not read 'interval' from GET $REST_URL/jobs/$JOB_ID/checkpoints/config; the response was: $body"
+        record_result "checkpointing-enabled" "FAIL"
+        return 1
+    fi
+    if [[ "$interval" != "$CHECKPOINT_INTERVAL_MS" ]]; then
+        log_error "The job's checkpoint interval is ${interval}ms, expected ${CHECKPOINT_INTERVAL_MS}ms. The value written to $FLINK_CONF is not the value in effect."
+        record_result "checkpointing-enabled" "FAIL"
+        return 1
+    fi
+    log_ok "checkpointing-enabled: interval ${interval}ms"
+
+    # The two-checkpoint containment gate assumes checkpoints do not overlap, which
+    # is Flink's default of one concurrent checkpoint. Read from the same
+    # authoritative endpoint rather than inferred.
+    local max_concurrent
+    if max_concurrent=$(printf '%s' "$body" | json_query int "max_concurrent"); then
+        log_info "checkpointing-enabled: max_concurrent = $max_concurrent"
+        (( max_concurrent == 1 )) || log_warn "More than one concurrent checkpoint is allowed, so the two-checkpoint containment gate is weaker than intended: the second completion no longer implies it started after the first finished."
+    else
+        log_warn "Could not read 'max_concurrent'; the containment gate assumes it is 1"
+    fi
+
+    record_result "checkpointing-enabled" "PASS"
+}
+
+start_cluster() {
+    log_section "Start Flink standalone cluster"
+    "$FLINK_HOME/bin/start-cluster.sh"
+
+    log_info "Waiting for JobManager REST API at $REST_URL ..."
+    local deadline=$((SECONDS + CLUSTER_TIMEOUT))
+    while (( SECONDS < deadline )); do
+        if curl -fsS "$REST_URL/overview" >/dev/null 2>&1; then
+            log_ok "Flink cluster is up"
+            return 0
+        fi
+        sleep "$POLL_INTERVAL"
+    done
+
+    log_error "Flink cluster did not become ready within ${CLUSTER_TIMEOUT}s. A duplicate key in $FLINK_CONF is the usual cause; check the JobManager log for a YAML parse error."
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# The tool releases itself after RELEASE_TIMEOUT_S whether or not this script has
+# finished the kill/restart cycle, so everything between "tool parked" and "release
+# created" has to fit inside that. The deadline is read from the payload module
+# rather than restated, so the two cannot drift apart.
+#
+# The guarantee is held by measurement, not prediction. start_handshake_clock stamps
+# a real wall-clock deadline the moment the tool parks, and every charged step takes
+# the smaller of its configured budget and the time actually left. That way a cost
+# nobody modelled — a slow REST call, a sluggish TaskManager start, anything — has
+# already consumed real time and simply leaves the next step less to spend. Summing
+# nominal timeouts could not do this: the sum says nothing about what the run spent.
+# ---------------------------------------------------------------------------
+read_release_deadline() {
+    RELEASE_DEADLINE_S=$(PYTHONPATH="$ROOT_DIR/python" "$VENV_DIR/bin/python" -c \
+        'from flink_agents.e2e_tests.e2e_tests_integration.checkpoint_recovery_agent import RELEASE_TIMEOUT_S; print(int(RELEASE_TIMEOUT_S))') || {
+        log_error "Could not read RELEASE_TIMEOUT_S from the payload module. The job would not be importable on the TaskManager either."
+        exit 1
+    }
+}
+
+start_handshake_clock() {
+    HANDSHAKE_DEADLINE_AT=$((SECONDS + RELEASE_DEADLINE_S - HANDSHAKE_SAFETY_S))
+    log_info "Handshake clock started: ${RELEASE_DEADLINE_S}s tool deadline less ${HANDSHAKE_SAFETY_S}s safety, so $((RELEASE_DEADLINE_S - HANDSHAKE_SAFETY_S))s to reach the release"
+}
+
+# Seconds left before the tool would release itself. Never negative.
+handshake_budget_left() {
+    local left=$((HANDSHAKE_DEADLINE_AT - SECONDS))
+    (( left < 0 )) && left=0
+    printf '%s' "$left"
+}
+
+# The smaller of a step's configured ceiling and the time actually remaining. Returns
+# 1 when nothing is left, so the caller fails on the real reason rather than starting
+# a wait that cannot finish.
+charged_timeout() {
+    local label="$1" configured="$2" left
+    left="$(handshake_budget_left)"
+    if (( left <= 0 )); then
+        log_error "$label: the tool's ${RELEASE_DEADLINE_S}s release deadline elapsed before this step began, so the tool has already released itself and the recovery window is gone. Earlier steps ran slower than their budgets allow for."
+        return 1
+    fi
+    if (( configured > left )); then
+        log_warn "$label: budget trimmed from ${configured}s to ${left}s, the time left before the tool releases itself"
+        printf '%s' "$left"
+    else
+        printf '%s' "$configured"
+    fi
+}
+
+# Pre-flight feasibility check, run before the job is submitted so an unusable
+# configuration fails in seconds rather than twenty minutes in.
+#
+# This one predicts, so it is deliberately conservative: each charged wait is billed
+# its ceiling plus one poll interval and one request timeout, because the loop tests
+# its deadline at the top and a poll already in flight can overrun by that much. The
+# costs belonging to no single wait are billed as HANDSHAKE_FIXED_COST_S. Being wrong
+# here can only make this check over- or under-eager; it cannot let the tool
+# self-release, because that is the runtime clamp's job.
+assert_handshake_budget() {
+    log_section "Check the recovery budget against the tool's deadline"
+
+    read_release_deadline
+
+    local per_wait_overrun=$((POLL_INTERVAL + CURL_MAX_TIME))
+    local ceilings=$((CHECKPOINT_TIMEOUT + TM_GONE_TIMEOUT + TM_UP_TIMEOUT + RESTORE_TIMEOUT))
+    local predicted=$((ceilings + 4 * per_wait_overrun + HANDSHAKE_FIXED_COST_S))
+    local allowed=$((RELEASE_DEADLINE_S - HANDSHAKE_SAFETY_S))
+
+    # The tool's deadline is named on the success path too, not only in the failure
+    # message: which deadline the run was measured against is the fact a reader needs,
+    # and it comes from the payload module rather than from anything restated here.
+    log_info "Charged waits total ${ceilings}s of ceilings, plus ${per_wait_overrun}s possible overrun each and ${HANDSHAKE_FIXED_COST_S}s of unattributed cost: ${predicted}s predicted against ${allowed}s allowed, from the tool's ${RELEASE_DEADLINE_S}s release deadline less ${HANDSHAKE_SAFETY_S}s safety"
+
+    if (( predicted > allowed )); then
+        log_error "The recovery sequence could take up to ${predicted}s of wall clock, which exceeds the ${allowed}s available before the tool releases itself (${RELEASE_DEADLINE_S}s deadline less ${HANDSHAKE_SAFETY_S}s safety). The run would fail as a handshake timeout and misattribute harness slowness to the handshake. Lower CHECKPOINT_TIMEOUT / TM_GONE_TIMEOUT / TM_UP_TIMEOUT / RESTORE_TIMEOUT, or CURL_MAX_TIME."
+        exit 1
+    fi
+    log_ok "Recovery budget fits with $((allowed - predicted))s of predicted slack"
+}
+
+extract_job_id() {
+    # "Job has been submitted with JobID <id>"
+    grep -Eo 'JobID [0-9a-f]{32}' "$1" | tail -n 1 | awk '{print $2}'
+}
+
+submit_job() {
+    log_section "Submit the recovery job"
+
+    local script_path="$ROOT_DIR/python/$JOB_MODULE"
+    if [[ ! -f "$script_path" ]]; then
+        log_error "Job program not found: $script_path"
+        exit 1
+    fi
+
+    local purelib
+    purelib=$("$VENV_DIR/bin/python" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
+
+    local out rc=0
+    out=$(mktemp)
+    # -pyexec / -pypath are the option names the Flink CLI accepts (the long forms
+    # are --pyExecutable and --pyPythonPath). The repo tree precedes the installed
+    # wheel on the path, which is priority rather than isolation, so the version
+    # this run actually imported is asserted from the job's own report below.
+    timeout "$SUBMIT_TIMEOUT" "$FLINK_HOME/bin/flink" run \
+            --detached \
+            -pyexec "$VENV_DIR/bin/python" \
+            -pypath "$ROOT_DIR/python:$purelib" \
+            -py "$script_path" \
+            --input-file "$INPUT_FILE" \
+            --handshake-dir "$HANDSHAKE_DIR" \
+            --verdict-dir "$VERDICT_DIR" >"$out" 2>&1 || rc=$?
+    cat "$out"
+
+    if (( rc != 0 )); then
+        log_error "Job submission failed (exit $rc)"
+        rm -f "$out"
+        exit 1
+    fi
+
+    JOB_ID=$(extract_job_id "$out") || true
+    rm -f "$out"
+    if [[ -z "$JOB_ID" ]]; then
+        log_error "Could not extract the job id from the submission output"
+        exit 1
+    fi
+    SUBMITTED_JOB_IDS+=("$JOB_ID")
+    log_ok "Submitted (JobID: $JOB_ID)"
+}
+
+wait_job_running() {
+    wait_for_rest "job-running" "/jobs/$JOB_ID" "str:state" "str:state" "eq:RUNNING" \
+        "$JOB_RUNNING_TIMEOUT" || { record_result "job-running" "FAIL"; return 1; }
+}
+
+# ---------------------------------------------------------------------------
+# The job writes an identity report from the TaskManager before it parks. This is
+# a fail-fast gate: it catches a wrong flink-agents on the TaskManager's path
+# before we spend the whole kill/restart cycle. It describes the process that is
+# about to be killed; the copy that describes the process performing the
+# assertions travels inside the verdict record.
+# ---------------------------------------------------------------------------
+assert_runtime_identity() {
+    log_section "Check which flink-agents the TaskManager imported"
+
+    local identity="$HANDSHAKE_DIR/runtime-identity.json"
+    if ! wait_for_file "runtime-identity" "$identity" "$IDENTITY_TIMEOUT"; then
+        record_result "runtime-identity" "FAIL"
+        return 1
+    fi
+
+    local version module_file
+    if ! version=$(json_query str "flink_agents_version" < "$identity"); then
+        log_error "runtime-identity: could not read 'flink_agents_version' from $identity"
+        cat "$identity" >&2 || true
+        record_result "runtime-identity" "FAIL"
+        return 1
+    fi
+    if ! module_file=$(json_query str "flink_agents_api_file" < "$identity"); then
+        log_error "runtime-identity: could not read 'flink_agents_api_file' from $identity"
+        cat "$identity" >&2 || true
+        record_result "runtime-identity" "FAIL"
+        return 1
+    fi
+    log_info "TaskManager imported flink_agents from: $module_file"
+
+    if [[ "$version" != "$EXPECTED_AGENTS_VERSION" ]]; then
+        log_error "runtime-identity: TaskManager reports flink-agents $version, expected $EXPECTED_AGENTS_VERSION. The job ran against a different installation than the one just built."
+        record_result "runtime-identity" "FAIL"
+        return 1
+    fi
+
+    # The version alone comes from distribution metadata and cannot tell two trees
+    # apart that both call themselves 0.3.dev0 — an installed wheel and this working
+    # tree would report the same string. The api-file probe is what identifies the
+    # tree, so assert it points inside the checkout -pypath was pointed at.
+    local expected_prefix="$ROOT_DIR/python/flink_agents/api/"
+    if [[ "$module_file" != "$expected_prefix"* ]]; then
+        log_error "runtime-identity: the TaskManager imported flink_agents.api from '$module_file', which is not under '$expected_prefix'. The job exercised a different copy of the code than the one in this checkout, so a pass would not be evidence about these sources."
+        record_result "runtime-identity" "FAIL"
+        return 1
+    fi
+
+    log_ok "runtime-identity: flink-agents $version from $module_file"
+    record_result "runtime-identity" "PASS"
+}
+
+wait_tool_parked() {
+    log_section "Wait for the job to park inside the tool call"
+    if ! wait_for_file "tool-parked" "$HANDSHAKE_DIR/tool-entered" "$TOOL_ENTERED_TIMEOUT"; then
+        log_error "tool-parked: the agent never reached the blocking tool, so the tool-call context was never written and there is nothing for a checkpoint to capture."
+        record_result "tool-parked" "FAIL"
+        return 1
+    fi
+    # From here until `release` is written, wall clock is charged against the tool's
+    # own deadline.
+    start_handshake_clock
+    record_result "tool-parked" "PASS"
+}
+
+# ---------------------------------------------------------------------------
+# Require TWO further completed checkpoints, not one. A checkpoint already in
+# flight when the tool parked may complete afterwards while having started before
+# the agent's memory was flushed, so a single increment does not prove the
+# payload was captured. With one concurrent checkpoint allowed, the second
+# increment cannot have started before the first completed, which is after the
+# tool parked.
+# ---------------------------------------------------------------------------
+wait_for_checkpoint_containing_payload() {
+    log_section "Wait for a checkpoint taken while the run is parked"
+
+    local baseline
+    if ! baseline=$(rest_field "/jobs/$JOB_ID/checkpoints" int "counts.completed"); then
+        log_error "checkpoint-baseline: could not read 'counts.completed' from GET $REST_URL/jobs/$JOB_ID/checkpoints"
+        record_result "checkpoint-containment" "FAIL"
+        return 1
+    fi
+    log_info "checkpoint-baseline: $baseline completed checkpoints at the moment the tool parked"
+
+    local budget
+    if ! budget="$(charged_timeout "checkpoint-containment" "$CHECKPOINT_TIMEOUT")"; then
+        record_result "checkpoint-containment" "FAIL"
+        return 1
+    fi
+
+    if ! wait_for_rest "checkpoint-containment" "/jobs/$JOB_ID/checkpoints" \
+            "int:counts.total" "int:counts.completed" "ge:$((baseline + 2))" \
+            "$budget"; then
+        log_error "checkpoint-containment: fewer than two checkpoints completed while the run was parked. Checkpointing is enabled, asserted earlier against the job's own checkpoint config, so check next whether checkpoints start and then never finish: GET $REST_URL/jobs/$JOB_ID/checkpoints reports counts.total against counts.completed and counts.in_progress. Checkpoints that keep starting and stay in progress have been measured when the in-flight action occupies the task's mailbox thread, which is the state tool-call.async being off would produce."
+        record_result "checkpoint-containment" "FAIL"
+        return 1
+    fi
+    record_result "checkpoint-containment" "PASS"
+}
+
+record_taskmanager_identity() {
+    log_section "Record the TaskManager's identity before killing it"
+
+    local pids
+    if command -v jps >/dev/null 2>&1; then
+        pids=$(jps | awk '$2 == "TaskManagerRunner" { print $1 }')
+    else
+        log_warn "jps not on PATH; falling back to pgrep"
+        pids=$(pgrep -f TaskManagerRunner || true)
+    fi
+
+    local count
+    count=$(printf '%s\n' "$pids" | grep -c '[0-9]' || true)
+    if [[ "$count" != "1" ]]; then
+        log_error "Expected exactly one TaskManagerRunner process, found $count: $(printf '%s' "$pids" | tr '\n' ' ')"
+        record_result "taskmanager-recreated" "FAIL"
+        return 1
+    fi
+    TM_PID_BEFORE=$(printf '%s\n' "$pids" | head -n 1)
+
+    if ! TM_RESOURCE_ID_BEFORE=$(rest_field "/taskmanagers" str "taskmanagers.0.id"); then
+        log_error "Could not read 'taskmanagers.0.id' from GET $REST_URL/taskmanagers"
+        record_result "taskmanager-recreated" "FAIL"
+        return 1
+    fi
+
+    # Baseline for the restore wait, captured before the kill for the same reason the
+    # checkpoint gate captures one: an absolute ">= 1" would be satisfied by a restore
+    # that had already happened for some other reason, so the assertion has to be that
+    # the count went up across *our* kill.
+    if ! RESTORED_BEFORE=$(rest_field "/jobs/$JOB_ID/checkpoints" int "counts.restored"); then
+        log_error "Could not read 'counts.restored' from GET $REST_URL/jobs/$JOB_ID/checkpoints"
+        record_result "taskmanager-recreated" "FAIL"
+        return 1
+    fi
+
+    log_ok "TaskManager pid $TM_PID_BEFORE, resource id $TM_RESOURCE_ID_BEFORE, restores so far $RESTORED_BEFORE"
+}
+
+kill_taskmanager() {
+    log_section "Kill -9 the TaskManager"
+    # SIGKILL, not the graceful stop taskmanager.sh would do: a clean shutdown is
+    # not process recreation, and recreating the JVM is the whole point.
+    kill -9 "$TM_PID_BEFORE"
+    log_ok "Sent SIGKILL to $TM_PID_BEFORE"
+
+    if kill -0 "$TM_PID_BEFORE" 2>/dev/null; then
+        sleep "$POLL_INTERVAL"
+    fi
+    if kill -0 "$TM_PID_BEFORE" 2>/dev/null; then
+        log_error "TaskManager pid $TM_PID_BEFORE is still alive after SIGKILL"
+        record_result "taskmanager-recreated" "FAIL"
+        return 1
+    fi
+
+    # Distinct from "the process is dead": this is the JobManager noticing, which
+    # is what makes the subsequent restore a real recovery rather than a no-op.
+    local budget
+    if ! budget="$(charged_timeout "taskmanager-deregistered" "$TM_GONE_TIMEOUT")"; then
+        record_result "taskmanager-recreated" "FAIL"
+        return 1
+    fi
+    if ! wait_for_rest "taskmanager-deregistered" "/taskmanagers" \
+            "len:taskmanagers" "len:taskmanagers" "eq:0" "$budget"; then
+        log_error "taskmanager-deregistered: the JobManager still lists a TaskManager. Heartbeat detection normally takes about 20s with Flink's defaults."
+        record_result "taskmanager-recreated" "FAIL"
+        return 1
+    fi
+}
+
+restart_taskmanager() {
+    log_section "Start a replacement TaskManager"
+    # Runs in this shell, which has the venv activated, so the replacement resolves
+    # the same bare `python` the original did.
+    "$FLINK_HOME/bin/taskmanager.sh" start
+
+    local budget
+    if ! budget="$(charged_timeout "taskmanager-registered" "$TM_UP_TIMEOUT")"; then
+        record_result "taskmanager-recreated" "FAIL"
+        return 1
+    fi
+    if ! wait_for_rest "taskmanager-registered" "/taskmanagers" \
+            "len:taskmanagers" "len:taskmanagers" "ge:1" "$budget"; then
+        log_error "taskmanager-registered: the replacement TaskManager never registered. Check the highest-numbered flink-*-taskexecutor-*.log in the archived logs."
+        record_result "taskmanager-recreated" "FAIL"
+        return 1
+    fi
+
+    local pid_after id_after
+    if command -v jps >/dev/null 2>&1; then
+        pid_after=$(jps | awk '$2 == "TaskManagerRunner" { print $1 }' | head -n 1)
+    else
+        pid_after=$(pgrep -f TaskManagerRunner | head -n 1 || true)
+    fi
+    id_after=$(rest_field "/taskmanagers" str "taskmanagers.0.id") || id_after=""
+
+    if [[ -z "$pid_after" || "$pid_after" == "$TM_PID_BEFORE" ]]; then
+        log_error "taskmanager-recreated: pid after restart is '$pid_after', before was '$TM_PID_BEFORE'. The JVM was not replaced, so nothing proves the Python interpreter was recreated."
+        record_result "taskmanager-recreated" "FAIL"
+        return 1
+    fi
+    if [[ -z "$id_after" || "$id_after" == "$TM_RESOURCE_ID_BEFORE" ]]; then
+        log_error "taskmanager-recreated: resource id after restart is '$id_after', before was '$TM_RESOURCE_ID_BEFORE'."
+        record_result "taskmanager-recreated" "FAIL"
+        return 1
+    fi
+
+    log_ok "TaskManager replaced: pid $TM_PID_BEFORE -> $pid_after, id $TM_RESOURCE_ID_BEFORE -> $id_after"
+    record_result "taskmanager-recreated" "PASS"
+}
+
+# ---------------------------------------------------------------------------
+# counts.restored relative to the pre-kill baseline, not an absolute ">= 1", and
+# never the numRestarts metric — numRestarts also increments on a restart that
+# restored nothing, which is exactly the case this test must not mistake for
+# success. latest.restored is then checked as a second, independent signal from the
+# same document.
+# ---------------------------------------------------------------------------
+wait_for_restore() {
+    log_section "Wait for a restore from checkpoint"
+
+    local budget
+    if ! budget="$(charged_timeout "restore" "$RESTORE_TIMEOUT")"; then
+        record_result "restore" "FAIL"
+        return 1
+    fi
+
+    if ! wait_for_rest "restore" "/jobs/$JOB_ID/checkpoints" \
+            "int:counts.total" "int:counts.restored" "ge:$((RESTORED_BEFORE + 1))" \
+            "$budget"; then
+        log_error "restore: counts.restored never rose above the pre-kill baseline of $RESTORED_BEFORE. The job may have restarted from scratch, in which case nothing was recovered and the payload assertions would be meaningless."
+        record_result "restore" "FAIL"
+        return 1
+    fi
+
+    local latest
+    if ! latest=$(rest_field "/jobs/$JOB_ID/checkpoints" nullable "latest.restored"); then
+        log_error "restore: counts.restored rose, but 'latest.restored' could not be read from GET $REST_URL/jobs/$JOB_ID/checkpoints"
+        record_result "restore" "FAIL"
+        return 1
+    fi
+    if [[ "$latest" != "present" ]]; then
+        log_error "restore: counts.restored rose above $RESTORED_BEFORE but latest.restored is null, which is contradictory — treating it as a failure rather than guessing which signal to trust."
+        record_result "restore" "FAIL"
+        return 1
+    fi
+
+    log_ok "restore: counts.restored rose above $RESTORED_BEFORE and latest.restored is populated"
+    record_result "restore" "PASS"
+}
+
+release_tool() {
+    log_section "Release the blocked tool"
+
+    # The measured bound, checked once more at the point it matters. The clamp stops
+    # any step starting past the deadline, but the last one can still overrun it, and
+    # a release written after the tool gave up produces a confusing handshake failure
+    # rather than a clear one.
+    local left
+    left="$(handshake_budget_left)"
+    if (( left <= 0 )); then
+        log_error "release: reached the release point with no time left before the tool's ${RELEASE_DEADLINE_S}s deadline. The recovery sequence was slower than its budget allows, so the tool has released itself and the transcript will show a handshake timeout instead of the real cause."
+        record_result "release-in-time" "FAIL"
+        return 1
+    fi
+    log_ok "release: ${left}s still in hand before the tool's deadline"
+    record_result "release-in-time" "PASS"
+
+    # Only now may the run finish: everything the assertions depend on is in a
+    # completed checkpoint and has been restored into a new process.
+    : > "$HANDSHAKE_DIR/release"
+    log_ok "Created $HANDSHAKE_DIR/release"
+}
+
+job_state() {
+    rest_field "/jobs/$JOB_ID" str "state" || printf 'UNREADABLE'
+}
+
+# ---------------------------------------------------------------------------
+# The job publishes a single "verdict" field. Read that; do not recompute the
+# conjunction from the component booleans here, or the pass condition would exist
+# in two places and could disagree.
+# ---------------------------------------------------------------------------
+assert_verdict() {
+    log_section "Read the verdict the job published"
+
+    local verdict_file="$VERDICT_DIR/verdict.json"
+    local deadline=$((SECONDS + VERDICT_TIMEOUT)) state
+    while (( SECONDS < deadline )); do
+        [[ -f "$verdict_file" ]] && break
+        state=$(job_state)
+        if [[ "$state" == "FAILED" || "$state" == "CANCELED" ]]; then
+            log_warn "Job reached $state while waiting for the verdict"
+            break
+        fi
+        sleep "$POLL_INTERVAL"
+    done
+
+    if [[ ! -f "$verdict_file" ]]; then
+        log_error "verdict: $verdict_file was never written. The job finished or died without running its assertions, so nothing was verified."
+        if [[ -f "$verdict_file.tmp" ]]; then
+            log_error "verdict: found a leftover $verdict_file.tmp — the writer was interrupted between write and rename"
+        fi
+        log_info "verdict: job state is $(job_state)"
+        record_result "verdict" "FAIL"
+        return 1
+    fi
+
+    log_info "verdict file contents:"
+    cat "$verdict_file" >&2 || true
+
+    local verdict
+    if ! verdict=$(json_query str "verdict" < "$verdict_file"); then
+        log_error "verdict: $verdict_file has no readable 'verdict' field. The harness and the job disagree about the verdict format."
+        record_result "verdict" "FAIL"
+        return 1
+    fi
+
+    local observed_type
+    observed_type=$(json_query str "blob_observed_type" < "$verdict_file") || observed_type="unreadable"
+    log_info "verdict: the restored bytes value materialized as '$observed_type'"
+
+    if [[ "$verdict" != "pass" ]]; then
+        log_error "verdict: the job reported '$verdict'. The per-assertion booleans in the file above name which check failed."
+        record_result "verdict" "FAIL"
+        return 1
+    fi
+    log_ok "verdict: pass"
+    record_result "verdict" "PASS"
+}
+
+main() {
+    install_flink
+    build_project
+    stage_dist_jars
+    prepare_work_dirs
+    configure_flink
+    start_cluster
+    # A wrong effective config means checkpointing may be off, so stop here rather
+    # than running a recovery test that cannot recover anything.
+    assert_effective_config || return 0
+    assert_handshake_budget
+    submit_job
+
+    # From here on a failed step records a FAIL and returns, so the EXIT trap still
+    # archives the logs and print_summary turns the FAIL into a non-zero exit.
+    wait_job_running          || return 0
+    assert_checkpointing_enabled || return 0
+    assert_runtime_identity   || return 0
+    wait_tool_parked          || return 0
+    wait_for_checkpoint_containing_payload || return 0
+    record_taskmanager_identity || return 0
+    kill_taskmanager        || return 0
+    restart_taskmanager     || return 0
+    wait_for_restore        || return 0
+    release_tool            || return 0
+    assert_verdict          || return 0
+}
+
+# The no-run hook lets a test source this file to exercise individual functions
+# against fixtures without starting a cluster. Same mechanism, same spelling as
+# tools/install.sh's FLINK_AGENTS_INSTALL_SH_NO_RUN.
+if [[ "${FLINK_AGENTS_RECOVERY_SH_NO_RUN:-0}" != "1" ]]; then
+    main "$@"
+fi

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/checkpoint_recovery_agent.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/checkpoint_recovery_agent.py
@@ -19,10 +19,13 @@
 
 A deterministic mock chat model emits one tool call, and the tool then blocks on a
 filesystem handshake, so the harness rather than the clock decides when the agent
-run may finish. While the run is parked, the built-in tool-call context and a
-``bytes`` short-term-memory value sit in checkpointable state; the harness kills and
-restarts the TaskManager, and the assertions below then run in a TaskManager process
-that never performed any of the writes.
+run may finish. The chat request also carries an output schema, so the tool-call
+context, that schema, and a ``bytes`` short-term-memory value all sit in
+checkpointable state while the run is parked; the harness kills and restarts the
+TaskManager, and the assertions below then run in a TaskManager process that never
+performed any of the writes. Rebuilding the schema there resolves its class by name
+from the module path recorded before the kill, so that path must still name this
+class in the restarted process.
 
 Submitted to a real cluster by ``checkpoint_recovery_job``. The module name is
 deliberately neither ``*_test.py`` nor ``*_example.py``: the first would make pytest
@@ -41,7 +44,7 @@ from pydantic import BaseModel
 from pyflink.datastream import KeySelector
 
 import flink_agents.api.memory_object as memory_object_module
-from flink_agents.api.agents.agent import Agent
+from flink_agents.api.agents.agent import STRUCTURED_OUTPUT, Agent
 from flink_agents.api.agents.types import OutputSchema
 from flink_agents.api.chat_message import ChatMessage, MessageRole
 from flink_agents.api.chat_models.chat_model import (
@@ -93,6 +96,30 @@ _BLOB_MEMORY_KEY = "blob"
 # makes the value load-bearing: it must not be a substring of that failure string,
 # which rules out anything built from the tool's own name.
 _TOOL_SENTINEL = "handshake-done-sentinel"
+
+# Field name of the round-two structured response, and the key
+# _structured_transcript looks up. That lookup is the check that the schema rebuilt
+# from restored state is this one: it returns None whenever the key is absent, which
+# fails the verdict. Validation upstream cannot carry the check, because pydantic
+# ignores extra keys by default — a schema rebuilt as some other class raises only if
+# that class has required fields the payload lacks, and otherwise accepts the payload
+# while dropping this key. The name is distinctive so that a successful lookup means
+# this class was rebuilt, rather than one that happens to declare a field of the same
+# name.
+_STRUCTURED_TRANSCRIPT_FIELD = "recovery_transcript"
+
+
+class RecoveryStructuredResponse(BaseModel):
+    """Round-two response shape, named by the output schema on the chat request.
+
+    Attributes:
+    ----------
+    recovery_transcript : str
+        Every message of the round-two request joined into one string.
+    """
+
+    recovery_transcript: str
+
 
 # A NUL plus bytes that are not valid UTF-8, so a value handled as UTF-8 text anywhere
 # on the path either raises or comes back corrupted. A single-byte codec such as
@@ -214,8 +241,8 @@ def _blob_matches(raw: Any) -> bool:
 
     The type gate is part of the assertion, not defensive coding. ``bytes()``
     accepts any iterable of ints, so without it a ``byte[]`` materialized as
-    ``[0, 1, 102, ...]`` would compare equal to the blob and pass — and this
-    predicate is the one whose bug produces a false pass.
+    ``[0, 1, 102, ...]`` would compare equal to the blob and pass, and a bug here
+    produces a false pass rather than a failure.
 
     ``bytes`` is admitted because it is the only one of the two the memory value
     validator accepts at write time. ``bytearray`` is admitted because the value
@@ -228,6 +255,27 @@ def _blob_matches(raw: Any) -> bool:
     if not isinstance(raw, bytes | bytearray):
         return False
     return bytes(raw) == _KNOWN_BLOB
+
+
+def _structured_transcript(raw: Any) -> str | None:
+    """Return the transcript held by a structured output, else ``None``.
+
+    The value arrives as a plain ``dict`` rather than as the model: the response
+    crosses the event bridge as JSON, and only ``Row`` is reconstructed to its own
+    type there. The model instance is accepted too, so the contract holds wherever
+    it is exercised.
+
+    ``None`` means no transcript was recovered — either nothing structured at all, or
+    a payload that does not carry this field as a string — which fails the verdict.
+    It is never conflated with an empty transcript, so a round in which this schema
+    was never applied cannot pass the marker checks that read the returned string.
+    """
+    if isinstance(raw, RecoveryStructuredResponse):
+        return raw.recovery_transcript
+    if isinstance(raw, dict):
+        value = raw.get(_STRUCTURED_TRANSCRIPT_FIELD)
+        return value if isinstance(value, str) else None
+    return None
 
 
 def _required_config(ctx: RunnerContext, key: str) -> str:
@@ -262,7 +310,7 @@ class CheckpointRecoveryKeySelector(KeySelector):
 
 
 class RecoveryMockChatConnection(BaseChatModelConnection):
-    """Mock connection emitting one tool call, then joining the whole transcript."""
+    """Mock connection emitting one tool call, then joining the transcript as JSON."""
 
     def chat(
         self,
@@ -274,15 +322,23 @@ class RecoveryMockChatConnection(BaseChatModelConnection):
         """Request the blocking tool, or join every message once the tool replied.
 
         A non-``None`` ``output_schema`` is rejected: this connection has no native
-        structured-output translation. Declaring the parameter keeps a caller-supplied
-        schema out of ``**kwargs``.
+        structured-output translation. A schema set on the request still takes
+        effect, because the caller applies it to the returned content rather than
+        handing it down here, and the content of the round after the tool result is
+        emitted as the JSON object that application expects. Declaring the parameter
+        keeps a caller-supplied schema out of ``**kwargs``.
         """
         self._reject_unsupported_output_schema(output_schema)
         if messages[-1].role == MessageRole.TOOL:
             # Joining every message carries the rebuilt transcript out to the
-            # emitted content, which is where the assertion can reach it.
+            # emitted content, which is where the assertion can reach it. It is
+            # wrapped as a JSON object because the caller parses this round against
+            # the output schema; the joined text survives verbatim inside the field.
             content = "\n".join(message.content for message in messages)
-            return ChatMessage(role=MessageRole.ASSISTANT, content=content)
+            return ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content=json.dumps({_STRUCTURED_TRANSCRIPT_FIELD: content}),
+            )
 
         # Validate the tool was bound before the model was invoked.
         assert tools[0].name == BLOCKING_TOOL_NAME
@@ -395,6 +451,10 @@ class CheckpointRecoveryAgent(Agent):
                     ChatMessage(role=MessageRole.USER, content=input_data.content)
                 ],
                 prompt_args={"task": input_data.content},
+                # Set once, on the only request this agent issues. The framework
+                # persists it with the tool-call context and re-reads the restored
+                # copy for the round that follows the tool result.
+                output_schema=OutputSchema(output_schema=RecoveryStructuredResponse),
             )
         )
 
@@ -402,21 +462,35 @@ class CheckpointRecoveryAgent(Agent):
     @staticmethod
     def process_chat_response(event: Event, ctx: RunnerContext) -> None:
         """Check the restored payload, publish the verdict, then fail on mismatch."""
-        transcript = ChatResponseEvent.from_event(event).response.content
+        chat_response = ChatResponseEvent.from_event(event).response
+        raw_structured = chat_response.extra_args.get(STRUCTURED_OUTPUT)
+        transcript = _structured_transcript(raw_structured)
         input_id = ctx.short_term_memory.get("input_id")
         raw = ctx.short_term_memory.get(_BLOB_MEMORY_KEY)
 
         blob_ok = _blob_matches(raw)
-        # _ROUND_ONE_MARKER is the load-bearing half: it exists only in the round-one
-        # assistant message, so it can reach here only through the restored tool-call
-        # context. USER_CONTENT is also restored, but weakly, because round two
-        # re-renders the prompt from restored prompt_args and that rendering contains
-        # it too.
-        context_ok = _ROUND_ONE_MARKER in transcript and USER_CONTENT in transcript
-        handshake_ok = _TOOL_SENTINEL in transcript
+        # The markers reach the assertion through the structured payload, so
+        # structured_ok carries its own claim: an output schema whose class was
+        # resolved by name from the recorded module path was applied to the round-two
+        # response. What places that round in a process which never emitted the tool
+        # call is restored_context, which pairs its checks with a process counter.
+        # structured_ok also guards the substring checks, which have no string to
+        # read when the payload is absent.
+        structured_ok = transcript is not None
+        # _ROUND_ONE_MARKER is the load-bearing half of the transcript: it exists only
+        # in the round-one assistant message, so it can reach here only through the
+        # restored tool-call context. USER_CONTENT is also restored, but weakly,
+        # because round two re-renders the prompt from restored prompt_args and that
+        # rendering contains it too.
+        context_ok = (
+            structured_ok
+            and _ROUND_ONE_MARKER in transcript
+            and USER_CONTENT in transcript
+        )
+        handshake_ok = structured_ok and _TOOL_SENTINEL in transcript
         restored_blob = blob_ok and _BLOB_WRITES_IN_THIS_PROCESS == 0
         restored_context = context_ok and _TOOL_CALLS_EMITTED_IN_THIS_PROCESS == 0
-        passed = restored_blob and restored_context and handshake_ok
+        passed = structured_ok and restored_blob and restored_context and handshake_ok
         # Identity is spread first so that no key it grows later can overwrite an
         # assertion field. The harness reads "verdict"; losing it to a silent
         # collision would be unrecoverable from the file alone.
@@ -429,10 +503,15 @@ class CheckpointRecoveryAgent(Agent):
             "context_ok": context_ok,
             "restored_context": restored_context,
             "handshake_ok": handshake_ok,
+            "structured_ok": structured_ok,
             "blob_observed_type": type(raw).__name__,
+            "structured_observed_type": type(raw_structured).__name__,
             "blob_writes_in_this_process": _BLOB_WRITES_IN_THIS_PROCESS,
             "tool_calls_emitted_in_this_process": _TOOL_CALLS_EMITTED_IN_THIS_PROCESS,
             "transcript": transcript,
+            # The unparsed response alongside the unpacked transcript, so a payload
+            # that failed to unpack is diagnosable from this file alone.
+            "response_content": chat_response.content,
         }
         verdict = json.dumps(record, sort_keys=True)
         _atomic_write(

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/checkpoint_recovery_agent.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/checkpoint_recovery_agent.py
@@ -1,0 +1,447 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+"""Agent that parks a built-in tool-call round so a checkpoint can capture it.
+
+A deterministic mock chat model emits one tool call, and the tool then blocks on a
+filesystem handshake, so the harness rather than the clock decides when the agent
+run may finish. While the run is parked, the built-in tool-call context and a
+``bytes`` short-term-memory value sit in checkpointable state; the harness kills and
+restarts the TaskManager, and the assertions below then run in a TaskManager process
+that never performed any of the writes.
+
+Submitted to a real cluster by ``checkpoint_recovery_job``. The module name is
+deliberately neither ``*_test.py`` nor ``*_example.py``: the first would make pytest
+collect it, the second would make the example-submission nightly submit it.
+"""
+
+import json
+import sys
+import time
+import uuid
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any, Dict, List, Sequence
+
+from pydantic import BaseModel
+from pyflink.datastream import KeySelector
+
+import flink_agents.api.memory_object as memory_object_module
+from flink_agents.api.agents.agent import Agent
+from flink_agents.api.agents.types import OutputSchema
+from flink_agents.api.chat_message import ChatMessage, MessageRole
+from flink_agents.api.chat_models.chat_model import (
+    BaseChatModelConnection,
+    BaseChatModelSetup,
+)
+from flink_agents.api.decorators import (
+    action,
+    chat_model_connection,
+    chat_model_setup,
+    prompt,
+    tool,
+)
+from flink_agents.api.events.chat_event import ChatRequestEvent, ChatResponseEvent
+from flink_agents.api.events.event import Event, InputEvent, OutputEvent
+from flink_agents.api.events.event_type import EventType
+from flink_agents.api.prompts.prompt import Prompt
+from flink_agents.api.resource import ResourceDescriptor
+from flink_agents.api.runner_context import RunnerContext
+from flink_agents.api.tools import InjectedArg
+from flink_agents.api.tools.tool import Tool as BaseTool
+from flink_agents.api.tools.tool import ToolType
+
+# Config keys the submitting job must set; a missing one fails the run loudly.
+HANDSHAKE_DIR_CONFIG_KEY = "handshake_dir"
+VERDICT_DIR_CONFIG_KEY = "verdict_dir"
+
+# Filenames exchanged with the harness.
+TOOL_ENTERED_MARKER = "tool-entered"
+RELEASE_MARKER = "release"
+IDENTITY_MARKER = "runtime-identity.json"
+VERDICT_MARKER = "verdict.json"
+
+RELEASE_TIMEOUT_S = 240.0
+POLL_INTERVAL_S = 0.2
+
+# The user message content, also built into the input record by the job.
+USER_CONTENT = "hold the tool call open across a taskmanager restart"
+
+BLOCKING_TOOL_NAME = "block_until_released"
+
+_ROUND_ONE_MARKER = "recovery-round-one-assistant"
+_BLOB_MEMORY_KEY = "blob"
+
+# Returned by the tool only on the released path, and required in the transcript.
+# The framework converts a tool exception into the response string
+# "Tool `block_until_released` execute failed." rather than failing the action, so a
+# timed-out handshake reaches the assertions only as the absence of this value. That
+# makes the value load-bearing: it must not be a substring of that failure string,
+# which rules out anything built from the tool's own name.
+_TOOL_SENTINEL = "handshake-done-sentinel"
+
+# A NUL plus bytes that are not valid UTF-8, so a value handled as UTF-8 text anywhere
+# on the path either raises or comes back corrupted. A single-byte codec such as
+# latin-1 would round trip it intact, so this catches UTF-8 handling rather than every
+# possible string conversion.
+_KNOWN_BLOB = b"\x00\x01flink-agents\xff\xfe"
+
+# Process-local and deliberately outside Flink state. Anything checkpointed is
+# restored along with the payload and therefore cannot tell a restored read apart
+# from the reader's own write.
+#
+# Pemja runs as ExecType.MULTI_THREAD against a singleton main interpreter, so these
+# globals outlive an in-place task restart and are reset only when the TaskManager
+# process itself dies. A read that returns the known value while they are still zero
+# therefore proves the write happened in a different TaskManager process, which is
+# stronger than proving it happened in a different interpreter.
+_PROCESS_EPOCH = uuid.uuid4().hex
+_BLOB_WRITES_IN_THIS_PROCESS = 0
+_TOOL_CALLS_EMITTED_IN_THIS_PROCESS = 0
+
+
+def _atomic_write(target: Path, content: str) -> None:
+    """Publish a file by renaming it into place so no reader sees a partial write."""
+    tmp = target.parent / f"{target.name}.tmp"
+    tmp.write_text(content, encoding="utf-8")
+    tmp.replace(target)
+
+
+def await_release(
+    handshake_dir: str,
+    *,
+    timeout_s: float = RELEASE_TIMEOUT_S,
+    poll_interval_s: float = POLL_INTERVAL_S,
+) -> None:
+    """Announce that the tool was entered, then block until the harness releases it.
+
+    The marker is written before the wait begins so the harness can order its kill
+    strictly after the tool-call context reached checkpointable state.
+
+    Raises ``TimeoutError`` at the deadline so the wait is bounded and the reason
+    reaches the TaskManager log. The raise has no effect on control flow: the caller
+    converts every tool exception into an ordinary tool response, so raising and
+    returning drive the run identically. What makes a timeout observable is the
+    sentinel the tool returns only on this function's success path.
+
+    Parameters
+    ----------
+    handshake_dir : str
+        Directory the harness created before submitting the job.
+    timeout_s : float
+        How long to wait for the release marker before failing the run.
+    poll_interval_s : float
+        Interval between existence checks.
+    """
+    base = Path(handshake_dir)
+    _atomic_write(base / TOOL_ENTERED_MARKER, _PROCESS_EPOCH)
+
+    release = base / RELEASE_MARKER
+    deadline = time.monotonic() + timeout_s
+    while not release.exists():
+        if time.monotonic() > deadline:
+            msg = f"waited {timeout_s}s for the release marker at {release}"
+            raise TimeoutError(msg)
+        time.sleep(poll_interval_s)
+
+
+def _flink_agents_version() -> str:
+    """Report the installed distribution version, or ``unknown`` if there is none."""
+    try:
+        return version("flink-agents")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _runtime_identity() -> Dict[str, Any]:
+    """Describe the flink-agents installation this process is actually running.
+
+    The probe is ``flink_agents.api.memory_object`` rather than the ``flink_agents``
+    package. ``flink_agents/__init__.py`` is a single ``pkgutil.extend_path`` call, so
+    ``flink_agents.__file__`` names whichever ``__init__.py`` came first on the path
+    while ``flink_agents.api`` can be served from a different entry. ``api`` extends
+    nothing, so a module under it pins the installation that supplied the code under
+    test.
+    """
+    return {
+        "flink_agents_api_file": memory_object_module.__file__,
+        "flink_agents_version": _flink_agents_version(),
+        "python_executable": sys.executable,
+        "python_version": sys.version,
+        "process_epoch": _PROCESS_EPOCH,
+    }
+
+
+def _write_runtime_identity(handshake_dir: str) -> None:
+    """Publish the pre-kill identity so the harness can fail before it kills anything.
+
+    This copy always describes the process that is about to be killed. The copy the
+    assertions rely on rides in the verdict record, which the surviving process
+    writes.
+    """
+    _atomic_write(
+        Path(handshake_dir) / IDENTITY_MARKER,
+        json.dumps(_runtime_identity(), sort_keys=True),
+    )
+
+
+def _mark_blob_written() -> None:
+    global _BLOB_WRITES_IN_THIS_PROCESS
+    _BLOB_WRITES_IN_THIS_PROCESS += 1
+
+
+def _mark_tool_call_emitted() -> None:
+    global _TOOL_CALLS_EMITTED_IN_THIS_PROCESS
+    _TOOL_CALLS_EMITTED_IN_THIS_PROCESS += 1
+
+
+def _blob_matches(raw: Any) -> bool:
+    """Check the value is ``bytes`` or ``bytearray`` holding the known blob.
+
+    The type gate is part of the assertion, not defensive coding. ``bytes()``
+    accepts any iterable of ints, so without it a ``byte[]`` materialized as
+    ``[0, 1, 102, ...]`` would compare equal to the blob and pass — and this
+    predicate is the one whose bug produces a false pass.
+
+    ``bytes`` is admitted because it is the only one of the two the memory value
+    validator accepts at write time. ``bytearray`` is admitted because the value
+    comes back across the bridge from a Java ``byte[]`` and may materialize as
+    either — a read-side allowance this test makes, not one the write-side contract
+    grants. Nothing else is admitted on the chance it might appear; anything else
+    fails here rather than aborting the action, so the run still publishes a verdict
+    and ``blob_observed_type`` records what did come back.
+    """
+    if not isinstance(raw, bytes | bytearray):
+        return False
+    return bytes(raw) == _KNOWN_BLOB
+
+
+def _required_config(ctx: RunnerContext, key: str) -> str:
+    value = ctx.config.get_str(key)
+    if not value:
+        msg = f"Missing config for the checkpoint recovery job: {key}"
+        raise ValueError(msg)
+    return value
+
+
+class CheckpointRecoveryInput(BaseModel):
+    """Input record for the checkpoint recovery agent.
+
+    Attributes:
+    ----------
+    id : int
+        Unique identifier used as the partition key.
+    content : str
+        The user message content fed to the agent.
+    """
+
+    id: int
+    content: str
+
+
+class CheckpointRecoveryKeySelector(KeySelector):
+    """KeySelector extracting the partition key from a CheckpointRecoveryInput."""
+
+    def get_key(self, value: CheckpointRecoveryInput) -> int:
+        """Extract key from CheckpointRecoveryInput."""
+        return value.id
+
+
+class RecoveryMockChatConnection(BaseChatModelConnection):
+    """Mock connection emitting one tool call, then joining the whole transcript."""
+
+    def chat(
+        self,
+        messages: Sequence[ChatMessage],
+        tools: List[BaseTool] | None = None,
+        output_schema: OutputSchema | None = None,
+        **kwargs: Any,
+    ) -> ChatMessage:
+        """Request the blocking tool, or join every message once the tool replied.
+
+        A non-``None`` ``output_schema`` is rejected: this connection has no native
+        structured-output translation. Declaring the parameter keeps a caller-supplied
+        schema out of ``**kwargs``.
+        """
+        self._reject_unsupported_output_schema(output_schema)
+        if messages[-1].role == MessageRole.TOOL:
+            # Joining every message carries the rebuilt transcript out to the
+            # emitted content, which is where the assertion can reach it.
+            content = "\n".join(message.content for message in messages)
+            return ChatMessage(role=MessageRole.ASSISTANT, content=content)
+
+        # Validate the tool was bound before the model was invoked.
+        assert tools[0].name == BLOCKING_TOOL_NAME
+        _mark_tool_call_emitted()
+        tool_call = {
+            "id": str(uuid.uuid4()),
+            "type": ToolType.FUNCTION,
+            "function": {"name": BLOCKING_TOOL_NAME, "arguments": {}},
+        }
+        return ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content=_ROUND_ONE_MARKER,
+            tool_calls=[tool_call],
+        )
+
+
+class RecoveryMockChatModel(BaseChatModelSetup):
+    """Mock chat model setup for the checkpoint recovery agent."""
+
+    @property
+    def model_kwargs(self) -> Dict[str, Any]:
+        """Return model kwargs."""
+        return {}
+
+
+class CheckpointRecoveryAgent(Agent):
+    """Agent held mid-tool-call so a checkpoint captures its memory."""
+
+    @prompt
+    @staticmethod
+    def recovery_prompt() -> Prompt:
+        """Prompt used by the mock chat model."""
+        return Prompt.from_text(
+            text="Please call the appropriate tool to do the following task: {task}",
+        )
+
+    @chat_model_connection
+    @staticmethod
+    def recovery_connection() -> ResourceDescriptor:
+        """Chat model connection used by the mock chat model."""
+        return ResourceDescriptor(
+            clazz=f"{RecoveryMockChatConnection.__module__}."
+            f"{RecoveryMockChatConnection.__name__}"
+        )
+
+    @chat_model_setup
+    @staticmethod
+    def recovery_chat_model() -> ResourceDescriptor:
+        """Chat model referenced by the ChatRequestEvent."""
+        return ResourceDescriptor(
+            clazz=f"{RecoveryMockChatModel.__module__}."
+            f"{RecoveryMockChatModel.__name__}",
+            connection="recovery_connection",
+            model="mock-model",
+            prompt="recovery_prompt",
+            tools=[BLOCKING_TOOL_NAME],
+        )
+
+    @tool(
+        injected_args={
+            "handshake_dir": InjectedArg.from_config(HANDSHAKE_DIR_CONFIG_KEY)
+        }
+    )
+    @staticmethod
+    def block_until_released(handshake_dir: str) -> str:
+        """Hold the agent run open until the harness releases it.
+
+        Takes no model-visible arguments, so the mock never has to fabricate one.
+        The post-restore re-execution finds the release marker already present and
+        returns immediately, which makes the handshake idempotent.
+
+        Parameters
+        ----------
+        handshake_dir : str
+            The handshake directory, injected by runtime.
+
+        Returns:
+        -------
+        str:
+            The sentinel, which reaches the transcript as the tool message and is
+            required by the assertion. A timed-out handshake never gets here, so the
+            transcript carries the framework's failure string instead.
+        """
+        await_release(handshake_dir)
+        return _TOOL_SENTINEL
+
+    @action(EventType.InputEvent)
+    @staticmethod
+    def process_input(event: Event, ctx: RunnerContext) -> None:
+        """Record the payload and start the tool-call round."""
+        input_data = CheckpointRecoveryInput.model_validate(
+            InputEvent.from_event(event).input
+        )
+        # Resolve both directories up front: a misspelled verdict_dir would otherwise
+        # surface only after the whole park/kill/restart cycle has been paid for.
+        handshake_dir = _required_config(ctx, HANDSHAKE_DIR_CONFIG_KEY)
+        _required_config(ctx, VERDICT_DIR_CONFIG_KEY)
+        _write_runtime_identity(handshake_dir)
+
+        # Carry the record id across the chat round-trip via per-key memory,
+        # since ChatResponseEvent does not echo the original input.
+        ctx.short_term_memory.set("input_id", input_data.id)
+        ctx.short_term_memory.set(_BLOB_MEMORY_KEY, _KNOWN_BLOB)
+        _mark_blob_written()
+
+        ctx.send_event(
+            ChatRequestEvent(
+                model="recovery_chat_model",
+                messages=[
+                    ChatMessage(role=MessageRole.USER, content=input_data.content)
+                ],
+                prompt_args={"task": input_data.content},
+            )
+        )
+
+    @action(EventType.ChatResponseEvent)
+    @staticmethod
+    def process_chat_response(event: Event, ctx: RunnerContext) -> None:
+        """Check the restored payload, publish the verdict, then fail on mismatch."""
+        transcript = ChatResponseEvent.from_event(event).response.content
+        input_id = ctx.short_term_memory.get("input_id")
+        raw = ctx.short_term_memory.get(_BLOB_MEMORY_KEY)
+
+        blob_ok = _blob_matches(raw)
+        # _ROUND_ONE_MARKER is the load-bearing half: it exists only in the round-one
+        # assistant message, so it can reach here only through the restored tool-call
+        # context. USER_CONTENT is also restored, but weakly, because round two
+        # re-renders the prompt from restored prompt_args and that rendering contains
+        # it too.
+        context_ok = _ROUND_ONE_MARKER in transcript and USER_CONTENT in transcript
+        handshake_ok = _TOOL_SENTINEL in transcript
+        restored_blob = blob_ok and _BLOB_WRITES_IN_THIS_PROCESS == 0
+        restored_context = context_ok and _TOOL_CALLS_EMITTED_IN_THIS_PROCESS == 0
+        passed = restored_blob and restored_context and handshake_ok
+        # Identity is spread first so that no key it grows later can overwrite an
+        # assertion field. The harness reads "verdict"; losing it to a silent
+        # collision would be unrecoverable from the file alone.
+        record = {
+            **_runtime_identity(),
+            "verdict": "pass" if passed else "fail",
+            "input_id": input_id,
+            "blob_ok": blob_ok,
+            "restored_blob": restored_blob,
+            "context_ok": context_ok,
+            "restored_context": restored_context,
+            "handshake_ok": handshake_ok,
+            "blob_observed_type": type(raw).__name__,
+            "blob_writes_in_this_process": _BLOB_WRITES_IN_THIS_PROCESS,
+            "tool_calls_emitted_in_this_process": _TOOL_CALLS_EMITTED_IN_THIS_PROCESS,
+            "transcript": transcript,
+        }
+        verdict = json.dumps(record, sort_keys=True)
+        _atomic_write(
+            Path(_required_config(ctx, VERDICT_DIR_CONFIG_KEY)) / VERDICT_MARKER,
+            verdict,
+        )
+
+        if not passed:
+            msg = f"checkpoint recovery assertions failed: {verdict}"
+            raise AssertionError(msg)
+
+        ctx.send_event(OutputEvent(output=verdict))

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/checkpoint_recovery_agent.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/checkpoint_recovery_agent.py
@@ -237,24 +237,20 @@ def _mark_tool_call_emitted() -> None:
 
 
 def _blob_matches(raw: Any) -> bool:
-    """Check the value is ``bytes`` or ``bytearray`` holding the known blob.
+    """Check the value is exact ``bytes`` holding the known blob.
 
-    The type gate is part of the assertion, not defensive coding. ``bytes()``
-    accepts any iterable of ints, so without it a ``byte[]`` materialized as
-    ``[0, 1, 102, ...]`` would compare equal to the blob and pass, and a bug here
-    produces a false pass rather than a failure.
+    The type gate is part of the assertion, not defensive coding. A ``bytearray``, a
+    ``memoryview`` and a ``bytes`` subclass all compare equal to the blob, so content
+    alone says nothing about the form the value came back in: a gate that admitted
+    them would report a pass for a round trip that did not preserve the type.
 
-    ``bytes`` is admitted because it is the only one of the two the memory value
-    validator accepts at write time. ``bytearray`` is admitted because the value
-    comes back across the bridge from a Java ``byte[]`` and may materialize as
-    either — a read-side allowance this test makes, not one the write-side contract
-    grants. Nothing else is admitted on the chance it might appear; anything else
-    fails here rather than aborting the action, so the run still publishes a verdict
-    and ``blob_observed_type`` records what did come back.
+    Exact type rather than ``isinstance``, matching the write side, which accepts only
+    exact ``bytes`` into short-term memory and rejects both a ``bytearray`` and a
+    ``bytes`` subclass. Nothing else is admitted on the chance it might appear. An
+    unexpected type returns ``False`` rather than raising, so the run still publishes a
+    verdict and ``blob_observed_type`` records what did come back.
     """
-    if not isinstance(raw, bytes | bytearray):
-        return False
-    return bytes(raw) == _KNOWN_BLOB
+    return type(raw) is bytes and raw == _KNOWN_BLOB
 
 
 def _structured_transcript(raw: Any) -> str | None:

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/checkpoint_recovery_helpers_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/checkpoint_recovery_helpers_test.py
@@ -78,11 +78,16 @@ def test_deadline_raises(tmp_path: Path) -> None:
         await_release(str(tmp_path), timeout_s=0.3, poll_interval_s=0.05)
 
 
+class _BytesSub(bytes):
+    """A ``bytes`` subclass, which short-term memory rejects at write time."""
+
+
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [
         (_KNOWN_BLOB, True),
-        (bytearray(_KNOWN_BLOB), True),
+        (bytearray(_KNOWN_BLOB), False),
+        (_BytesSub(_KNOWN_BLOB), False),
         (b"other", False),
         (memoryview(_KNOWN_BLOB), False),
         (list(_KNOWN_BLOB), False),
@@ -92,17 +97,17 @@ def test_deadline_raises(tmp_path: Path) -> None:
         (5, False),
     ],
 )
-def test_blob_matches_compares_content_only(raw: Any, expected: bool) -> None:
-    """Contract: ``bytes`` or ``bytearray`` holding the known content, nothing else.
+def test_blob_matches_requires_exact_bytes(raw: Any, expected: bool) -> None:
+    """Contract: exact ``bytes`` holding the known content, nothing else.
 
-    A list or tuple of the same ints must not pass: ``bytes()`` accepts any iterable
-    of ints, so a sequence that merely enumerates the right byte values is not
-    evidence the value survived as a byte array.
+    A ``bytearray``, a ``bytes`` subclass and a ``memoryview`` over the same buffer
+    all compare equal to the blob, and all three are rejected: short-term memory
+    accepts only exact ``bytes`` at write time, so a value arriving as any of them is
+    a round trip that did not preserve the type rather than a match.
 
-    ``memoryview`` is rejected deliberately, not by oversight. Admitting it would be
-    speculation about how the bridge materializes a ``byte[]``, and it would also
-    admit views whose element format is not a byte. If one ever does arrive this
-    fails, and ``blob_observed_type`` in the verdict names what came back.
+    A list or tuple of the same ints must not pass either: a sequence enumerating the
+    right byte values is not evidence the value survived as a byte array. Whatever
+    does come back, ``blob_observed_type`` in the verdict names it.
     """
     assert _blob_matches(raw) is expected
 

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/checkpoint_recovery_helpers_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/checkpoint_recovery_helpers_test.py
@@ -1,0 +1,104 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+"""Unit tests for the checkpoint-recovery helpers that decide pass or fail.
+
+Covers the handshake's two obligations to the harness and the blob predicate the
+verdict is computed from.
+"""
+
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from flink_agents.e2e_tests.e2e_tests_integration.checkpoint_recovery_agent import (
+    _KNOWN_BLOB,
+    RELEASE_MARKER,
+    TOOL_ENTERED_MARKER,
+    _blob_matches,
+    await_release,
+)
+
+
+def test_release_present_checks_before_sleeping(tmp_path: Path) -> None:
+    """Contract: the release marker is checked before any poll interval is paid.
+
+    After a restore the tool re-enters the handshake with the marker already on
+    disk. The poll interval used here is far larger than the assertion window, so
+    an implementation that slept first would miss it.
+    """
+    (tmp_path / RELEASE_MARKER).touch()
+
+    start = time.monotonic()
+    await_release(str(tmp_path), timeout_s=30.0, poll_interval_s=5.0)
+
+    assert time.monotonic() - start < 2.0
+
+
+def test_tool_entered_marker_is_written(tmp_path: Path) -> None:
+    """Contract: entering the handshake announces itself to the harness.
+
+    The harness orders its kill after this marker appears, so a handshake that
+    waited without announcing would leave the harness with nothing to wait on.
+    """
+    (tmp_path / RELEASE_MARKER).touch()
+
+    await_release(str(tmp_path), timeout_s=30.0, poll_interval_s=5.0)
+
+    assert (tmp_path / TOOL_ENTERED_MARKER).exists()
+
+
+def test_deadline_raises(tmp_path: Path) -> None:
+    """Contract: the handshake raises at its deadline instead of returning.
+
+    The raise bounds the wait and puts the reason in the TaskManager log. It does
+    not by itself fail the run, because the caller swallows tool exceptions; the
+    tool result sentinel is what makes a timeout observable downstream.
+    """
+    with pytest.raises(TimeoutError):
+        await_release(str(tmp_path), timeout_s=0.3, poll_interval_s=0.05)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (_KNOWN_BLOB, True),
+        (bytearray(_KNOWN_BLOB), True),
+        (b"other", False),
+        (memoryview(_KNOWN_BLOB), False),
+        (list(_KNOWN_BLOB), False),
+        (tuple(_KNOWN_BLOB), False),
+        ("string", False),
+        (None, False),
+        (5, False),
+    ],
+)
+def test_blob_matches_compares_content_only(raw: Any, expected: bool) -> None:
+    """Contract: ``bytes`` or ``bytearray`` holding the known content, nothing else.
+
+    A list or tuple of the same ints must not pass: ``bytes()`` accepts any iterable
+    of ints, so a sequence that merely enumerates the right byte values is not
+    evidence the value survived as a byte array.
+
+    ``memoryview`` is rejected deliberately, not by oversight. Admitting it would be
+    speculation about how the bridge materializes a ``byte[]``, and it would also
+    admit views whose element format is not a byte. If one ever does arrive this
+    fails, and ``blob_observed_type`` in the verdict names what came back.
+    """
+    assert _blob_matches(raw) is expected

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/checkpoint_recovery_helpers_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/checkpoint_recovery_helpers_test.py
@@ -17,8 +17,8 @@
 #################################################################################
 """Unit tests for the checkpoint-recovery helpers that decide pass or fail.
 
-Covers the handshake's two obligations to the harness and the blob predicate the
-verdict is computed from.
+Covers the handshake's two obligations to the harness and the two helpers that
+feed the verdict's assertions.
 """
 
 import time
@@ -29,9 +29,12 @@ import pytest
 
 from flink_agents.e2e_tests.e2e_tests_integration.checkpoint_recovery_agent import (
     _KNOWN_BLOB,
+    _STRUCTURED_TRANSCRIPT_FIELD,
     RELEASE_MARKER,
     TOOL_ENTERED_MARKER,
+    RecoveryStructuredResponse,
     _blob_matches,
+    _structured_transcript,
     await_release,
 )
 
@@ -102,3 +105,29 @@ def test_blob_matches_compares_content_only(raw: Any, expected: bool) -> None:
     fails, and ``blob_observed_type`` in the verdict names what came back.
     """
     assert _blob_matches(raw) is expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (RecoveryStructuredResponse(recovery_transcript="joined"), "joined"),
+        ({_STRUCTURED_TRANSCRIPT_FIELD: "joined"}, "joined"),
+        ({_STRUCTURED_TRANSCRIPT_FIELD: 5}, None),
+        ({"other_field": "joined"}, None),
+        (None, None),
+        ("joined", None),
+    ],
+)
+def test_structured_transcript_requires_a_structured_payload(
+    raw: Any, expected: str | None
+) -> None:
+    """Contract: only a structured payload yields a transcript, everything else None.
+
+    The transcript is the sole carrier of the marker assertions, so a round in which
+    the output schema was never applied must not be mistaken for one in which it was.
+    ``None`` is the value a response carrying no structured output yields. A bare
+    string is rejected so the response content cannot stand in for a transcript: the
+    connection emits that content with no schema involved, yet it wraps the joined
+    transcript in JSON and so carries every marker the verdict looks for.
+    """
+    assert _structured_transcript(raw) == expected

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/checkpoint_recovery_job.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/checkpoint_recovery_job.py
@@ -1,0 +1,131 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+"""Submittable driver for the checkpoint recovery agent.
+
+Run with ``flink run -py`` against a standalone cluster. Checkpointing, state
+storage and the restart strategy come from the cluster configuration the harness
+writes, so this program only supplies the job-scoped wiring, the file the source
+watches, and the two directories the agent exchanges files through.
+
+The source must be unbounded. A bounded source raises end-of-input right after the
+record, and the agent operator's end-of-input drain then holds the mailbox thread
+while the run is parked in its tool, so the checkpoint barrier is never consumed and
+no checkpoint completes. A continuously-monitored file source instead stays open for
+the life of the job, yet yields records from its file only once: the enumerator
+remembers the paths it has handed out and carries that set in the checkpoint, so
+neither a line appended later nor a restore produces a second record.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from pyflink.common import Duration, WatermarkStrategy
+from pyflink.datastream import RuntimeExecutionMode, StreamExecutionEnvironment
+from pyflink.datastream.connectors.file_system import FileSource, StreamFormat
+
+from flink_agents.api.core_options import AgentExecutionOptions
+from flink_agents.api.execution_environment import AgentsExecutionEnvironment
+from flink_agents.e2e_tests.e2e_tests_integration.checkpoint_recovery_agent import (
+    HANDSHAKE_DIR_CONFIG_KEY,
+    USER_CONTENT,
+    VERDICT_DIR_CONFIG_KEY,
+    CheckpointRecoveryAgent,
+    CheckpointRecoveryInput,
+    CheckpointRecoveryKeySelector,
+)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Drive the checkpoint recovery agent on a standalone cluster."
+    )
+    parser.add_argument(
+        "--input-file",
+        required=True,
+        help="Single-line file the harness created. It triggers the run; the "
+        "line's content is unused.",
+    )
+    parser.add_argument(
+        "--handshake-dir",
+        required=True,
+        help="Directory the harness created for the tool handshake markers.",
+    )
+    parser.add_argument(
+        "--verdict-dir",
+        required=True,
+        help="Directory the agent publishes its verdict file into.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> None:
+    """Build and submit the recovery job."""
+    args = _parse_args(argv)
+
+    env = StreamExecutionEnvironment.get_execution_environment()
+    env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
+    env.set_parallelism(1)
+
+    # Point at the file, not its directory: Flink's enumerator recurses into a
+    # directory, so a file dropped there later could become a second record.
+    input_stream = env.from_source(
+        source=FileSource.for_record_stream_format(
+            StreamFormat.text_line_format(),
+            Path(args.input_file).resolve().as_uri(),
+        )
+        # This call is what makes the source unbounded; a file source is otherwise
+        # a bounded static set that finishes. The interval paces only the re-scans,
+        # and every re-scan here finds a path already handed out, so the value is
+        # not load-bearing.
+        .monitor_continuously(Duration.of_millis(1000))
+        .build(),
+        watermark_strategy=WatermarkStrategy.no_watermarks(),
+        source_name="checkpoint_recovery_trigger",
+    ).map(
+        # The line is a trigger, not data. Building the record from USER_CONTENT
+        # keeps that constant in the agent module, beside the assertion that
+        # matches it against the restored transcript.
+        lambda _: CheckpointRecoveryInput(id=1, content=USER_CONTENT)
+    )
+
+    agents_env = AgentsExecutionEnvironment.get_execution_environment(env=env)
+    agents_config = agents_env.get_config()
+    agents_config.set_str(HANDSHAKE_DIR_CONFIG_KEY, args.handshake_dir)
+    agents_config.set_str(VERDICT_DIR_CONFIG_KEY, args.verdict_dir)
+    # Already the default, pinned because the whole design depends on it: the tool
+    # blocks for minutes, and it may only do so off the mailbox thread, or barriers
+    # never reach the parked run and no checkpoint can contain the payload.
+    agents_config.set(AgentExecutionOptions.TOOL_CALL_ASYNC, True)
+
+    output_datastream = (
+        agents_env.from_datastream(
+            input=input_stream, key_selector=CheckpointRecoveryKeySelector()
+        )
+        .apply(CheckpointRecoveryAgent())
+        .to_datastream()
+    )
+    # The verdict travels through its own file; this sink only leaves a
+    # human-readable copy in the TaskManager output.
+    output_datastream.print()
+
+    agents_env.execute()
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/tools/test/helpers/recovery.bash
+++ b/tools/test/helpers/recovery.bash
@@ -1,0 +1,210 @@
+# Helpers for the checkpoint-recovery harness tests. Loaded via
+# `load 'helpers/recovery'`.
+
+# Sources test_checkpoint_recovery.sh with the no-run hook so main() is skipped.
+load_recovery_sh() {
+    export FLINK_AGENTS_RECOVERY_SH_NO_RUN=1
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+    RECOVERY_SH="$REPO_ROOT/e2e-test/test-scripts/test_checkpoint_recovery.sh"
+
+    # Sourcing arms the script's own EXIT trap, which cancels jobs, stops a Flink
+    # cluster and calls print_summary — none of which belongs in a unit test.
+    #
+    # It must be removed, but removing it naively takes bats's EXIT trap with it,
+    # and that trap is how bats reports each result. Without it a skipped or failing
+    # test produces no output at all: it disappears from the run and the summary
+    # counts it as never executed. Save bats's handler and restore it.
+    local bats_exit_trap
+    bats_exit_trap="$(trap -p EXIT)"
+
+    # shellcheck disable=SC1090
+    source "$RECOVERY_SH"
+
+    trap - EXIT
+    if [[ -n "$bats_exit_trap" ]]; then
+        eval "$bats_exit_trap"
+    fi
+    return 0
+}
+
+# Resets the script's module-level state so tests do not leak into one another.
+reset_recovery_sh_state() {
+    RESULT_NAMES=()
+    RESULT_STATES=()
+    SUBMITTED_JOB_IDS=()
+    CONFIG_KEYS_SET=()
+    JOB_ID="test-job"
+    WORK_DIR=""
+    HANDSHAKE_DIR=""
+    VERDICT_DIR=""
+    INPUT_DIR=""
+    INPUT_FILE=""
+    CHECKPOINT_DIR="/tmp/ckpt"
+    FLINK_CONF=""
+    TM_PID_BEFORE=""
+    TM_RESOURCE_ID_BEFORE=""
+    RESTORED_BEFORE=""
+    RELEASE_DEADLINE_S=""
+    CHECKPOINT_INTERVAL_MS="5000"
+    RESTART_ATTEMPTS="3"
+    STANDALONE_STARTUP_TIME="600s"
+    EXPECTED_AGENTS_VERSION="0.3.dev0"
+    # Keep the polls short; every wait under test is given a small budget.
+    POLL_INTERVAL=1
+}
+
+# Replaces the REST transport with a fixed body. Callers set REST_STUB_BODY.
+stub_rest_get() {
+    REST_STUB_BODY=""
+    rest_get() { printf '%s' "$REST_STUB_BODY"; }
+}
+
+# json_query reads its body from stdin, and bats's `run` takes a single command
+# rather than a pipeline — so these wrap the pipe. Running it through `bash -c`
+# instead would lose the sourced functions.
+query_fixture() {
+    local fixture="$1" mode="$2" path="$3"
+    "$fixture" | json_query "$mode" "$path"
+}
+
+query_body() {
+    local body="$1" mode="$2" path="$3"
+    printf '%s' "$body" | json_query "$mode" "$path"
+}
+
+# ---------------------------------------------------------------------------
+# Response fixtures, shaped after the real REST payloads.
+# ---------------------------------------------------------------------------
+fixture_checkpoints() {
+    cat <<'JSON'
+{"counts":{"restored":0,"total":7,"in_progress":1,"completed":6,"failed":0},
+ "summary":{},
+ "latest":{"completed":{"id":6},"savepoint":null,"failed":null,"restored":null},
+ "history":[]}
+JSON
+}
+
+fixture_checkpoints_restored() {
+    cat <<'JSON'
+{"counts":{"restored":1,"total":9,"in_progress":0,"completed":8,"failed":0},
+ "summary":{},
+ "latest":{"completed":{"id":8},"savepoint":null,"failed":null,
+           "restored":{"id":6,"restore_timestamp":123,"is_savepoint":false,
+                       "external_path":"file:///x"}},
+ "history":[]}
+JSON
+}
+
+fixture_taskmanagers_one() {
+    printf '%s' '{"taskmanagers":[{"id":"172.18.0.3:39479-caf7a9","path":"akka://x","dataPort":1}]}'
+}
+
+fixture_taskmanagers_none() {
+    printf '%s' '{"taskmanagers":[]}'
+}
+
+fixture_job_running() {
+    printf '%s' '{"jid":"abc","name":"n","state":"RUNNING","vertices":[]}'
+}
+
+# GET /jobmanager/config answers with a list of key/value pairs.
+fixture_jobmanager_config() {
+    cat <<'JSON'
+[{"key":"execution.checkpointing.dir","value":"file:///tmp/ckpt"},
+ {"key":"restart-strategy.type","value":"fixed-delay"},
+ {"key":"restart-strategy.fixed-delay.attempts","value":"3"},
+ {"key":"resourcemanager.standalone.start-up-time","value":"600s"}]
+JSON
+}
+
+# GET /jobs/:jobid/checkpoints/config answers from the job's checkpoint
+# coordinator, and reports the interval in milliseconds.
+fixture_checkpoint_config() {
+    printf '%s' '{"mode":"exactly_once","interval":5000,"timeout":600000,"min_pause":0,"max_concurrent":1,"externalization":{"enabled":false,"delete_on_cancellation":true},"state_backend":"HashMapStateBackend","checkpoint_storage":"FileSystemCheckpointStorage"}'
+}
+
+# ---------------------------------------------------------------------------
+# A nested Flink 2.x config.yaml, shaped like the shipped file: the keys the
+# harness appends have no nested counterpart, and two that do are present so a
+# test can show appending did not displace them.
+# ---------------------------------------------------------------------------
+write_nested_config_fixture() {
+    cat > "$1" <<'YAML'
+################################################################################
+# Sample nested Flink 2.x configuration.
+################################################################################
+
+jobmanager:
+  rpc:
+    address: localhost
+    port: 6123
+  memory:
+    process:
+      size: 1600m
+  execution:
+    failover-strategy: region
+
+taskmanager:
+  bind-host: localhost
+  host: localhost
+  numberOfTaskSlots: 1
+  memory:
+    process:
+      size: 1728m
+
+parallelism:
+  default: 1
+
+execution:
+  checkpointing:
+    incremental: true
+
+rest:
+  address: localhost
+  bind-address: localhost
+YAML
+}
+
+# Any top-level (column 0) YAML key appearing more than once. snakeyaml, which
+# Flink's config loader uses, rejects a duplicate key outright rather than taking
+# the last value, so this is the condition a repeated append has to avoid. Done
+# with grep rather than a YAML parser so the suite needs no Python packages.
+duplicate_top_level_keys() {
+    grep -oE '^[^[:space:]#][^:]*:' "$1" | sort | uniq -d
+}
+
+# An interpreter that can import the payload module, or empty if there is none.
+# assert_handshake_budget reads the tool's release deadline from that module, so
+# without one the test cannot run. The candidates cover the venv the e2e harness
+# itself activates, one sitting in the checkout, an activated environment, and
+# finally whatever python is on PATH.
+find_payload_interpreter() {
+    local candidate
+    for candidate in "$REPO_ROOT/.flink-agents-env/bin/python" \
+                     "$REPO_ROOT/venv/bin/python" \
+                     "${VIRTUAL_ENV:-}/bin/python" \
+                     "$(command -v python3 || true)" \
+                     "$(command -v python || true)"; do
+        [[ -n "$candidate" && -x "$candidate" ]] || continue
+        if PYTHONPATH="$REPO_ROOT/python" "$candidate" -c \
+            'import flink_agents.e2e_tests.e2e_tests_integration.checkpoint_recovery_agent' \
+            >/dev/null 2>&1; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# The Flink config.yaml as shipped, from an installed Flink or from PyFlink's
+# bundled copy. Empty when neither is present.
+find_shipped_config() {
+    local candidate
+    for candidate in "${FLINK_HOME:-}/conf/config.yaml" \
+                     "$REPO_ROOT"/.flink-agents-env/lib/python*/site-packages/pyflink/conf/config.yaml \
+                     "$REPO_ROOT"/venv/lib/python*/site-packages/pyflink/conf/config.yaml \
+                     "${VIRTUAL_ENV:-}"/lib/python*/site-packages/pyflink/conf/config.yaml; do
+        [[ -f "$candidate" ]] && { printf '%s' "$candidate"; return 0; }
+    done
+    return 1
+}

--- a/tools/test/helpers/recovery.bash
+++ b/tools/test/helpers/recovery.bash
@@ -41,6 +41,7 @@ reset_recovery_sh_state() {
     INPUT_FILE=""
     CHECKPOINT_DIR="/tmp/ckpt"
     FLINK_CONF=""
+    FLINK_CONF_BACKUP=""
     TM_PID_BEFORE=""
     TM_RESOURCE_ID_BEFORE=""
     RESTORED_BEFORE=""

--- a/tools/test/unit/checkpoint_recovery_harness.bats
+++ b/tools/test/unit/checkpoint_recovery_harness.bats
@@ -1,0 +1,900 @@
+#!/usr/bin/env bats
+
+# Unit tests for the pure functions in
+# e2e-test/test-scripts/test_checkpoint_recovery.sh.
+#
+# That script's job is to decide whether Python agent memory survived a
+# TaskManager kill, and almost all of it needs a real cluster. These tests cover
+# the parts that do not: JSON extraction, the comparison operator, the wait
+# helpers' failure reporting, the idempotent config edit, and the three
+# assertions that turn observations into a pass or a fail.
+#
+# The emphasis is on failure reporting rather than happy paths. A recovery test
+# that cannot distinguish "the condition was false" from "I was looking in the
+# wrong place" reports absence when it means ignorance, and that is precisely how
+# a test passes while verifying nothing.
+
+# Needed for `run --separate-stderr`, used where a helper returns a value on stdout
+# and logs on stderr. tools/test/run.sh pins bats to v1.11.0.
+bats_require_minimum_version 1.5.0
+
+setup() {
+    load '../helpers/recovery'
+    load_recovery_sh
+    reset_recovery_sh_state
+}
+
+# ---------------------------------------------------------------------------
+# json_query — reading values
+# ---------------------------------------------------------------------------
+
+@test "json_query: int reads a nested count" {
+    run query_fixture fixture_checkpoints int counts.completed
+    [ "$status" -eq 0 ]
+    [ "$output" = "6" ]
+}
+
+@test "json_query: str reads a job state" {
+    run query_fixture fixture_job_running str state
+    [ "$status" -eq 0 ]
+    [ "$output" = "RUNNING" ]
+}
+
+@test "json_query: len counts a list" {
+    run query_fixture fixture_taskmanagers_one len taskmanagers
+    [ "$status" -eq 0 ]
+    [ "$output" = "1" ]
+}
+
+@test "json_query: len of an empty list is 0, not a read failure" {
+    run query_fixture fixture_taskmanagers_none len taskmanagers
+    [ "$status" -eq 0 ]
+    [ "$output" = "0" ]
+}
+
+@test "json_query: a list index walks into the list" {
+    run query_fixture fixture_taskmanagers_one str taskmanagers.0.id
+    [ "$status" -eq 0 ]
+    [ "$output" = "172.18.0.3:39479-caf7a9" ]
+}
+
+@test "json_query: nullable distinguishes a null leaf from a populated one" {
+    run query_fixture fixture_checkpoints nullable latest.restored
+    [ "$status" -eq 0 ]
+    [ "$output" = "null" ]
+
+    run query_fixture fixture_checkpoints_restored nullable latest.restored
+    [ "$status" -eq 0 ]
+    [ "$output" = "present" ]
+}
+
+@test "json_query: conf finds a key whose name contains dots" {
+    run query_fixture fixture_jobmanager_config conf restart-strategy.type
+    [ "$status" -eq 0 ]
+    [ "$output" = "fixed-delay" ]
+}
+
+@test "json_query: interval comes back as exact milliseconds" {
+    run query_fixture fixture_checkpoint_config int interval
+    [ "$status" -eq 0 ]
+    [ "$output" = "5000" ]
+}
+
+# ---------------------------------------------------------------------------
+# json_query — read failures. Every one of these must exit non-zero and print
+# nothing, so that "I could not read this" can never be mistaken for a value.
+# ---------------------------------------------------------------------------
+
+@test "json_query: an empty body is a read failure" {
+    run query_body '' int counts.completed
+    [ "$status" -eq 1 ]
+    [ "$output" = "" ]
+}
+
+@test "json_query: a whitespace-only body is a read failure" {
+    run query_body '   ' int counts.completed
+    [ "$status" -eq 1 ]
+    [ "$output" = "" ]
+}
+
+@test "json_query: malformed JSON is a read failure" {
+    run query_body '{"counts":' int counts.completed
+    [ "$status" -eq 1 ]
+    [ "$output" = "" ]
+}
+
+@test "json_query: an HTML error page is a read failure" {
+    run query_body '<html>404</html>' int counts.completed
+    [ "$status" -eq 1 ]
+    [ "$output" = "" ]
+}
+
+@test "json_query: a missing leaf is a read failure" {
+    run query_fixture fixture_checkpoints int counts.nope
+    [ "$status" -eq 1 ]
+}
+
+@test "json_query: a misspelled nullable leaf is a read failure, not a null" {
+    # Otherwise a typo would read as "no restore yet" forever and the wait would
+    # blame the condition instead of the field name.
+    run query_fixture fixture_checkpoints nullable latest.restoredx
+    [ "$status" -eq 1 ]
+}
+
+@test "json_query: a leaf of the wrong type is a read failure" {
+    run query_fixture fixture_checkpoints str counts.completed
+    [ "$status" -eq 1 ]
+
+    run query_fixture fixture_checkpoints len counts
+    [ "$status" -eq 1 ]
+
+    run query_body '{"a":true}' int a
+    [ "$status" -eq 1 ]
+}
+
+@test "json_query: an absent conf key is a read failure" {
+    run query_fixture fixture_jobmanager_config conf nosuch.key
+    [ "$status" -eq 1 ]
+}
+
+@test "json_query: a list index past the end is a read failure" {
+    run query_fixture fixture_taskmanagers_none str taskmanagers.0.id
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# value_matches
+# ---------------------------------------------------------------------------
+
+@test "value_matches: eq compares strings" {
+    run value_matches "RUNNING" "eq:RUNNING"
+    [ "$status" -eq 0 ]
+    run value_matches "CREATED" "eq:RUNNING"
+    [ "$status" -eq 1 ]
+}
+
+@test "value_matches: ge is inclusive" {
+    run value_matches "3" "ge:3"
+    [ "$status" -eq 0 ]
+    run value_matches "4" "ge:3"
+    [ "$status" -eq 0 ]
+    run value_matches "2" "ge:3"
+    [ "$status" -eq 1 ]
+}
+
+@test "value_matches: nonnull keys off the nullable marker" {
+    run value_matches "present" "nonnull"
+    [ "$status" -eq 0 ]
+    run value_matches "null" "nonnull"
+    [ "$status" -eq 1 ]
+}
+
+@test "value_matches: a non-numeric ge operand is refused, not evaluated" {
+    # (( )) would treat RUNNING as a variable name and abort the script under
+    # set -u. Status 2 means "cannot compare", which the caller separates from
+    # "does not match".
+    run value_matches "RUNNING" "ge:3"
+    [ "$status" -eq 2 ]
+
+    run value_matches "3" "ge:oops"
+    [ "$status" -eq 2 ]
+}
+
+@test "value_matches: an unknown operator is refused" {
+    run value_matches "3" "gt:2"
+    [ "$status" -eq 2 ]
+    run value_matches "3" "lt:2"
+    [ "$status" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# wait_for_rest — the four states of (probe parsed, target parsed). Each must
+# report a different thing, because each means something different.
+# ---------------------------------------------------------------------------
+
+@test "wait_for_rest: a satisfied condition returns 0" {
+    stub_rest_get
+    REST_STUB_BODY="$(fixture_checkpoints)"
+    run wait_for_rest "stub" "/stub" "int:counts.total" "int:counts.completed" "ge:6" 3
+    [ "$status" -eq 0 ]
+}
+
+@test "wait_for_rest: neither field readable blames the endpoint" {
+    stub_rest_get
+    REST_STUB_BODY=""
+    run wait_for_rest "stub" "/stub" "int:counts.total" "int:counts.completed" "ge:99" 3
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"never parsed"* ]]
+    [[ "$output" == *"NOT evidence"* ]]
+}
+
+@test "wait_for_rest: probe readable but target not blames the field name" {
+    stub_rest_get
+    REST_STUB_BODY="$(fixture_checkpoints)"
+    run wait_for_rest "stub" "/stub" "int:counts.total" "int:counts.completedx" "ge:1" 3
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"so the endpoint is right"* ]]
+    [[ "$output" == *"never parsed 'counts.completedx'"* ]]
+    [[ "$output" == *"NOT evidence"* ]]
+}
+
+@test "wait_for_rest: a genuinely false condition reports the observed value" {
+    stub_rest_get
+    REST_STUB_BODY="$(fixture_checkpoints)"
+    run wait_for_rest "stub" "/stub" "int:counts.total" "int:counts.completed" "ge:99" 3
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"was last '6'"* ]]
+    # A condition that really was evaluated and really was false must not carry
+    # the disclaimer, or the disclaimer stops meaning anything.
+    [[ "$output" != *"NOT evidence"* ]]
+}
+
+@test "wait_for_rest: target observed but probe missing still reports the value" {
+    # The fourth state. Reporting only "the probe never parsed" here would
+    # withhold the one number a reader needs, and would claim the condition was
+    # not evaluated when it was.
+    stub_rest_get
+    REST_STUB_BODY='{"counts":{"completed":6}}'
+    run wait_for_rest "stub" "/stub" "int:counts.total" "int:counts.completed" "ge:99" 3
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"was last '6'"* ]]
+    [[ "$output" != *"NOT evidence"* ]]
+    # ...while still saying the response was not fully as expected.
+    [[ "$output" == *"only partly as expected"* ]]
+}
+
+@test "wait_for_rest: an uncomparable value stops the wait instead of spinning" {
+    stub_rest_get
+    REST_STUB_BODY="$(fixture_job_running)"
+    run wait_for_rest "stub" "/stub" "str:state" "str:state" "ge:3" 6
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"cannot be evaluated"* ]]
+}
+
+@test "wait_for_rest: a slow endpoint does not multiply the budget" {
+    # Counting only the sleeps ignores what each iteration actually costs — the
+    # request plus two python3 spawns — so against a slow endpoint a nominal
+    # budget used to overrun several times over, which would blow through the
+    # tool's release deadline before the harness noticed.
+    #
+    # The 2s delay in the stub is what makes this test discriminate: measured
+    # against a zero-latency stub, a deadline and an accumulated count both finish
+    # a 4s budget in 4s, and the test would pass either way.
+    REST_STUB_BODY="$(fixture_checkpoints)"
+    rest_get() { sleep 2; printf '%s' "$REST_STUB_BODY"; }
+    local start=$SECONDS
+    run wait_for_rest "stub" "/stub" "int:counts.total" "int:counts.completed" "ge:99" 4
+    local elapsed=$((SECONDS - start))
+    [ "$status" -eq 1 ]
+    # A deadline stops at about 6s here. Accumulating sleeps would have run four
+    # iterations of roughly 3s each, so about 12s.
+    [ "$elapsed" -lt 9 ]
+}
+
+# ---------------------------------------------------------------------------
+# wait_for_file — every file the job publishes is written to "<name>.tmp" and
+# renamed, so a crash between the two leaves a permanent twin.
+# ---------------------------------------------------------------------------
+
+@test "wait_for_file: an existing file returns 0" {
+    : > "$BATS_TEST_TMPDIR/verdict.json"
+    run wait_for_file "stub" "$BATS_TEST_TMPDIR/verdict.json" 2
+    [ "$status" -eq 0 ]
+}
+
+@test "wait_for_file: an absent file times out without inventing a twin" {
+    run wait_for_file "stub" "$BATS_TEST_TMPDIR/verdict.json" 2
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"did not appear"* ]]
+    [[ "$output" != *"leftover"* ]]
+}
+
+@test "wait_for_file: a leftover .tmp twin is reported and never accepted" {
+    : > "$BATS_TEST_TMPDIR/verdict.json.tmp"
+    run wait_for_file "stub" "$BATS_TEST_TMPDIR/verdict.json" 2
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"leftover"* ]]
+    [[ "$output" == *"verdict.json.tmp"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Environment setup. The harness assembles the Python environment and the cluster
+# classpath itself rather than delegating to tools/install.sh, because install.sh
+# would populate both from a *released* Flink Agents. These cover the choices that
+# assembly makes: which directory and interpreter become the venv, when an existing
+# one is reused instead, what an absent build artifact does, and which dist jars the
+# cluster is left holding.
+# ---------------------------------------------------------------------------
+
+@test "prepare_python_venv: an existing venv is reused, not recreated" {
+    VENV_DIR="$BATS_TEST_TMPDIR/venv"
+    mkdir -p "$VENV_DIR/bin"
+    : > "$VENV_DIR/pyvenv.cfg"
+    printf '#!/bin/sh\n' > "$VENV_DIR/bin/python"
+    chmod +x "$VENV_DIR/bin/python"
+    # Recreating would run this and fail, so a pass means it was not attempted.
+    PYTHON_BIN=false
+
+    run prepare_python_venv
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Reusing Python venv"* ]]
+}
+
+@test "prepare_python_venv: a non-empty directory that is not a venv is refused" {
+    VENV_DIR="$BATS_TEST_TMPDIR/occupied"
+    mkdir -p "$VENV_DIR"
+    : > "$VENV_DIR/unrelated-file"
+    PYTHON_BIN=false
+
+    run prepare_python_venv
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not an empty directory or a valid venv"* ]]
+}
+
+@test "prepare_python_venv: creating one targets VENV_DIR with the configured interpreter" {
+    VENV_DIR="$BATS_TEST_TMPDIR/fresh"
+    local recorder="$BATS_TEST_TMPDIR/recording-python"
+    cat > "$recorder" <<EOF
+#!/bin/sh
+printf '%s\n' "\$*" > "$BATS_TEST_TMPDIR/venv-args"
+EOF
+    chmod +x "$recorder"
+    PYTHON_BIN="$recorder"
+
+    run prepare_python_venv
+    [ "$status" -eq 0 ]
+    [ "$(cat "$BATS_TEST_TMPDIR/venv-args")" = "-m venv $VENV_DIR" ]
+}
+
+@test "install_built_python_package: an absent wheel is a failure, never a fallback" {
+    ROOT_DIR="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$ROOT_DIR/python/dist"
+
+    run install_built_python_package
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Python wheel not found"* ]]
+}
+
+# A jar carrying a different version has a different filename, so copying the
+# built one cannot replace it — both would end up on the classpath.
+@test "stage_dist_jars: a dist jar of another version is removed, not left beside the built one" {
+    ROOT_DIR="$BATS_TEST_TMPDIR/repo"
+    FLINK_HOME="$BATS_TEST_TMPDIR/flink"
+    FLINK_MAJOR_MINOR="2.3"
+    mkdir -p "$ROOT_DIR/dist/flink-2.3/target" "$FLINK_HOME/lib"
+    printf '<project>\n<version>ignored-parent</version>\n<version>0.3-SNAPSHOT</version>\n</project>\n' \
+        > "$ROOT_DIR/pom.xml"
+    : > "$ROOT_DIR/dist/flink-2.3/target/flink-agents-dist-flink-2.3-0.3-SNAPSHOT.jar"
+    : > "$FLINK_HOME/lib/flink-agents-dist-flink-2.3-0.3.0.jar"
+
+    stage_dist_jars
+
+    local jars=("$FLINK_HOME/lib"/flink-agents-dist-*.jar)
+    [ "${#jars[@]}" -eq 1 ]
+    [ "$(basename "${jars[0]}")" = "flink-agents-dist-flink-2.3-0.3-SNAPSHOT.jar" ]
+}
+
+# ---------------------------------------------------------------------------
+# The trigger file. The job's source stays open for the life of the job, so it
+# needs a file to read and the harness supplies it. Both silent failure modes are
+# covered here: a file the source's filter skips, and an empty file, either of
+# which leaves the job running and reading nothing until a later wait expires.
+#
+# The `|| false` after each [[ ]] is load-bearing, not decoration. errexit in bash
+# 3.2, the interpreter macOS supplies and bats takes test bodies from, does not
+# apply to [[ ]], so a bare [[ ]] assertion cannot fail a test there — it only
+# fails from bash 4 on. Chaining a simple command onto it restores the check.
+# ---------------------------------------------------------------------------
+
+@test "prepare_work_dirs: writes a trigger file the source will read" {
+    TMPDIR="$BATS_TEST_TMPDIR"
+
+    prepare_work_dirs
+
+    [ -s "$INPUT_FILE" ]
+    # Inside the work directory, so cleanup removes it and two runs cannot share one.
+    [[ "$INPUT_FILE" == "$WORK_DIR"/* ]] || false
+    # Flink's default file filter skips these prefixes even for a path handed to the
+    # source directly, and skipping is silent.
+    [[ "$(basename "$INPUT_FILE")" != [._]* ]] || false
+}
+
+@test "prepare_work_dirs: an empty trigger file stops the run instead of reaching the job" {
+    TMPDIR="$BATS_TEST_TMPDIR"
+    # Land the rename on an empty file, which is the state the guard exists for.
+    mv() { : > "$2"; }
+
+    run prepare_work_dirs
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"missing or empty"* ]] || false
+}
+
+# Covers the argument submit_job builds, and the file state at that boundary given a
+# caller that ran prepare_work_dirs first. It does not establish that main() calls them
+# in that order; the test below does that.
+@test "submit_job: the job is handed a trigger file that already exists and is non-empty" {
+    TMPDIR="$BATS_TEST_TMPDIR"
+    ROOT_DIR="$BATS_TEST_TMPDIR/repo"
+    VENV_DIR="$BATS_TEST_TMPDIR/venv"
+    FLINK_HOME="$BATS_TEST_TMPDIR/flink"
+    local state="$BATS_TEST_TMPDIR/input-file-state"
+    local fake_bin="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$ROOT_DIR/python/$(dirname "$JOB_MODULE")" \
+             "$VENV_DIR/bin" "$FLINK_HOME/bin" "$fake_bin"
+    : > "$ROOT_DIR/python/$JOB_MODULE"
+    printf '#!/bin/sh\necho purelib\n' > "$VENV_DIR/bin/python"
+    # macOS ships no timeout(1), and the harness calls it unqualified.
+    printf '#!/bin/sh\nshift\nexec "$@"\n' > "$fake_bin/timeout"
+
+    # Stands in for the Flink CLI, and reports the state of the file it was pointed
+    # at as of the moment of submission. -f as well as -s: a directory is non-empty
+    # by -s, so without it any path-shaped argument would satisfy the check.
+    cat > "$FLINK_HOME/bin/flink" <<EOF
+#!/bin/sh
+prev=""
+for arg in "\$@"; do
+    if [ "\$prev" = "--input-file" ]; then
+        if [ -f "\$arg" ] && [ -s "\$arg" ]; then
+            echo non-empty-file > "$state"
+        else
+            echo "not-a-non-empty-file: \$arg" > "$state"
+        fi
+    fi
+    prev="\$arg"
+done
+[ -f "$state" ] || echo no-input-file-argument > "$state"
+echo "Job has been submitted with JobID 0123456789abcdef0123456789abcdef"
+EOF
+    chmod +x "$VENV_DIR/bin/python" "$fake_bin/timeout" "$FLINK_HOME/bin/flink"
+    PATH="$fake_bin:$PATH"
+
+    prepare_work_dirs
+    run submit_job
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$state")" = "non-empty-file" ]
+}
+
+# The source enumerates its splits eagerly, at job start, so a trigger file written
+# after submission is a race, and losing that order is this commit's one hard failure.
+# Every step main() drives needs a cluster and is stubbed out; prepare_work_dirs is
+# left real, so what submit_job sees is the file the harness actually produced.
+@test "main: the trigger file is written before the job is submitted" {
+    TMPDIR="$BATS_TEST_TMPDIR"
+    local observed="$BATS_TEST_TMPDIR/state-at-submit"
+    local step
+    for step in install_flink build_project stage_dist_jars configure_flink \
+                start_cluster assert_effective_config assert_handshake_budget \
+                wait_job_running assert_checkpointing_enabled assert_runtime_identity \
+                wait_tool_parked wait_for_checkpoint_containing_payload \
+                record_taskmanager_identity kill_taskmanager restart_taskmanager \
+                wait_for_restore release_tool assert_verdict; do
+        eval "$step() { :; }"
+    done
+    submit_job() {
+        if [ -f "$INPUT_FILE" ] && [ -s "$INPUT_FILE" ]; then
+            echo non-empty-file > "$observed"
+        else
+            echo "not-a-non-empty-file: '$INPUT_FILE'" > "$observed"
+        fi
+    }
+
+    main
+
+    [ "$(cat "$observed")" = "non-empty-file" ]
+}
+
+# ---------------------------------------------------------------------------
+# The config edit. A repeated append is a hard YAML duplicate-key failure that
+# stops the cluster from starting, and install.sh reuses an extracted Flink home,
+# so this fires on the second local run rather than in CI.
+# ---------------------------------------------------------------------------
+
+@test "configure_flink: applying twice leaves each key exactly once" {
+    FLINK_CONF="$BATS_TEST_TMPDIR/config.yaml"
+    write_nested_config_fixture "$FLINK_CONF"
+
+    configure_flink
+    local after_first
+    after_first=$(wc -l < "$FLINK_CONF")
+    configure_flink
+    [ "$(wc -l < "$FLINK_CONF")" -eq "$after_first" ]
+
+    local key
+    for key in execution.checkpointing.interval execution.checkpointing.dir \
+               restart-strategy.type restart-strategy.fixed-delay.attempts \
+               resourcemanager.standalone.start-up-time; do
+        [ "$(grep -c "^${key}: " "$FLINK_CONF")" -eq 1 ]
+    done
+}
+
+@test "configure_flink: applying twice introduces no duplicate top-level key" {
+    FLINK_CONF="$BATS_TEST_TMPDIR/config.yaml"
+    write_nested_config_fixture "$FLINK_CONF"
+    configure_flink
+    configure_flink
+    run duplicate_top_level_keys "$FLINK_CONF"
+    [ "$output" = "" ]
+}
+
+@test "configure_flink: the interval is written in the unit the assertion reads" {
+    FLINK_CONF="$BATS_TEST_TMPDIR/config.yaml"
+    write_nested_config_fixture "$FLINK_CONF"
+    CHECKPOINT_INTERVAL_MS=7000
+    configure_flink
+    run grep '^execution.checkpointing.interval: ' "$FLINK_CONF"
+    [ "$status" -eq 0 ]
+    [ "$output" = "execution.checkpointing.interval: 7000ms" ]
+}
+
+@test "delete_config_key: reverting restores the file byte for byte" {
+    FLINK_CONF="$BATS_TEST_TMPDIR/config.yaml"
+    write_nested_config_fixture "$FLINK_CONF"
+    cp "$FLINK_CONF" "$BATS_TEST_TMPDIR/config.yaml.orig"
+
+    configure_flink
+    local key
+    for key in "${CONFIG_KEYS_SET[@]}"; do
+        delete_config_key "$key"
+    done
+
+    run diff "$BATS_TEST_TMPDIR/config.yaml.orig" "$FLINK_CONF"
+    [ "$status" -eq 0 ]
+}
+
+@test "configure_flink: appending does not displace a shipped nested value" {
+    FLINK_CONF="$BATS_TEST_TMPDIR/config.yaml"
+    write_nested_config_fixture "$FLINK_CONF"
+    configure_flink
+    # The nested blocks the appended flat keys sit next to must survive verbatim,
+    # indentation included.
+    run grep -c '^  numberOfTaskSlots: 1$' "$FLINK_CONF"
+    [ "$output" = "1" ]
+    run grep -c '^    address: localhost$' "$FLINK_CONF"
+    [ "$output" = "1" ]
+    run grep -c '^  address: localhost$' "$FLINK_CONF"
+    [ "$output" = "1" ]
+}
+
+@test "configure_flink: idempotent against the real shipped config.yaml" {
+    local shipped
+    shipped="$(find_shipped_config || true)"
+    [[ -n "$shipped" ]] || skip "no shipped Flink config.yaml found; install Flink or PyFlink to cover this"
+
+    FLINK_CONF="$BATS_TEST_TMPDIR/shipped.yaml"
+    cp "$shipped" "$FLINK_CONF"
+    cp "$shipped" "$BATS_TEST_TMPDIR/shipped.orig"
+
+    configure_flink
+    configure_flink
+    run duplicate_top_level_keys "$FLINK_CONF"
+    [ "$output" = "" ]
+
+    local key
+    for key in "${CONFIG_KEYS_SET[@]}"; do
+        delete_config_key "$key"
+    done
+    run diff "$BATS_TEST_TMPDIR/shipped.orig" "$FLINK_CONF"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# assert_effective_config — proves the append reached the configuration the
+# JobManager loaded. It cannot prove the option took effect, because
+# /jobmanager/config echoes unrecognized keys too; that is what
+# assert_checkpointing_enabled is for.
+# ---------------------------------------------------------------------------
+
+@test "assert_effective_config: a complete configuration passes" {
+    stub_rest_get
+    REST_STUB_BODY="$(fixture_jobmanager_config)"
+    assert_effective_config
+    [ "${RESULT_STATES[0]}" = "PASS" ]
+}
+
+@test "assert_effective_config: a missing key fails and is recorded" {
+    stub_rest_get
+    REST_STUB_BODY="$(fixture_jobmanager_config | sed '/restart-strategy.type/d')"
+    run assert_effective_config
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"absent from the cluster configuration"* ]]
+
+    # Recorded, not just reported: the recorded FAIL is what makes the script
+    # exit non-zero. `run` uses a subshell, so assert again in this one.
+    REST_STUB_BODY="$(fixture_jobmanager_config | sed '/restart-strategy.type/d')"
+    assert_effective_config || true
+    [ "${RESULT_STATES[0]}" = "FAIL" ]
+}
+
+@test "assert_effective_config: a wrong value reports both sides" {
+    stub_rest_get
+    REST_STUB_BODY="$(fixture_jobmanager_config | sed 's/"fixed-delay"/"disable"/')"
+    run assert_effective_config
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"restart-strategy.type is 'disable', expected 'fixed-delay'"* ]]
+}
+
+@test "assert_effective_config: an unreachable endpoint fails" {
+    stub_rest_get
+    REST_STUB_BODY=""
+    run assert_effective_config
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Could not read"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# assert_checkpointing_enabled — the authoritative guard on the single
+# misconfiguration that would let the whole test pass having verified nothing.
+# ---------------------------------------------------------------------------
+
+@test "assert_checkpointing_enabled: the expected interval passes" {
+    stub_rest_get
+    REST_STUB_BODY="$(fixture_checkpoint_config)"
+    assert_checkpointing_enabled
+    [ "${RESULT_STATES[0]}" = "PASS" ]
+}
+
+@test "assert_checkpointing_enabled: a 404 means checkpointing is off" {
+    # curl -fsS fails on 404, so rest_get yields nothing. This endpoint exists
+    # only when the job has checkpointing, which is why absence is conclusive.
+    stub_rest_get
+    REST_STUB_BODY=""
+    run assert_checkpointing_enabled
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"checkpointing is off"* ]]
+}
+
+@test "assert_checkpointing_enabled: a different interval fails" {
+    stub_rest_get
+    REST_STUB_BODY="$(fixture_checkpoint_config | sed 's/"interval":5000/"interval":180000/')"
+    run assert_checkpointing_enabled
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"180000ms, expected 5000ms"* ]]
+}
+
+@test "assert_checkpointing_enabled: overlapping checkpoints warn about the gate" {
+    stub_rest_get
+    REST_STUB_BODY="$(fixture_checkpoint_config | sed 's/"max_concurrent":1/"max_concurrent":3/')"
+    run assert_checkpointing_enabled
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"weaker than intended"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# assert_verdict — the job publishes one "verdict" field. The harness reads it
+# and must not recompute the pass condition from the component booleans.
+# ---------------------------------------------------------------------------
+
+verdict_setup() {
+    VERDICT_DIR="$BATS_TEST_TMPDIR/verdict"
+    mkdir -p "$VERDICT_DIR"
+    VERDICT_TIMEOUT=2
+    job_state() { printf 'RUNNING'; }
+}
+
+@test "assert_verdict: a pass verdict passes" {
+    verdict_setup
+    printf '%s' '{"verdict":"pass","blob_observed_type":"bytes"}' > "$VERDICT_DIR/verdict.json"
+    assert_verdict
+    [ "${RESULT_STATES[0]}" = "PASS" ]
+}
+
+@test "assert_verdict: a missing verdict file is a failure, never a pass" {
+    verdict_setup
+    run assert_verdict
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"nothing was verified"* ]]
+}
+
+@test "assert_verdict: a fail verdict fails and is recorded" {
+    verdict_setup
+    printf '%s' '{"verdict":"fail","blob_observed_type":"NoneType"}' > "$VERDICT_DIR/verdict.json"
+    run assert_verdict
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"the job reported 'fail'"* ]]
+
+    assert_verdict || true
+    [ "${RESULT_STATES[0]}" = "FAIL" ]
+}
+
+@test "assert_verdict: the verdict field wins over the component booleans" {
+    # Every component says pass; the verdict says fail. The harness must not
+    # rebuild the conjunction, or the pass condition would live in two places.
+    verdict_setup
+    printf '%s' '{"verdict":"fail","restored_blob":true,"restored_context":true,"handshake_ok":true}' \
+        > "$VERDICT_DIR/verdict.json"
+    run assert_verdict
+    [ "$status" -eq 1 ]
+}
+
+@test "assert_verdict: a file without a verdict field is a format mismatch" {
+    verdict_setup
+    printf '%s' '{"restored_blob":true}' > "$VERDICT_DIR/verdict.json"
+    run assert_verdict
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"disagree about the verdict format"* ]]
+}
+
+@test "assert_verdict: an unparsable verdict file fails" {
+    verdict_setup
+    printf '%s' 'not json at all' > "$VERDICT_DIR/verdict.json"
+    run assert_verdict
+    [ "$status" -eq 1 ]
+}
+
+@test "assert_verdict: a .tmp twin is never read as the verdict" {
+    verdict_setup
+    printf '%s' '{"verdict":"pass"}' > "$VERDICT_DIR/verdict.json.tmp"
+    run assert_verdict
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"leftover"* ]]
+}
+
+@test "assert_verdict: a job that died without a verdict fails fast" {
+    verdict_setup
+    VERDICT_TIMEOUT=30
+    job_state() { printf 'FAILED'; }
+    local start=$SECONDS
+    run assert_verdict
+    local elapsed=$((SECONDS - start))
+    [ "$status" -eq 1 ]
+    [ "$elapsed" -lt 10 ]
+}
+
+# ---------------------------------------------------------------------------
+# The tool releases itself after a fixed deadline whether or not the harness has
+# finished, so everything between parking the tool and creating `release` has to
+# fit inside it — in wall clock, not in a sum of nominal timeouts.
+#
+# charged_timeout holds the guarantee by measuring; assert_handshake_budget is a
+# conservative pre-flight prediction that fails an unusable configuration fast.
+# ---------------------------------------------------------------------------
+
+payload_budget_setup() {
+    VENV_DIR="$(dirname "$(dirname "$(find_payload_interpreter || true)")")"
+    [[ -x "$VENV_DIR/bin/python" ]] || skip "no interpreter can import the payload module"
+    ROOT_DIR="$REPO_ROOT"
+}
+
+@test "assert_handshake_budget: the shipped defaults fit in wall clock" {
+    payload_budget_setup
+    run assert_handshake_budget
+    [ "$status" -eq 0 ]
+    # The deadline is read from the payload module rather than restated here.
+    [[ "$output" == *"240s"* ]]
+}
+
+@test "assert_handshake_budget: a budget that fits nominally but not in wall clock is rejected" {
+    # These four were the shipped defaults until the budget was made to bound wall
+    # clock: they sum to 195s, comfortably under the 240s deadline, so summing
+    # nominal timeouts accepted them. Charged properly — each wait can overrun by a
+    # poll interval plus a request timeout, and the unattributed costs are real —
+    # they need 268s against 225s available, and must be rejected.
+    payload_budget_setup
+    CHECKPOINT_TIMEOUT=45 TM_GONE_TIMEOUT=60 TM_UP_TIMEOUT=45 RESTORE_TIMEOUT=45
+    run assert_handshake_budget
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"could take up to"* ]]
+    [[ "$output" == *"exceeds"* ]]
+}
+
+@test "assert_handshake_budget: a grossly inflated budget is rejected" {
+    payload_budget_setup
+    CHECKPOINT_TIMEOUT=200 TM_GONE_TIMEOUT=60 TM_UP_TIMEOUT=45 RESTORE_TIMEOUT=45
+    run assert_handshake_budget
+    [ "$status" -eq 1 ]
+}
+
+@test "assert_handshake_budget: a slower request timeout can make a budget infeasible" {
+    # CURL_MAX_TIME is charged per wait, so raising it eats the slack. This is the
+    # coupling that a nominal sum cannot see at all.
+    payload_budget_setup
+    run assert_handshake_budget
+    [ "$status" -eq 0 ]
+    CURL_MAX_TIME=30
+    run assert_handshake_budget
+    [ "$status" -eq 1 ]
+}
+
+@test "charged_timeout: passes a configured budget through when time remains" {
+    RELEASE_DEADLINE_S=240
+    HANDSHAKE_DEADLINE_AT=$((SECONDS + 100))
+    run --separate-stderr charged_timeout "step" 30
+    [ "$status" -eq 0 ]
+    [ "$output" = "30" ]
+}
+
+@test "charged_timeout: clamps to the time actually left" {
+    # The measured bound. Whatever earlier steps spent — modelled or not — has
+    # already gone, so this step may only have what is left.
+    RELEASE_DEADLINE_S=240
+    HANDSHAKE_DEADLINE_AT=$((SECONDS + 7))
+    # --separate-stderr because the clamp logs a warning while returning the number.
+    run --separate-stderr charged_timeout "step" 30
+    [ "$status" -eq 0 ]
+    [ "$output" -le 7 ]
+    [ "$output" -gt 0 ]
+}
+
+@test "charged_timeout: fails once the deadline has passed" {
+    RELEASE_DEADLINE_S=240
+    HANDSHAKE_DEADLINE_AT=$((SECONDS - 1))
+    run charged_timeout "step" 30
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"elapsed before this step began"* ]]
+}
+
+@test "handshake_budget_left: never reports a negative remainder" {
+    HANDSHAKE_DEADLINE_AT=$((SECONDS - 60))
+    run --separate-stderr handshake_budget_left
+    [ "$output" = "0" ]
+}
+
+# ---------------------------------------------------------------------------
+# cleanup's work-directory decision. The directory holds the verdict, the
+# handshake markers and the checkpoints, so it must survive anything that needs
+# explaining. Exercised in a subshell because the decision runs from the EXIT
+# trap and depends on the exit status.
+# ---------------------------------------------------------------------------
+
+run_cleanup_with_exit() {  # $1 = exit code, $2 = recorded state ("" for none)
+    local code="$1" state="$2"
+    env FLINK_AGENTS_RECOVERY_SH_NO_RUN=1 bash -c '
+        source "$1"
+        WORK_DIR="$2"; mkdir -p "$WORK_DIR"
+        FLINK_CONF=""
+        if [[ -n "$4" ]]; then RESULT_NAMES=(step); RESULT_STATES=("$4"); fi
+        exit "$3"
+    ' _ "$RECOVERY_SH" "$BATS_TEST_TMPDIR/wd" "$code" "$state" >/dev/null 2>&1 || true
+}
+
+@test "cleanup: a clean exit with everything passing removes the work directory" {
+    run_cleanup_with_exit 0 PASS
+    [ ! -d "$BATS_TEST_TMPDIR/wd" ]
+}
+
+@test "cleanup: a recorded FAIL keeps the work directory" {
+    run_cleanup_with_exit 0 FAIL
+    [ -d "$BATS_TEST_TMPDIR/wd" ]
+}
+
+@test "cleanup: a non-zero exit keeps it even with no FAIL recorded" {
+    # The setup steps and several assertions abort under set -e without recording
+    # anything, so judging by the recorded results alone would delete the
+    # diagnostics for exactly the runs that need them.
+    run_cleanup_with_exit 3 PASS
+    [ -d "$BATS_TEST_TMPDIR/wd" ]
+}
+
+@test "cleanup: recording nothing at all keeps the work directory" {
+    run_cleanup_with_exit 0 ""
+    [ -d "$BATS_TEST_TMPDIR/wd" ]
+}
+
+# ---------------------------------------------------------------------------
+# print_summary
+# ---------------------------------------------------------------------------
+
+@test "print_summary: recording nothing exits non-zero" {
+    # A run that recorded no assertion verified nothing. Reporting that as
+    # success is the failure this script exists to prevent.
+    RESULT_NAMES=()
+    RESULT_STATES=()
+    run print_summary
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"nothing was verified"* ]]
+}
+
+@test "print_summary: any recorded FAIL exits non-zero" {
+    RESULT_NAMES=("a" "b")
+    RESULT_STATES=("PASS" "FAIL")
+    run print_summary
+    [ "$status" -eq 1 ]
+}
+
+@test "print_summary: all passing returns 0" {
+    RESULT_NAMES=("a" "b")
+    RESULT_STATES=("PASS" "PASS")
+    run print_summary
+    [ "$status" -eq 0 ]
+}

--- a/tools/test/unit/checkpoint_recovery_harness.bats
+++ b/tools/test/unit/checkpoint_recovery_harness.bats
@@ -188,6 +188,40 @@ setup() {
 }
 
 # ---------------------------------------------------------------------------
+# The REST transport itself. Every read the harness performs goes through
+# rest_get, and nothing else in this suite looks at the request layer: rest_get
+# is replaced by stub_rest_get everywhere it is exercised.
+# ---------------------------------------------------------------------------
+
+@test "REST reads: every curl in test_checkpoint_recovery.sh is bounded by --max-time" {
+    # Contract: no request may run without a deadline of its own. A peer that
+    # accepts the connection and then never answers is not covered by curl's
+    # connect timeout, so an unbounded read has nothing to end it and outlives the
+    # wait loop that issued it.
+    #
+    # This reads the script's text rather than its behavior, which makes it
+    # deliberately brittle: the -m short form, a curl inside a heredoc, or a
+    # request split across a line continuation would fail it and need it
+    # rewritten — the continuation because --max-time on the next line is never
+    # seen. That cost is accepted because the invariant has no behavioral surface
+    # here — every caller stubs the transport out — and an unbounded read
+    # reintroduced anywhere in the file would otherwise be invisible until a run
+    # hung.
+    run grep -nE '^[[:space:]]*[^#]*curl[[:space:]]' "$RECOVERY_SH"
+    # A denominator: a rename or a refactor that leaves no curl at all must fail
+    # here rather than sweep nothing and read as a pass.
+    [ "$status" -eq 0 ]
+
+    local line
+    while IFS= read -r line; do
+        case "$line" in
+            *--max-time*) continue ;;
+            *) printf 'unbounded curl: %s\n' "$line"; return 1 ;;
+        esac
+    done <<< "$output"
+}
+
+# ---------------------------------------------------------------------------
 # wait_for_rest — the four states of (probe parsed, target parsed). Each must
 # report a different thing, because each means something different.
 # ---------------------------------------------------------------------------
@@ -527,7 +561,7 @@ EOF
     [ "$output" = "execution.checkpointing.interval: 7000ms" ]
 }
 
-@test "delete_config_key: reverting restores the file byte for byte" {
+@test "delete_config_key: removes the appended lines and nothing else" {
     FLINK_CONF="$BATS_TEST_TMPDIR/config.yaml"
     write_nested_config_fixture "$FLINK_CONF"
     cp "$FLINK_CONF" "$BATS_TEST_TMPDIR/config.yaml.orig"
@@ -576,6 +610,58 @@ EOF
     done
     run diff "$BATS_TEST_TMPDIR/shipped.orig" "$FLINK_CONF"
     [ "$status" -eq 0 ]
+}
+
+# stat spells a file mode differently in its BSD and GNU flavors, and these tests
+# run under both.
+file_mode() {
+    stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
+}
+
+@test "restore_flink_conf: the installation's config comes back byte for byte and mode for mode" {
+    FLINK_CONF="$BATS_TEST_TMPDIR/config.yaml"
+    write_nested_config_fixture "$FLINK_CONF"
+    # A value the installation itself set, at column 0, for a key this run also
+    # writes. set_config_key drops that line before appending its own, so nothing
+    # narrower than the whole file can put it back.
+    printf 'restart-strategy.type: exponential-delay\n' >> "$FLINK_CONF"
+    chmod 644 "$FLINK_CONF"
+    cp -p "$FLINK_CONF" "$BATS_TEST_TMPDIR/config.yaml.orig"
+
+    backup_flink_conf
+    configure_flink
+
+    # Without these two the test could pass against a run that never altered the
+    # file, proving nothing about the restore.
+    run grep -c '^restart-strategy.type: exponential-delay$' "$FLINK_CONF"
+    [ "$output" = "0" ]
+    # The mode half of that denominator: the 644 check after the restore is vacuous
+    # unless the mode moves off it first.
+    [ "$(file_mode "$FLINK_CONF")" = "600" ]
+
+    restore_flink_conf
+    run diff "$BATS_TEST_TMPDIR/config.yaml.orig" "$FLINK_CONF"
+    [ "$status" -eq 0 ]
+    [ "$(file_mode "$FLINK_CONF")" = "644" ]
+    [ ! -f "$FLINK_CONF_BACKUP" ]
+
+    # Restoring a second time finds no copy and returns without touching anything.
+    # The status is what distinguishes that from a failed copy: cp cannot truncate
+    # the destination when its source is missing, so the file is unchanged either
+    # way and comparing it again would assert nothing.
+    run restore_flink_conf
+    [ "$status" -eq 0 ]
+}
+
+@test "install_flink: takes the pre-run copy of config.yaml" {
+    # The wiring rather than the function. restore_flink_conf can only put the file
+    # back if the copy was taken, and the test above calls backup_flink_conf itself
+    # — so dropping the one call inside install_flink leaves the suite green. Read
+    # from the parsed function body because install_flink needs a real Flink
+    # distribution to run: this pins the call, not where it sits in the body.
+    run declare -f install_flink
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q 'backup_flink_conf'
 }
 
 # ---------------------------------------------------------------------------
@@ -837,15 +923,19 @@ payload_budget_setup() {
 # trap and depends on the exit status.
 # ---------------------------------------------------------------------------
 
-run_cleanup_with_exit() {  # $1 = exit code, $2 = recorded state ("" for none)
-    local code="$1" state="$2"
+run_cleanup_with_exit() {  # $1 = exit code, $2 = recorded state ("" for none),
+                           # $3 = FLINK_CONF, $4 = FLINK_CONF_BACKUP (both
+                           # optional; empty leaves the restore inert)
+    local code="$1" state="$2" conf="${3:-}" backup="${4:-}"
     env FLINK_AGENTS_RECOVERY_SH_NO_RUN=1 bash -c '
         source "$1"
         WORK_DIR="$2"; mkdir -p "$WORK_DIR"
-        FLINK_CONF=""
+        FLINK_CONF="$5"
+        FLINK_CONF_BACKUP="$6"
         if [[ -n "$4" ]]; then RESULT_NAMES=(step); RESULT_STATES=("$4"); fi
         exit "$3"
-    ' _ "$RECOVERY_SH" "$BATS_TEST_TMPDIR/wd" "$code" "$state" >/dev/null 2>&1 || true
+    ' _ "$RECOVERY_SH" "$BATS_TEST_TMPDIR/wd" "$code" "$state" "$conf" "$backup" \
+        >/dev/null 2>&1 || true
 }
 
 @test "cleanup: a clean exit with everything passing removes the work directory" {
@@ -869,6 +959,21 @@ run_cleanup_with_exit() {  # $1 = exit code, $2 = recorded state ("" for none)
 @test "cleanup: recording nothing at all keeps the work directory" {
     run_cleanup_with_exit 0 ""
     [ -d "$BATS_TEST_TMPDIR/wd" ]
+}
+
+@test "cleanup: the EXIT trap puts the installation's config.yaml back" {
+    # The other half of the wiring: a restore nothing calls leaves the installation
+    # mutated, and a test that calls restore_flink_conf directly cannot see that.
+    write_nested_config_fixture "$BATS_TEST_TMPDIR/config.yaml"
+    cp -p "$BATS_TEST_TMPDIR/config.yaml" "$BATS_TEST_TMPDIR/config.yaml.orig"
+    cp -p "$BATS_TEST_TMPDIR/config.yaml" "$BATS_TEST_TMPDIR/config.yaml.bak"
+    printf 'execution.checkpointing.interval: 5000ms\n' >> "$BATS_TEST_TMPDIR/config.yaml"
+
+    run_cleanup_with_exit 0 PASS \
+        "$BATS_TEST_TMPDIR/config.yaml" "$BATS_TEST_TMPDIR/config.yaml.bak"
+
+    run diff "$BATS_TEST_TMPDIR/config.yaml.orig" "$BATS_TEST_TMPDIR/config.yaml"
+    [ "$status" -eq 0 ]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Linked issue: #836

### Purpose of change

No test covers Python agent memory surviving the loss of a TaskManager process. Existing e2e suites run on MiniCluster, which never recreates the embedded Python interpreter, so a value Pemja cannot materialize into a JVM type fails only on a real restore. This test hard-kills a real TaskManager and asserts the tool-call context and a raw `bytes` value both survived.

#### Runtime flow

1. The harness configures checkpointing and a restart strategy on a standalone cluster, stages this checkout's artifacts, and submits the job detached.
2. The agent writes the blob to memory, bumps a process-local counter, and requests a chat. The mock model emits one tool call; the tool writes `tool-entered` and blocks on `release`.
3. On `tool-entered` it waits for two further completed checkpoints, records the pid, resource id and restore count, SIGKILLs the TaskManager, starts a replacement, waits for a restore, then writes `release`.
4. The re-executed tool returns its sentinel. The agent checks the restored blob and transcript against the counters, writes `verdict.json`, and raises on mismatch.

#### Key decisions

The source must be unbounded. A bounded one raises end-of-input right after the record, and `ActionExecutionOperator.endInput()` then holds the mailbox thread while the run is parked, so no checkpoint completes. Measured on the pinned stack: unbounded 16 completions in 15s, bounded 0.

Provenance rests on module-level counters outside Flink state, since anything checkpointed is restored with the payload and cannot tell a restored read from the reader's own write. Pemja's singleton interpreter keeps globals across an in-place task restart, so zero counters prove a different OS process.

`counts.restored` rather than `numRestarts`, which counts a restart that restored nothing.

### Implementation Description

#### Behavioral contracts

1. A pass requires a published `verdict: "pass"`; a run recording no assertion exits non-zero.
2. The interval comes from the job's own coordinator config, not the harness's file.
3. The payload sits in a checkpoint taken while parked: two completions past a park-time baseline.
4. `counts.restored` rises above its pre-kill baseline.
5. `latest.restored` is non-null. If 4 and 5 disagree the run fails rather than picking one.
6. The process was replaced: pid and resource id both differ from pre-kill.
7. The values came from another process: both counters are 0 where they are asserted.
8. The blob is exactly `bytes` with the exact content; a `bytearray`, a `bytes` subclass, or a list of the same ints all fail.
9. The kill/restart window fits the tool's deadline: a pre-flight check plus a per-wait clamp.
10. The TaskManager ran this checkout: version `0.3.dev0`, `flink_agents.api` under its path.
11. Config edits are idempotent and reverted, leaving no duplicate top-level YAML key.
12. The new workflow job never runs on a pull request.
13. The output schema the request carries is rebuilt from restored state and applied to the round-two response, and a round that never applied it cannot pass.

#### Failure behavior

A missing `handshake_dir` or `verdict_dir` raises `ValueError`. Checkpointing off or a wrong interval records a FAIL and exits non-zero, and an infeasible budget exits 1.

An unreachable, slow, or wrongly shaped REST response never reads as a false condition. Requests are bounded by `CURL_MAX_TIME`; an empty body, bad JSON, a missing path, or a wrongly typed leaf all fail the read.

One path degrades deliberately. The framework absorbs a tool exception into a `... execute failed.` response rather than failing the action, so the tool returns a sentinel the assertion requires. The agent publishes the verdict before raising `AssertionError`, so a failed run leaves a readable file.

### Tests

| Contract | Tests |
|---|---|
| 1 verdict only | 7 `assert_verdict`, 3 `print_summary` |
| 2 checkpointing | 4 `assert_checkpointing_enabled` |
| 3 two checkpoints | none; see negative control |
| 4 restored count | none; see provenance control |
| 5 restored non-null | none; see provenance control |
| 6 process replaced | none |
| 7 counters | none; exercised via 8 |
| 8 blob predicate | `_blob_matches`, 10 cases |
| 9 budget | 4 `assert_handshake_budget`, 3 `charged_timeout`, 1 `handshake_budget_left` |
| 10 identity | none |
| 11 config idempotent | 6 `configure_flink` / `delete_config_key` |
| 12 not on a PR | none |
| 13 output schema | `_structured_transcript`, 7 cases |
| handshake, for 3 and 7 | 3 `await_release` |

About 45 of the 82 bats tests pin harness plumbing the contracts above deliberately do not cover: REST reads, file waits, cluster and venv setup, and EXIT-trap cleanup.

The 82 bats and 19 Python tests run pre-merge; the cluster test does not, since its job is `schedule` and `workflow_dispatch` only. Fork runs are the only evidence, and the controls are what make the pass meaningful.

Happy path: 9/9 assertions, verdict `pass`, pid 4567 to 5892 with the resource id changed, `counts.completed` 3 while parked, `counts.restored` 0 to 1, both counters 0, blob back as `bytes`, and the restored output schema applied (`structured_ok`, observed as a `dict`).

Negative control, release marker pre-created: failed at `checkpoint-containment`, `counts.completed` stuck at 1 against a required 3.

Provenance control, kill skipped: failed at `restore`, `counts.restored` stayed 0 and the pid was never replaced. The failure lands at the restore wait rather than at the verdict.

It does not reproduce the SIGSEGV that motivated the issue: the memory value validator now raises `TypeError` at `set()` before Pemja is reached, so that control no longer exists. Unit tests pin which types the validator admits; only this one shows an admitted type survives a restore.

Known limitations: timeouts are sized from observed runs, not proven bounds; and 11 pre-existing bats assertions are vacuous under bash 3.2 bodies, since `errexit` does not apply to `[[ ]]`.

### API

No public API change, and no product code touched. Six of the seven files are new; the seventh adds a job to the nightly workflow, leaving its existing job, triggers and paths filter untouched. Nothing changes for a caller who does nothing differently.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

Generated-by: Claude Code 2.1.224

