### PR TITLE
[ci] Name the tools script test job after the command it runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
         if: github.ref == 'refs/heads/main' || github.base_ref == 'main'
         run: python3 tools/check-skill-schema.py
 
-  install_sh_tests:
-    name: install.sh tests (${{ matrix.os }})
+  tools_script_tests:
+    name: tools script tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -65,7 +65,7 @@ jobs:
       - name: Install bash 4+ (macOS)
         if: runner.os == 'macOS'
         run: brew install bash
-      - name: Run install.sh tests
+      - name: Run tools script tests
         run: bash tools/test/run.sh
 
   build_backend_tests:


### PR DESCRIPTION
Linked issue: N/A (hotfix, no behavior change)

### Purpose of change

The `install.sh tests` job runs one command, `bash tools/test/run.sh`, and that script discovers suites with `bats --recursive tools/test/unit tools/test/integration`. It runs whatever lives in those two directories rather than a fixed list, so the job name describes what those directories happen to contain today rather than what the job actually runs, and nothing keeps the two in sync.

Three open PRs each add a suite for a different script (#992 for `test_checkpoint_recovery.sh`, #995 for `build.sh`, #996 for `check-license.sh`), so the current name becomes visibly wrong as soon as any one of them lands. A failure in one of those suites would surface as a red check labelled `install.sh tests`, pointing a reader at the wrong script.

This renames the job id, its display name, and the step name to match the command the job runs.

### Tests

No new tests. This is a rename of three strings in one workflow file.

Verified no behavior change:

- The `run:` command is untouched, so the same suites run in the same way.
- No job in `ci.yml` declares `needs` on this job, and no other workflow references the `install_sh_tests` id.
- The repository ruleset ("Default Branch Protection") declares only `deletion` and `non_fast_forward` rules and no required status checks, so no configuration references the old check name.
- The workflow still parses and the job count is unchanged at 8.
- CI on this PR exercises the renamed job on both `ubuntu-latest` and `macos-latest`.

### API

No public API changes.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

Generated-by: Claude Code 2.1.228 (Claude Opus 5)
