### PR TITLE
[infra] Include model in AI provenance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,4 +33,4 @@ Linked issue: #xxx
 - [ ] Yes
 - [ ] No
 
-If yes, include a `Generated-by: <tool name and version>` line in the commit message so it reaches Git history, and repeat it here for reviewer visibility. See the [ASF generative tooling guidance](https://www.apache.org/legal/generative-tooling.html).
+If yes, include a `Generated-by: <tool name and version> (<model name and version>)` line, for example `Generated-by: Claude Code 2.1.226 (Claude Opus 4.6)`, in the commit message so it reaches Git history. Repeat the same line here for reviewer visibility. See the [ASF generative tooling guidance](https://www.apache.org/legal/generative-tooling.html).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Java tests use JUnit 5 with AssertJ and Mockito. Python tests use pytest; integr
 
 ## Commit & Pull Request Guidelines
 
-Use concise subjects with bracketed components, matching existing history, such as `[python] Admit bytes in memory values` or `[api][java] Add event constants`. For nontrivial behavior changes, open or link a GitHub issue before the PR. PR titles should include relevant components like `[api]`, `[runtime]`, `[java]`, `[python]`, or `[hotfix]`; describe the change, test evidence, and any compatibility impact. Answer the PR template's generative-AI question, and when such tooling was used, include a `Generated-by: <tool name and version>` line in the commit message so it reaches Git history, repeating it in the PR description for reviewer visibility, per the [ASF generative tooling guidance](https://www.apache.org/legal/generative-tooling.html).
+Use concise subjects with bracketed components, matching existing history, such as `[python] Admit bytes in memory values` or `[api][java] Add event constants`. For nontrivial behavior changes, open or link a GitHub issue before the PR. PR titles should include relevant components like `[api]`, `[runtime]`, `[java]`, `[python]`, or `[hotfix]`; describe the change, test evidence, and any compatibility impact. Answer the PR template's generative-AI question, and when such tooling was used, include a `Generated-by: <tool name and version> (<model name and version>)` line, for example `Generated-by: Claude Code 2.1.226 (Claude Opus 4.6)`, in the commit message so it reaches Git history. Repeat the same line in the PR description for reviewer visibility, per the [ASF generative tooling guidance](https://www.apache.org/legal/generative-tooling.html).
 
 ## Code Review
 


### PR DESCRIPTION
Linked issue: N/A

### Purpose of change

Include the coding model name and version in the `Generated-by` provenance line, in addition to the coding agent name and version.

This keeps the repository guidance and pull request template aligned and makes AI-assisted change provenance more precise when the same coding agent can use different models.

### Tests

- `git diff --check`
- No runtime tests were run because this patch only updates repository guidance and the pull request template.
- `./tools/check-license.sh` was attempted but was blocked by the existing ignored `.codex/config.toml`, which does not have an Apache license header and is unrelated to this patch.

### API

No public APIs are changed.

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-included` <!-- Your PR already contains the necessary documentation updates -->

### Was this patch authored or co-authored using generative AI tooling?

<!-- Do not remove this section. Check the proper box only. -->

- [x] Yes
- [ ] No

Generated-by: Codex 0.144.5 (GPT-5)
