### PR TITLE
[integrations][vector-store][java] Apply Elasticsearch KNN filters before selecting neighbors

### DIFF
--- a/docs/content/docs/development/vector_stores.md
+++ b/docs/content/docs/development/vector_stores.md
@@ -800,7 +800,7 @@ Elasticsearch is currently supported in the Java API only. To use Elasticsearch 
 | `dims`            | int  | `768`                     | Vector dimensionality                                              |
 | `k`               | int  | None                      | Number of nearest neighbors to return; can be overridden per query |
 | `num_candidates`  | int  | None                      | Candidate set size for ANN search; can be overridden per query     |
-| `filter_query`    | str  | None                      | Raw JSON Elasticsearch filter query (DSL) applied as a post-filter |
+| `filter_query`    | str  | None                      | Raw JSON Elasticsearch filter query (DSL) restricting which documents a KNN query can match |
 | `host`            | str  | `"http://localhost:9200"` | Elasticsearch endpoint                                             |
 | `hosts`           | str  | None                      | Comma-separated list of Elasticsearch endpoints                    |
 | `username`        | str  | None                      | Username for basic authentication                                  |

--- a/integrations/vector-stores/elasticsearch/src/main/java/org/apache/flink/agents/integrations/vectorstores/elasticsearch/ElasticsearchVectorStore.java
+++ b/integrations/vector-stores/elasticsearch/src/main/java/org/apache/flink/agents/integrations/vectorstores/elasticsearch/ElasticsearchVectorStore.java
@@ -82,8 +82,8 @@ import java.util.*;
  *   <li>{@code k} (optional): Number of nearest neighbors to return; can be overridden per query.
  *   <li>{@code num_candidates} (optional): Candidate set size for ANN search; can be overridden per
  *       query.
- *   <li>{@code filter_query} (optional): A raw JSON Elasticsearch filter query (DSL) that is
- *       applied as a post-filter; can be overridden per query.
+ *   <li>{@code filter_query} (optional): A raw JSON Elasticsearch filter query (DSL) restricting
+ *       which documents a KNN query can match; can be overridden per query.
  *   <li>{@code host} or {@code hosts} (optional): Elasticsearch endpoint(s). If omitted, defaults
  *       to {@code localhost:9200}.
  *   <li>Authentication (optional): Either basic auth via {@code username}/{@code password}, or API
@@ -572,7 +572,9 @@ public class ElasticsearchVectorStore extends BaseVectorStore
      *
      * <p>The method prepares a KNN search request using the supplied {@code embedding} and merges
      * default arguments from the store with the provided {@code args}. Optional filter queries
-     * (JSON DSL) are applied as a post filter.
+     * (JSON DSL) restrict the documents the KNN search may match, so the nearest neighbours are
+     * selected from among the matching documents rather than filtered out afterwards. Up to {@code
+     * k} matching documents are returned even when the closest vectors overall do not match.
      *
      * @param embedding The embedding vector to search with
      * @param limit Maximum number of items the caller is interested in; used as a fallback for
@@ -603,20 +605,32 @@ public class ElasticsearchVectorStore extends BaseVectorStore
             List<Float> queryVector = new ArrayList<>(embedding.length);
             for (float v : embedding) queryVector.add(v);
 
+            final String finalCombined = combined;
             SearchRequest.Builder builder =
                     new SearchRequest.Builder()
                             .index(index)
                             .knn(
-                                    kb ->
-                                            kb.field(this.vectorField)
-                                                    .queryVector(queryVector)
-                                                    .k(k)
-                                                    .numCandidates(numCandidates));
+                                    kb -> {
+                                        kb.field(this.vectorField)
+                                                .queryVector(queryVector)
+                                                .k(k)
+                                                .numCandidates(numCandidates);
+                                        // Filter inside the KNN clause rather than after it, so the
+                                        // k nearest neighbours are chosen from the documents that
+                                        // match. A post-filter can only discard hits the vector
+                                        // search already picked, which yields fewer than k results
+                                        // whenever the nearest vectors belong to filtered-out
+                                        // documents.
+                                        if (finalCombined != null) {
+                                            kb.filter(
+                                                    f ->
+                                                            f.withJson(
+                                                                    new StringReader(
+                                                                            finalCombined)));
+                                        }
+                                        return kb;
+                                    });
 
-            if (combined != null) {
-                final String finalCombined = combined;
-                builder = builder.postFilter(f -> f.withJson(new StringReader(finalCombined)));
-            }
             final SearchResponse<Map<String, Object>> searchResponse =
                     (SearchResponse) this.client.search(builder.build(), Map.class);
 

--- a/integrations/vector-stores/elasticsearch/src/test/java/org/apache/flink/agents/integrations/vectorstores/elasticsearch/ElasticsearchVectorStoreTest.java
+++ b/integrations/vector-stores/elasticsearch/src/test/java/org/apache/flink/agents/integrations/vectorstores/elasticsearch/ElasticsearchVectorStoreTest.java
@@ -192,6 +192,48 @@ public class ElasticsearchVectorStoreTest {
     }
 
     @Test
+    public void testQueryEmbeddingFiltersBeforeSelectingNeighbors() throws Exception {
+        // Contract: filters restrict the candidate set of the KNN search itself, so a matching
+        // document is returned even when it is not among the k nearest vectors overall. Applying
+        // the filter after the KNN phase instead would return nothing here, because the k nearest
+        // vectors all belong to the other user.
+        String name = "knn_prefilter";
+        ((CollectionManageableVectorStore) store).createCollectionIfNotExists(name, Map.of());
+
+        List<Document> docs = new ArrayList<>();
+        // Six documents pointing the same way as the query vector, none of them alice's.
+        for (int i = 0; i < 6; i++) {
+            Document bob =
+                    new Document("bob document " + i, Map.of("user_id", "bob"), "doc_bob_" + i);
+            bob.setEmbedding(new float[] {1.0f, 0.0f, 0.0f, 0.0f, 0.0f});
+            docs.add(bob);
+        }
+        // Three alice documents pointing orthogonally, so they never make the unfiltered top k.
+        for (int i = 0; i < 3; i++) {
+            Document alice =
+                    new Document(
+                            "alice document " + i, Map.of("user_id", "alice"), "doc_alice_" + i);
+            alice.setEmbedding(new float[] {0.0f, 0.0f, 0.0f, 0.0f, 1.0f});
+            docs.add(alice);
+        }
+        store.addEmbedding(docs, name, Collections.emptyMap());
+        Thread.sleep(1000);
+
+        List<Document> alice =
+                store.queryEmbedding(
+                        new float[] {1.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+                        5,
+                        name,
+                        Map.of("user_id", "alice"),
+                        Collections.emptyMap());
+
+        Assertions.assertEquals(3, alice.size());
+        Assertions.assertTrue(alice.stream().allMatch(d -> d.getId().startsWith("doc_alice_")));
+
+        ((CollectionManageableVectorStore) store).deleteCollection(name);
+    }
+
+    @Test
     public void testUpdateOverwritesExistingDocument() throws Exception {
         // ES bulk index is upsert by id — update should rewrite the doc in place.
         String name = "update_overwrite";


### PR DESCRIPTION
Linked issue: #999

### Purpose of change

`queryEmbedding` attached its filter with `post_filter`, which Elasticsearch applies after the KNN phase has already selected its `k` nearest hits. The filter could then only discard documents from that set, and never reach matching documents that fell outside the top `k`. A caller asking for five documents matching `user_id=alice` could get none back while hundreds were indexed, whenever the nearest vectors belonged to other users.

This moves the filter into the KNN clause, so the nearest neighbors are selected from among the documents that match. `get` and `delete` already build the same filter map into a real query clause, so this also removes the divergence between the three methods.

Both filter forms are affected, since the unified `filters` map and a raw `filter_query` are merged into a single query by `combineQueryJson` before it is attached.

### Tests

`ElasticsearchVectorStoreTest#testQueryEmbeddingFiltersBeforeSelectingNeighbors` indexes six documents pointing along the query vector and three orthogonal documents belonging to another user, then queries with `k` of 5 and a filter selecting the three. It fails with `expected: <3> but was: <0>` before the change and passes after, run against Elasticsearch 8.19.0.

The test uses `addEmbedding` with explicit vectors so the result depends only on where the filter is applied.

Note that `ElasticsearchVectorStoreTest` is annotated `@Disabled("Should setup Elasticsearch server.")`, so this test does not run in CI and needs a local Elasticsearch, as with the rest of the class.

### API

No signature changes. This does change observable behavior: callers passing a filter to `queryEmbedding` previously received at most the matching subset of the top `k`, and now receive up to `k` matching documents.

### Documentation

- [ ] `doc-needed`
- [ ] `doc-not-needed`
- [x] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

Generated-by: Claude Code 2.1.228 (Claude Opus 5)
