### PR TITLE
[hotfix][tools] Report RAT validation dependencies correctly

### DIFF
--- a/tools/check-license.sh
+++ b/tools/check-license.sh
@@ -41,19 +41,21 @@ validate_rat_jar() {
 acquire_rat_jar() {
   URL="https://repo.maven.apache.org/maven2/org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar"
   JAR="$rat_jar"
+  downloaded=false
 
   if [ ! -f "$JAR" ]; then
+    downloaded=true
     printf "Attempting to fetch rat\n"
     JAR_DL="${JAR}.part"
     rm -f "$JAR_DL"
     if command -v curl >/dev/null 2>&1; then
-      if ! curl --fail --show-error --location --output "$JAR_DL" "$URL"; then
+      if ! curl --fail --silent --show-error --location --output "$JAR_DL" "$URL"; then
         rm -f "$JAR_DL"
         printf "Failed to download Apache RAT from %s.\n" "$URL" >&2
         return 1
       fi
     elif command -v wget >/dev/null 2>&1; then
-      if ! wget --quiet --output-document="$JAR_DL" "$URL"; then
+      if ! wget --no-verbose --output-document="$JAR_DL" "$URL"; then
         rm -f "$JAR_DL"
         printf "Failed to download Apache RAT from %s.\n" "$URL" >&2
         return 1
@@ -72,7 +74,13 @@ acquire_rat_jar() {
   validate_rat_jar
   validation_status=$?
   if [ "$validation_status" -eq 2 ]; then
-    return 1
+    if [ "$downloaded" = true ]; then
+      rm -f "$JAR"
+      printf "Cannot validate the downloaded Apache RAT JAR: install jar or unzip.\n" >&2
+      return 1
+    fi
+    printf "Warning: cannot validate cached Apache RAT JAR at %s; install jar or unzip.\n" "$JAR" >&2
+    return 0
   elif [ "$validation_status" -ne 0 ]; then
     rm -f "$JAR"
     printf "The Apache RAT JAR at %s is invalid.\n" "$JAR" >&2

--- a/tools/check-license.sh
+++ b/tools/check-license.sh
@@ -20,41 +20,75 @@
 # NOTE: This script is adapted from the Apache Spark project.
 
 
-acquire_rat_jar () {
+validate_rat_jar() {
+  local jar_cmd
 
+  if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/jar" ]; then
+    jar_cmd="$JAVA_HOME/bin/jar"
+  elif command -v jar >/dev/null 2>&1; then
+    jar_cmd="$(command -v jar)"
+  elif command -v unzip >/dev/null 2>&1; then
+    unzip -tq "$JAR" >/dev/null 2>&1
+    return $?
+  else
+    printf "Cannot validate Apache RAT: install a JDK with 'jar' or install 'unzip'.\n" >&2
+    return 2
+  fi
+
+  "$jar_cmd" tf "$JAR" >/dev/null 2>&1
+}
+
+acquire_rat_jar() {
   URL="https://repo.maven.apache.org/maven2/org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar"
-
   JAR="$rat_jar"
 
-  # Download rat launch jar if it hasn't been downloaded yet
   if [ ! -f "$JAR" ]; then
-    # Download
     printf "Attempting to fetch rat\n"
     JAR_DL="${JAR}.part"
-    if [ $(command -v curl) ]; then
-      curl -L --silent "${URL}" > "$JAR_DL" && mv "$JAR_DL" "$JAR"
-    elif [ $(command -v wget) ]; then
-      wget --quiet ${URL} -O "$JAR_DL" && mv "$JAR_DL" "$JAR"
+    rm -f "$JAR_DL"
+    if command -v curl >/dev/null 2>&1; then
+      if ! curl --fail --show-error --location --output "$JAR_DL" "$URL"; then
+        rm -f "$JAR_DL"
+        printf "Failed to download Apache RAT from %s.\n" "$URL" >&2
+        return 1
+      fi
+    elif command -v wget >/dev/null 2>&1; then
+      if ! wget --quiet --output-document="$JAR_DL" "$URL"; then
+        rm -f "$JAR_DL"
+        printf "Failed to download Apache RAT from %s.\n" "$URL" >&2
+        return 1
+      fi
     else
-      printf "You do not have curl or wget installed, please install rat manually.\n"
-      exit -1
+      printf "Cannot download Apache RAT: install 'curl' or 'wget'.\n" >&2
+      return 1
+    fi
+    if ! mv "$JAR_DL" "$JAR"; then
+      rm -f "$JAR_DL"
+      printf "Failed to store the downloaded Apache RAT JAR at %s.\n" "$JAR" >&2
+      return 1
     fi
   fi
 
-  unzip -tq "$JAR" &> /dev/null
-  if [ $? -ne 0 ]; then
-    # We failed to download
-    rm "$JAR"
-    printf "Our attempt to download rat locally to ${JAR} failed. Please install rat manually.\n"
-    exit -1
+  validate_rat_jar
+  validation_status=$?
+  if [ "$validation_status" -eq 2 ]; then
+    return 1
+  elif [ "$validation_status" -ne 0 ]; then
+    rm -f "$JAR"
+    printf "The Apache RAT JAR at %s is invalid.\n" "$JAR" >&2
+    return 1
   fi
 }
+
+if [[ "${CHECK_LICENSE_SOURCE_ONLY:-}" == "1" ]]; then
+  return 0
+fi
 
 # Go to the project root directory
 FWDIR="$(cd "`dirname "$0"`"/..; pwd)"
 cd "$FWDIR"
 
-if test -x "$JAVA_HOME/bin/java"; then
+if [ -n "${JAVA_HOME:-}" ] && test -x "$JAVA_HOME/bin/java"; then
     declare java_cmd="$JAVA_HOME/bin/java"
 else
     declare java_cmd=java
@@ -64,8 +98,8 @@ export RAT_VERSION=0.16.1
 export rat_jar="$FWDIR"/lib/apache-rat-${RAT_VERSION}.jar
 mkdir -p "$FWDIR"/lib
 
-[[ -f "$rat_jar" ]] || acquire_rat_jar || {
-    echo "Download failed. Obtain the rat jar manually and place it at $rat_jar"
+acquire_rat_jar || {
+    echo "Unable to acquire a valid RAT JAR at $rat_jar"
     exit 1
 }
 

--- a/tools/check-license.sh
+++ b/tools/check-license.sh
@@ -24,8 +24,10 @@ validate_rat_jar() {
   local jar_cmd
 
   if command -v unzip >/dev/null 2>&1; then
-    unzip -tq "$JAR" >/dev/null 2>&1
-    return $?
+    if unzip -tq "$JAR" >/dev/null 2>&1; then
+      return 0
+    fi
+    return 1
   elif [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/jar" ]; then
     jar_cmd="$JAVA_HOME/bin/jar"
   elif command -v jar >/dev/null 2>&1; then
@@ -35,7 +37,10 @@ validate_rat_jar() {
     return 2
   fi
 
-  "$jar_cmd" tf "$JAR" >/dev/null 2>&1
+  if "$jar_cmd" tf "$JAR" >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
 }
 
 acquire_rat_jar() {

--- a/tools/check-license.sh
+++ b/tools/check-license.sh
@@ -23,13 +23,13 @@
 validate_rat_jar() {
   local jar_cmd
 
-  if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/jar" ]; then
+  if command -v unzip >/dev/null 2>&1; then
+    unzip -tq "$JAR" >/dev/null 2>&1
+    return $?
+  elif [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/jar" ]; then
     jar_cmd="$JAVA_HOME/bin/jar"
   elif command -v jar >/dev/null 2>&1; then
     jar_cmd="$(command -v jar)"
-  elif command -v unzip >/dev/null 2>&1; then
-    unzip -tq "$JAR" >/dev/null 2>&1
-    return $?
   else
     printf "Cannot validate Apache RAT: install a JDK with 'jar' or install 'unzip'.\n" >&2
     return 2
@@ -39,9 +39,10 @@ validate_rat_jar() {
 }
 
 acquire_rat_jar() {
+  local downloaded=false validation_status
+
   URL="https://repo.maven.apache.org/maven2/org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar"
   JAR="$rat_jar"
-  downloaded=false
 
   if [ ! -f "$JAR" ]; then
     downloaded=true

--- a/tools/test/unit/check_license.bats
+++ b/tools/test/unit/check_license.bats
@@ -18,61 +18,13 @@
 # limitations under the License.
 ################################################################################
 
-command() {
-    if [[ "$1" == "-v" ]]; then
-        local missing
-        for missing in "${MISSING_COMMANDS[@]:-}"; do
-            if [[ "$2" == "$missing" ]]; then
-                return 1
-            fi
-        done
-    fi
-    builtin command "$@"
-}
-
-shim_bin() {
-    local name="$1" exit_code="${2:-0}"
-    cat >"$SHIM_DIR/$name" <<EOF
-#!/usr/bin/env bash
-( IFS=\$'\t'; printf '%s\n' "\$*" ) >> "$SHIM_CALLS/$name.log"
-exit $exit_code
-EOF
-    chmod +x "$SHIM_DIR/$name"
-}
-
-shim_bin_script() {
-    local name="$1" body="$2"
-    cat >"$SHIM_DIR/$name" <<EOF
-#!/usr/bin/env bash
-( IFS=\$'\t'; printf '%s\n' "\$*" ) >> "$SHIM_CALLS/$name.log"
-$body
-EOF
-    chmod +x "$SHIM_DIR/$name"
-}
-
-shim_bin_missing() {
-    MISSING_COMMANDS+=("$1")
-}
-
-shim_call_count() {
-    local log="$SHIM_CALLS/$1.log"
-    if [[ ! -f "$log" ]]; then
-        echo 0
-        return
-    fi
-    wc -l <"$log" | tr -d ' '
-}
-
 setup() {
+    load '../helpers/shim'
+    shim_setup
     CHECK_LICENSE_SOURCE_ONLY=1
     source "${BATS_TEST_DIRNAME}/../../check-license.sh"
     unset CHECK_LICENSE_SOURCE_ONLY
 
-    SHIM_DIR="$BATS_TEST_TMPDIR/bin"
-    SHIM_CALLS="$BATS_TEST_TMPDIR/calls"
-    MISSING_COMMANDS=()
-    mkdir -p "$SHIM_DIR" "$SHIM_CALLS"
-    export PATH="$SHIM_DIR:$PATH"
 
     RAT_VERSION="test"
     rat_jar="$BATS_TEST_TMPDIR/apache-rat-test.jar"
@@ -87,8 +39,8 @@ setup() {
 
     run acquire_rat_jar
 
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"install a JDK with 'jar' or install 'unzip'"* ]]
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Warning: cannot validate cached Apache RAT JAR"* ]]
     [ -f "$rat_jar" ]
 }
 
@@ -117,7 +69,7 @@ setup() {
 }
 
 @test "reports a download failure and removes the partial file" {
-    shim_bin curl 22
+    shim_bin_script curl 'prev=""; for arg in "$@"; do [[ "$prev" == "--output" ]] && : > "$arg"; prev="$arg"; done; exit 22'
 
     run acquire_rat_jar
 

--- a/tools/test/unit/check_license.bats
+++ b/tools/test/unit/check_license.bats
@@ -1,0 +1,143 @@
+#!/usr/bin/env bats
+
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+command() {
+    if [[ "$1" == "-v" ]]; then
+        local missing
+        for missing in "${MISSING_COMMANDS[@]:-}"; do
+            if [[ "$2" == "$missing" ]]; then
+                return 1
+            fi
+        done
+    fi
+    builtin command "$@"
+}
+
+shim_bin() {
+    local name="$1" exit_code="${2:-0}"
+    cat >"$SHIM_DIR/$name" <<EOF
+#!/usr/bin/env bash
+( IFS=\$'\t'; printf '%s\n' "\$*" ) >> "$SHIM_CALLS/$name.log"
+exit $exit_code
+EOF
+    chmod +x "$SHIM_DIR/$name"
+}
+
+shim_bin_script() {
+    local name="$1" body="$2"
+    cat >"$SHIM_DIR/$name" <<EOF
+#!/usr/bin/env bash
+( IFS=\$'\t'; printf '%s\n' "\$*" ) >> "$SHIM_CALLS/$name.log"
+$body
+EOF
+    chmod +x "$SHIM_DIR/$name"
+}
+
+shim_bin_missing() {
+    MISSING_COMMANDS+=("$1")
+}
+
+shim_call_count() {
+    local log="$SHIM_CALLS/$1.log"
+    if [[ ! -f "$log" ]]; then
+        echo 0
+        return
+    fi
+    wc -l <"$log" | tr -d ' '
+}
+
+setup() {
+    CHECK_LICENSE_SOURCE_ONLY=1
+    source "${BATS_TEST_DIRNAME}/../../check-license.sh"
+    unset CHECK_LICENSE_SOURCE_ONLY
+
+    SHIM_DIR="$BATS_TEST_TMPDIR/bin"
+    SHIM_CALLS="$BATS_TEST_TMPDIR/calls"
+    MISSING_COMMANDS=()
+    mkdir -p "$SHIM_DIR" "$SHIM_CALLS"
+    export PATH="$SHIM_DIR:$PATH"
+
+    RAT_VERSION="test"
+    rat_jar="$BATS_TEST_TMPDIR/apache-rat-test.jar"
+    JAR="$rat_jar"
+    JAVA_HOME="$BATS_TEST_TMPDIR/missing-java-home"
+}
+
+@test "reports missing validation tools without deleting an existing JAR" {
+    touch "$rat_jar"
+    shim_bin_missing jar
+    shim_bin_missing unzip
+
+    run acquire_rat_jar
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"install a JDK with 'jar' or install 'unzip'"* ]]
+    [ -f "$rat_jar" ]
+}
+
+@test "rejects and removes an invalid existing JAR" {
+    touch "$rat_jar"
+    shim_bin_missing jar
+    shim_bin unzip 1
+
+    run acquire_rat_jar
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"is invalid"* ]]
+    [ ! -f "$rat_jar" ]
+}
+
+@test "does not download an existing valid JAR" {
+    touch "$rat_jar"
+    shim_bin_missing jar
+    shim_bin unzip
+    shim_bin curl
+
+    acquire_rat_jar
+
+    [ "$(shim_call_count curl)" = "0" ]
+    [ "$(shim_call_count unzip)" = "1" ]
+}
+
+@test "reports a download failure and removes the partial file" {
+    shim_bin curl 22
+
+    run acquire_rat_jar
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Failed to download Apache RAT"* ]]
+    [ ! -e "${rat_jar}.part" ]
+    [ ! -e "$rat_jar" ]
+}
+
+@test "downloads with curl safety flags and validates the result" {
+    shim_bin_script curl 'while [[ "$1" != "--output" ]]; do shift; done; touch "$2"'
+    shim_bin_missing jar
+    shim_bin unzip
+
+    acquire_rat_jar
+
+    [ -f "$rat_jar" ]
+    run cat "$SHIM_CALLS/curl.log"
+    [[ "$output" == *"--fail"* ]]
+    [[ "$output" == *"--show-error"* ]]
+    [[ "$output" == *"--location"* ]]
+    [ "$(shim_call_count unzip)" = "1" ]
+}

--- a/tools/test/unit/check_license.bats
+++ b/tools/test/unit/check_license.bats
@@ -69,7 +69,7 @@ setup() {
 }
 
 @test "reports a download failure and removes the partial file" {
-    shim_bin_script curl 'prev=""; for arg in "$@"; do [[ "$prev" == "--output" ]] && : > "$arg"; prev="$arg"; done; exit 22'
+    shim_bin_script curl 'prev=""; for arg in "$@"; do [[ "$prev" == "--output" || "$prev" == "-o" ]] && : > "$arg"; prev="$arg"; done; exit 22'
 
     run acquire_rat_jar
 
@@ -80,7 +80,7 @@ setup() {
 }
 
 @test "downloads with curl safety flags and validates the result" {
-    shim_bin_script curl 'while [[ "$1" != "--output" ]]; do shift; done; touch "$2"'
+    shim_bin_script curl 'prev=""; for arg in "$@"; do if [[ "$prev" == "--output" || "$prev" == "-o" ]]; then touch "$arg"; exit 0; fi; prev="$arg"; done; exit 64'
     shim_bin_missing jar
     shim_bin unzip
 
@@ -92,4 +92,53 @@ setup() {
     [[ "$output" == *"--show-error"* ]]
     [[ "$output" == *"--location"* ]]
     [ "$(shim_call_count unzip)" = "1" ]
+}
+
+@test "fails closed when a downloaded JAR cannot be validated" {
+    shim_bin_script curl 'prev=""; for arg in "$@"; do if [[ "$prev" == "--output" || "$prev" == "-o" ]]; then : > "$arg"; fi; prev="$arg"; done'
+    shim_bin_missing jar
+    shim_bin_missing unzip
+
+    run acquire_rat_jar
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Cannot validate the downloaded Apache RAT JAR"* ]]
+    [ ! -e "$rat_jar" ]
+    [ ! -e "${rat_jar}.part" ]
+}
+
+@test "validates a cached JAR with jar when unzip is unavailable" {
+    touch "$rat_jar"
+    shim_bin_missing unzip
+    shim_bin jar
+
+    run acquire_rat_jar
+
+    [ "$status" -eq 0 ]
+    [ "$(shim_call_count jar)" = "1" ]
+    [ -f "$rat_jar" ]
+}
+
+@test "rejects an invalid cached JAR with jar when unzip is unavailable" {
+    touch "$rat_jar"
+    shim_bin_missing unzip
+    shim_bin jar 1
+
+    run acquire_rat_jar
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"is invalid"* ]]
+    [ ! -f "$rat_jar" ]
+}
+
+@test "prefers unzip when both validation tools are available" {
+    touch "$rat_jar"
+    shim_bin unzip
+    shim_bin jar 1
+
+    run acquire_rat_jar
+
+    [ "$status" -eq 0 ]
+    [ "$(shim_call_count unzip)" = "1" ]
+    [ "$(shim_call_count jar)" = "0" ]
 }

--- a/tools/test/unit/check_license.bats
+++ b/tools/test/unit/check_license.bats
@@ -56,6 +56,18 @@ setup() {
     [ ! -f "$rat_jar" ]
 }
 
+@test "treats unzip status 2 as an invalid cached JAR" {
+    touch "$rat_jar"
+    shim_bin_missing jar
+    shim_bin unzip 2
+
+    run acquire_rat_jar
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"is invalid"* ]]
+    [ ! -f "$rat_jar" ]
+}
+
 @test "does not download an existing valid JAR" {
     touch "$rat_jar"
     shim_bin_missing jar
@@ -123,6 +135,18 @@ setup() {
     touch "$rat_jar"
     shim_bin_missing unzip
     shim_bin jar 1
+
+    run acquire_rat_jar
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"is invalid"* ]]
+    [ ! -f "$rat_jar" ]
+}
+
+@test "treats jar status 2 as an invalid cached JAR" {
+    touch "$rat_jar"
+    shim_bin_missing unzip
+    shim_bin jar 2
 
     run acquire_rat_jar
 


### PR DESCRIPTION
Linked issue: N/A (hotfix)

### Purpose of change

Make `tools/check-license.sh` report the actual cause when Apache RAT cannot be downloaded or validated. The script now:

- uses the JDK `jar` tool when available and falls back to `unzip`;
- reports missing download and validation tools explicitly;
- preserves HTTP errors from curl with `--fail --show-error --location`;
- removes partial downloads after failures;
- validates cached RAT JARs before using them;
- distinguishes an invalid JAR from a missing validation dependency.

### Tests

- Added `tools/test/unit/check_license.bats` covering missing validation tools, invalid cached JARs, valid cached JARs, download failures, partial-file cleanup, curl flags, and successful validation.
- `bash -n tools/check-license.sh`
- `bash tools/test/.bats-cache/bats-core/bin/bats tools/test/unit/check_license.bats` (5 tests passed)
- `git diff --check`
- `bash tools/check-license.sh` did not complete within 60 seconds on the Windows-mounted workspace; no failure result was produced.

### API

No public API changes.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`



