### PR TITLE
[infra] Update main version to 0.4-SNAPSHOT

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-api</artifactId>

--- a/dist/common/pom.xml
+++ b/dist/common/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-dist</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-dist-common</artifactId>

--- a/dist/flink-1.20/pom.xml
+++ b/dist/flink-1.20/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-dist</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-dist-flink-1.20</artifactId>

--- a/dist/flink-2.0/pom.xml
+++ b/dist/flink-2.0/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-dist</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-dist-flink-2.0</artifactId>

--- a/dist/flink-2.1/pom.xml
+++ b/dist/flink-2.1/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-dist</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-dist-flink-2.1</artifactId>

--- a/dist/flink-2.2/pom.xml
+++ b/dist/flink-2.2/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-dist</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-dist-flink-2.2</artifactId>

--- a/dist/flink-2.3/pom.xml
+++ b/dist/flink-2.3/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-dist</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-dist-flink-2.3</artifactId>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-dist</artifactId>

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -34,11 +34,11 @@ pygmentsUseClasses = true
   # we change the version for the complete docs when forking of a release branch
   # etc.
   # The full version string as referenced in Maven (e.g. 1.2.1)
-  Version = "0.3-SNAPSHOT"
+  Version = "0.4-SNAPSHOT"
 
   # For stable releases, leave the bugfix version out (e.g. 1.2). For snapshot
   # release this should be the same as the regular version
-  VersionTitle = "0.3-SNAPSHOT"
+  VersionTitle = "0.4-SNAPSHOT"
 
   # The branch for this version of Apache Flink Agents
   Branch = "main"

--- a/docs/content/docs/get-started/installation.md
+++ b/docs/content/docs/get-started/installation.md
@@ -245,7 +245,7 @@ After building from source, copy the self-contained distribution JAR
 (without the `-thin` suffix) to Flink's `lib` directory:
 
 ```shell
-# Set the Flink Agents version (from the version you built, e.g. 0.3-SNAPSHOT)
+# Set the Flink Agents version (from the version you built, e.g. 0.4-SNAPSHOT)
 export FLINK_AGENTS_VERSION=<version>
 
 cp dist/flink-${FLINK_VERSION%.*}/target/flink-agents-dist-flink-${FLINK_VERSION%.*}-${FLINK_AGENTS_VERSION}.jar $FLINK_HOME/lib/

--- a/e2e-test/flink-agents-end-to-end-tests-agent-plan-compatibility/pom.xml
+++ b/e2e-test/flink-agents-end-to-end-tests-agent-plan-compatibility/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-e2e-tests</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-end-to-end-tests-agent-plan-compatibility</artifactId>

--- a/e2e-test/flink-agents-end-to-end-tests-integration/pom.xml
+++ b/e2e-test/flink-agents-end-to-end-tests-integration/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-e2e-tests</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-end-to-end-tests-integration</artifactId>

--- a/e2e-test/flink-agents-end-to-end-tests-resource-cross-language/pom.xml
+++ b/e2e-test/flink-agents-end-to-end-tests-resource-cross-language/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-e2e-tests</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-end-to-end-tests-resource-cross-language</artifactId>

--- a/e2e-test/pom.xml
+++ b/e2e-test/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-e2e-tests</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-examples</artifactId>

--- a/ide-support/pom.xml
+++ b/ide-support/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-ide-support</artifactId>

--- a/integrations/chat-models/anthropic/pom.xml
+++ b/integrations/chat-models/anthropic/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-integrations-chat-models</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integrations/chat-models/azureai/pom.xml
+++ b/integrations/chat-models/azureai/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-integrations-chat-models</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integrations/chat-models/bedrock/pom.xml
+++ b/integrations/chat-models/bedrock/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-integrations-chat-models</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integrations/chat-models/gemini/pom.xml
+++ b/integrations/chat-models/gemini/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-integrations-chat-models</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integrations/chat-models/ollama/pom.xml
+++ b/integrations/chat-models/ollama/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-integrations-chat-models</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integrations/chat-models/openai/pom.xml
+++ b/integrations/chat-models/openai/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-integrations-chat-models</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integrations/chat-models/pom.xml
+++ b/integrations/chat-models/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-integrations</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-integrations-chat-models</artifactId>

--- a/integrations/embedding-models/bedrock/pom.xml
+++ b/integrations/embedding-models/bedrock/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-integrations-embedding-models</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integrations/embedding-models/ollama/pom.xml
+++ b/integrations/embedding-models/ollama/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-integrations-embedding-models</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integrations/embedding-models/pom.xml
+++ b/integrations/embedding-models/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-integrations</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-integrations-embedding-models</artifactId>

--- a/integrations/mcp/pom.xml
+++ b/integrations/mcp/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-integrations</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-integrations</artifactId>

--- a/integrations/vector-stores/elasticsearch/pom.xml
+++ b/integrations/vector-stores/elasticsearch/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-integrations-vector-stores</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integrations/vector-stores/milvus/pom.xml
+++ b/integrations/vector-stores/milvus/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-integrations-vector-stores</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integrations/vector-stores/opensearch/pom.xml
+++ b/integrations/vector-stores/opensearch/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-integrations-vector-stores</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integrations/vector-stores/pom.xml
+++ b/integrations/vector-stores/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-integrations</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-integrations-vector-stores</artifactId>

--- a/integrations/vector-stores/s3vectors/pom.xml
+++ b/integrations/vector-stores/s3vectors/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents-integrations-vector-stores</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plan/pom.xml
+++ b/plan/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-plan</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@ under the License.
     <name>Flink Agents : </name>
     <!-- TODO: build website and update url -->
     <url>https://flink.apache.org</url>
-    <version>0.3-SNAPSHOT</version>
+    <version>0.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/python_agent_with_java_action_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/python_agent_with_java_action_test.py
@@ -42,7 +42,7 @@ _TEST_JAR = (
     / "e2e-test"
     / "flink-agents-end-to-end-tests-resource-cross-language"
     / "target"
-    / "flink-agents-end-to-end-tests-resource-cross-language-0.3-SNAPSHOT-tests.jar"
+    / "flink-agents-end-to-end-tests-resource-cross-language-0.4-SNAPSHOT-tests.jar"
 )
 
 os.environ["PYTHONPATH"] = sysconfig.get_paths()["purelib"]

--- a/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/yaml_actions_in_java_cross_language_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/yaml_actions_in_java_cross_language_test.py
@@ -57,7 +57,7 @@ _TEST_JAR = (
     / "e2e-test"
     / "flink-agents-end-to-end-tests-resource-cross-language"
     / "target"
-    / "flink-agents-end-to-end-tests-resource-cross-language-0.3-SNAPSHOT-tests.jar"
+    / "flink-agents-end-to-end-tests-resource-cross-language-0.4-SNAPSHOT-tests.jar"
 )
 
 os.environ["PYTHONPATH"] = sysconfig.get_paths()["purelib"]

--- a/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/yaml_cross_language_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/yaml_cross_language_test.py
@@ -67,7 +67,7 @@ _TEST_JAR = (
     / "e2e-test"
     / "flink-agents-end-to-end-tests-resource-cross-language"
     / "target"
-    / "flink-agents-end-to-end-tests-resource-cross-language-0.3-SNAPSHOT-tests.jar"
+    / "flink-agents-end-to-end-tests-resource-cross-language-0.4-SNAPSHOT-tests.jar"
 )
 
 os.environ["PYTHONPATH"] = sysconfig.get_paths()["purelib"]

--- a/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/yaml_java_action_cross_language_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_resource_cross_language/yaml_java_action_cross_language_test.py
@@ -48,7 +48,7 @@ _TEST_JAR = (
     / "e2e-test"
     / "flink-agents-end-to-end-tests-resource-cross-language"
     / "target"
-    / "flink-agents-end-to-end-tests-resource-cross-language-0.3-SNAPSHOT-tests.jar"
+    / "flink-agents-end-to-end-tests-resource-cross-language-0.4-SNAPSHOT-tests.jar"
 )
 
 os.environ["PYTHONPATH"] = sysconfig.get_paths()["purelib"]

--- a/python/jar_manifest.json
+++ b/python/jar_manifest.json
@@ -1,7 +1,7 @@
 {
   "maven_base_url": "https://repo1.maven.org/maven2",
   "group_id": "org.apache.flink",
-  "version": "0.3-SNAPSHOT",
+  "version": "0.4-SNAPSHOT",
   "jars": [
     {
       "artifact_id": "flink-agents-dist-common",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -25,7 +25,7 @@ backend-path = ["_build_backend"]
 
 [project]
 name = "flink-agents"
-version = "0.3.dev0"
+version = "0.4.dev0"
 
 description = "Flink Agents Python API"
 license-files = ["LICENSE"]

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-agents</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-agents-runtime</artifactId>


### PR DESCRIPTION
Linked issue: N/A

### Purpose of change

The `release-0.3` branch was created for the 0.3 release, but the release
process step that updates `main` to the next development version was missed.

This change updates the project development version to 0.4:

- Maven modules use `0.4-SNAPSHOT`.
- The Python package uses `0.4.dev0`.
- Documentation metadata and `python/jar_manifest.json` use `0.4-SNAPSHOT`.
- Cross-language tests reference the new `0.4-SNAPSHOT` test JAR name.

The released version defaults in `tools/install.sh` remain unchanged.

### Tests

- `./tools/build.sh --java` (all 34 Maven modules built successfully; tests are
  skipped by the build script)
- `git diff --check`
- Verified that no `0.3-SNAPSHOT` or `0.3.dev0` development-version references
  remain

### API

No public API changes.

### Documentation

- [ ] `doc-needed`
- [ ] `doc-not-needed`
- [x] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [ ] Yes
- [x] No
