### PR TITLE
[hotfix] Add help handling to build script

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -17,6 +17,19 @@
 
 set -e
 
+show_help() {
+    cat <<EOF
+Build Flink Agents Java and Python artifacts
+
+Usage: $0 [options]
+
+Options:
+  -j, --java        Build only Java artifacts
+  -p, --python      Build only Python artifacts
+  -h, --help        Display this help message
+EOF
+}
+
 # Parse command-line arguments
 build_java=true
 build_python=true
@@ -27,6 +40,10 @@ while [[ "$#" -gt 0 ]]; do
             ;;
         -j|--java)
             build_python=false
+            ;;
+        -h|--help)
+            show_help
+            exit 0
             ;;
         *)
             echo "Error: Unknown option '$1'" >&2

--- a/tools/test/integration/build_help.bats
+++ b/tools/test/integration/build_help.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+BUILD_SCRIPT="${BATS_TEST_DIRNAME}/../../build.sh"
+
+@test "build --help prints usage and exits 0" {
+    run bash "$BUILD_SCRIPT" --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Build Flink Agents Java and Python artifacts"* ]]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"--java"* ]]
+    [[ "$output" == *"--python"* ]]
+}
+
+@test "build -h prints usage and exits 0" {
+    run bash "$BUILD_SCRIPT" -h
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "build rejects an unknown option with usage" {
+    run bash "$BUILD_SCRIPT" --no-such-option
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Error: Unknown option '--no-such-option'"* ]]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" != *"show_help: command not found"* ]]
+}

--- a/tools/test/integration/build_help.bats
+++ b/tools/test/integration/build_help.bats
@@ -40,7 +40,7 @@ BUILD_SCRIPT="${BATS_TEST_DIRNAME}/../../build.sh"
 @test "build rejects an unknown option with usage" {
     run bash "$BUILD_SCRIPT" --no-such-option
 
-    [ "$status" -ne 0 ]
+    [ "$status" -eq 1 ]
     [[ "$output" == *"Error: Unknown option '--no-such-option'"* ]]
     [[ "$output" == *"Usage:"* ]]
     [[ "$output" != *"show_help: command not found"* ]]


### PR DESCRIPTION
Linked issue: N/A (hotfix)

### Purpose of change

Add `-h`/`--help` handling to `tools/build.sh` and show usage for unknown options instead of failing because `show_help` is undefined.

### Tests

- Added `tools/test/integration/build_help.bats` covering `--help`, `-h`, and unknown options.
- Manually verified `bash tools/build.sh --help`, `bash tools/build.sh -h`, and `bash tools/build.sh --no-such-option` (Bats is not installed locally).

### API

No public API changes.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`

