### PR TITLE
[runtime][api] Scope long-term memory operations to the action that obtained the memory set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,7 @@ jobs:
         run: bash tools/start_ollama_server.sh
       - name: Run Java IT
         env:
+          ACTION_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
           LOG_LEVEL: INFO
         run: tools/ut.sh -j -e -f ${{ matrix.flink-version }}
 
@@ -309,6 +310,7 @@ jobs:
           mvn -B --no-transfer-progress -pl integrations/vector-stores/milvus -am -Dspotless.skip=true -Drat.skip=true -Dtest=MilvusVectorStoreTest -Dsurefire.failIfNoSpecifiedTests=false test
       - name: Run e2e tests
         env:
+          ACTION_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
           LOG_LEVEL: INFO
         run: |
           export ES_HOST="http://localhost:9200"

--- a/api/src/main/java/org/apache/flink/agents/api/memory/BaseLongTermMemory.java
+++ b/api/src/main/java/org/apache/flink/agents/api/memory/BaseLongTermMemory.java
@@ -31,6 +31,11 @@ public interface BaseLongTermMemory extends AutoCloseable {
     /**
      * Gets the memory set by name. If it does not exist, the backend creates it.
      *
+     * <p>The returned set is bound to the calling action, so call this from the action body itself,
+     * not from a callback running on another thread, and obtain one per action rather than holding
+     * one across actions. Operating on a set that carries no binding throws rather than silently
+     * widening the operation to every partition key.
+     *
      * @param name the name of the memory set
      * @return the memory set
      */
@@ -38,6 +43,10 @@ public interface BaseLongTermMemory extends AutoCloseable {
 
     /**
      * Deletes the memory set.
+     *
+     * <p>Unlike the set-scoped operations, this takes a name and applies to the key currently in
+     * scope, so it must be called from the action body rather than from another thread, and can
+     * target a different key than {@link MemorySet#delete} on a same-named set would.
      *
      * @param name the name of the memory set to delete
      * @return true if the memory set was successfully deleted

--- a/api/src/main/java/org/apache/flink/agents/api/memory/BaseLongTermMemory.java
+++ b/api/src/main/java/org/apache/flink/agents/api/memory/BaseLongTermMemory.java
@@ -33,8 +33,9 @@ public interface BaseLongTermMemory extends AutoCloseable {
      *
      * <p>The returned set is bound to the calling action, so call this from the action body itself,
      * not from a callback running on another thread, and obtain one per action rather than holding
-     * one across actions. Operating on a set that carries no binding throws rather than silently
-     * widening the operation to every partition key.
+     * one across actions. Operating on a set whose partition key is absent or empty throws rather
+     * than silently widening the operation to every partition key, and this method itself throws
+     * unless a non-empty partition key is in scope.
      *
      * @param name the name of the memory set
      * @return the memory set
@@ -46,7 +47,8 @@ public interface BaseLongTermMemory extends AutoCloseable {
      *
      * <p>Unlike the set-scoped operations, this takes a name and applies to the key currently in
      * scope, so it must be called from the action body rather than from another thread, and can
-     * target a different key than {@link MemorySet#delete} on a same-named set would.
+     * target a different key than {@link MemorySet#delete} on a same-named set would. It throws
+     * unless a non-empty partition key is in scope.
      *
      * @param name the name of the memory set to delete
      * @return true if the memory set was successfully deleted

--- a/api/src/main/java/org/apache/flink/agents/api/memory/BaseLongTermMemory.java
+++ b/api/src/main/java/org/apache/flink/agents/api/memory/BaseLongTermMemory.java
@@ -31,11 +31,11 @@ public interface BaseLongTermMemory extends AutoCloseable {
     /**
      * Gets the memory set by name. If it does not exist, the backend creates it.
      *
-     * <p>The returned set is bound to the calling action, so call this from the action body itself,
-     * not from a callback running on another thread, and obtain one per action rather than holding
-     * one across actions. Operating on a set whose partition key is absent or empty throws rather
-     * than silently widening the operation to every partition key, and this method itself throws
-     * unless a non-empty partition key is in scope.
+     * <p>The returned set is bound to the calling action, so call this from the action body itself;
+     * calling it from another thread throws {@link IllegalStateException}. Obtain one per action
+     * rather than holding one across actions. Operating on a set whose partition key is absent or
+     * empty throws rather than silently widening the operation to every partition key, and this
+     * method itself throws unless a non-empty partition key is in scope.
      *
      * @param name the name of the memory set
      * @return the memory set
@@ -46,9 +46,9 @@ public interface BaseLongTermMemory extends AutoCloseable {
      * Deletes the memory set.
      *
      * <p>Unlike the set-scoped operations, this takes a name and applies to the key currently in
-     * scope, so it must be called from the action body rather than from another thread, and can
-     * target a different key than {@link MemorySet#delete} on a same-named set would. It throws
-     * unless a non-empty partition key is in scope.
+     * scope, so it must be called from the action body; calling it from another thread throws
+     * {@link IllegalStateException}. It can target a different key than {@link MemorySet#delete} on
+     * a same-named set would, and throws unless a non-empty partition key is in scope.
      *
      * @param name the name of the memory set to delete
      * @return true if the memory set was successfully deleted

--- a/api/src/main/java/org/apache/flink/agents/api/memory/MemorySet.java
+++ b/api/src/main/java/org/apache/flink/agents/api/memory/MemorySet.java
@@ -30,10 +30,18 @@ import java.util.Objects;
 /**
  * Represents a long term memory set, a named collection of memory items. Acts as a thin proxy that
  * delegates all operations to the bound {@link BaseLongTermMemory}.
+ *
+ * <p>A set also carries the action context it was obtained in. Operations run on a worker thread
+ * when submitted through {@code durableExecuteAsync}, by which time the owning long term memory may
+ * already have switched to another partition key, so they take the context from the set rather than
+ * from it. A set must therefore be obtained per action and not reused across actions.
  */
 public class MemorySet {
     private final String name;
     private @JsonIgnore BaseLongTermMemory ltm;
+    private @JsonIgnore String partitionKey;
+    private @JsonIgnore String observationId = "";
+    private @JsonIgnore boolean observationSuppressed;
 
     @JsonCreator
     public MemorySet(@JsonProperty("name") String name) {
@@ -100,8 +108,35 @@ public class MemorySet {
         this.ltm = ltm;
     }
 
+    /**
+     * Binds this set to the action context it was obtained in. Called on the mailbox thread when
+     * the set is created.
+     *
+     * @param partitionKey the partition key this set is scoped to
+     * @param observationId identifier for the owning action's observations
+     * @param observationSuppressed whether observation is suppressed for the owning action
+     */
+    public void setActionContext(
+            String partitionKey, String observationId, boolean observationSuppressed) {
+        this.partitionKey = partitionKey;
+        this.observationId = observationId;
+        this.observationSuppressed = observationSuppressed;
+    }
+
     public String getName() {
         return name;
+    }
+
+    public String getPartitionKey() {
+        return partitionKey;
+    }
+
+    public String getObservationId() {
+        return observationId;
+    }
+
+    public boolean isObservationSuppressed() {
+        return observationSuppressed;
     }
 
     @Override

--- a/docs/content/docs/development/memory/long_term_memory.md
+++ b/docs/content/docs/development/memory/long_term_memory.md
@@ -179,6 +179,13 @@ public static void processEvent(Event event, RunnerContext ctx) throws Exception
 
 {{< /tabs >}}
 
+{{< hint warning >}}
+A memory set is scoped to the key of the action that obtained it. Call `get_memory_set` /
+`getMemorySet` inside each action that needs one, rather than caching a set and reusing it
+in a later action. Reusing a set would apply another key's operations to the key it was
+originally obtained for, and operating on a set that carries no scope raises an error.
+{{< /hint >}}
+
 ### Adding Items
 
 {{< tabs "Adding Items" >}}

--- a/docs/content/docs/development/memory/long_term_memory.md
+++ b/docs/content/docs/development/memory/long_term_memory.md
@@ -184,6 +184,9 @@ A memory set is scoped to the key of the action that obtained it. Call `get_memo
 `getMemorySet` inside each action that needs one, rather than caching a set and reusing it
 in a later action. Reusing a set would apply another key's operations to the key it was
 originally obtained for, and operating on a set that carries no scope raises an error.
+Long-term memory also requires a non-empty partition key. A key of `""` carries no
+isolation in the backing store, so obtaining or using a memory set under one raises
+rather than writing memories that no key can read back.
 {{< /hint >}}
 
 ### Adding Items
@@ -556,3 +559,5 @@ The isolation hierarchy works as follows:
 This means you can reuse the same memory set name across different partitions, and each partition will normally access only its own memories.
 
 > **Note:** Partition-level isolation uses a textual identity derived from the logical key instead of `key.hashCode()`. Java keys use `String.valueOf(key)`. Default-serialized PyFlink keys are deserialized and use Python `str`; explicitly typed PyFlink keys use `String.valueOf`, except byte-array keys, which use Python's bytes representation. This avoids hash collisions, but distinct keys may still share a memory context if they produce the same text, for example when custom key types have non-unique `toString()` or `__str__()` implementations. Key representations should therefore be stable and unique, and this isolation should not be treated as a security boundary.
+
+An empty partition key is rejected rather than used. The backing store treats an empty `agent_id` as no filter at all, so an empty key would widen every read and delete to every key in the job, and items added under it would be stored with no partition attribution to read back later. A job that can legitimately produce an empty key must map it to a non-empty placeholder before keying the stream; long-term memory cannot do that mapping itself without changing the identity of keys whose memories are already stored.

--- a/docs/content/docs/development/memory/long_term_memory.md
+++ b/docs/content/docs/development/memory/long_term_memory.md
@@ -184,6 +184,19 @@ A memory set is scoped to the key of the action that obtained it. Call `get_memo
 `getMemorySet` inside each action that needs one, rather than caching a set and reusing it
 in a later action. Reusing a set would apply another key's operations to the key it was
 originally obtained for, and operating on a set that carries no scope raises an error.
+
+Obtaining a memory set and deleting one both read the key currently in scope, which only
+the action's own thread reads consistently. Both raise wherever they run on a worker
+thread, so passing `getMemorySet` / `get_memory_set` or `deleteMemorySet` /
+`delete_memory_set` to `durableExecuteAsync` / `durable_execute_async` is unsupported: in
+Python, and in Java on JDK 21 and above, the callable runs on a worker thread and the call
+raises. On JDK 11 Java runs the callable inline instead, so the same code does not raise
+today, but it is unsupported there too and will raise once the job moves to a newer JDK.
+
+Operations on a set you already hold are unaffected, since they carry the key the set was
+obtained under. That is why a memory set may be handed to a worker thread but the long-term
+memory itself may not.
+
 Long-term memory also requires a non-empty partition key. A key of `""` carries no
 isolation in the backing store, so obtaining or using a memory set under one raises
 rather than writing memories that no key can read back.

--- a/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/SkillsIntegrationTest.java
+++ b/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/SkillsIntegrationTest.java
@@ -72,11 +72,20 @@ import static org.apache.flink.agents.api.agents.AgentExecutionOptions.MAX_RETRI
  */
 public class SkillsIntegrationTest {
 
+    /**
+     * Whether a usable key is present. GitHub sets the variable to the empty string when the secret
+     * is unavailable, such as on a pull request from a fork, so an absent key reaches the test as
+     * empty rather than as null.
+     */
+    private static boolean isApiKeySet() {
+        String apiKey = System.getenv("ACTION_API_KEY");
+        return apiKey != null && !apiKey.isEmpty();
+    }
+
     @Test
     public void testWorkflowWithSkills() throws Exception {
         Assumptions.assumeTrue(
-                System.getenv().get("ACTION_API_KEY") != null,
-                "ACTION_API_KEY is required for the skills end-to-end test.");
+                isApiKeySet(), "ACTION_API_KEY is required for the skills end-to-end test.");
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);
@@ -120,8 +129,7 @@ public class SkillsIntegrationTest {
     @Test
     public void testReActAgentWithSkills() throws Exception {
         Assumptions.assumeTrue(
-                System.getenv().get("ACTION_API_KEY") != null,
-                "ACTION_API_KEY is required for the skills end-to-end test.");
+                isApiKeySet(), "ACTION_API_KEY is required for the skills end-to-end test.");
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);

--- a/e2e-test/flink-agents-end-to-end-tests-resource-cross-language/src/test/java/org/apache/flink/agents/resource/test/Mem0LongTermMemoryTest.java
+++ b/e2e-test/flink-agents-end-to-end-tests-resource-cross-language/src/test/java/org/apache/flink/agents/resource/test/Mem0LongTermMemoryTest.java
@@ -73,7 +73,10 @@ public class Mem0LongTermMemoryTest {
         pythonReady = isPythonAvailable();
         esConfigured = System.getenv("ES_HOST") != null;
         milvusConfigured = System.getenv("MILVUS_URI") != null;
-        apiKeySet = System.getenv("ACTION_API_KEY") != null;
+        // GitHub sets the variable to the empty string when the secret is unavailable, such as
+        // on a pull request from a fork, so an absent key arrives as empty rather than as null.
+        String apiKey = System.getenv("ACTION_API_KEY");
+        apiKeySet = apiKey != null && !apiKey.isEmpty();
     }
 
     @ParameterizedTest(name = "vectorStore={0}")

--- a/python/flink_agents/api/memory/long_term_memory.py
+++ b/python/flink_agents/api/memory/long_term_memory.py
@@ -164,11 +164,11 @@ class BaseLongTermMemory(ABC, BaseModel):
         """Get the memory set by name. If it does not exist, create it.
 
         The returned set is bound to the calling action, so call this from the action
-        body itself, not from a callback running on another thread, and obtain one per
-        action rather than holding one across actions. Operating on a set whose
-        partition key is absent or empty raises rather than silently widening the
-        operation to every partition key, and this method itself raises unless a
-        non-empty partition key is in scope.
+        body itself; calling it from another thread raises. Obtain one per action rather
+        than holding one across actions. Operating on a set whose partition key is
+        absent or empty raises rather than silently widening the operation to every
+        partition key, and this method itself raises unless a non-empty partition key is
+        in scope.
 
         Args:
             name: The name of the memory set.
@@ -182,9 +182,10 @@ class BaseLongTermMemory(ABC, BaseModel):
         """Delete the memory set.
 
         Unlike the set-scoped operations, this takes a name and applies to the key
-        currently in scope, so it must be called from the action body rather than from
-        another thread, and can target a different key than ``MemorySet.delete`` on a
-        same-named set would. It raises unless a non-empty partition key is in scope.
+        currently in scope, so it must be called from the action body; calling it from
+        another thread raises. It can target a different key than ``MemorySet.delete``
+        on a same-named set would, and raises unless a non-empty partition key is in
+        scope.
 
         Args:
             name: The name of the memory set.

--- a/python/flink_agents/api/memory/long_term_memory.py
+++ b/python/flink_agents/api/memory/long_term_memory.py
@@ -72,12 +72,25 @@ class MemorySetItem(BaseModel):
 class MemorySet(BaseModel):
     """Represents a long term memory set contains memory items.
 
+    A set is bound to the action context it was obtained in. Operations run on a
+    worker thread when submitted through ``durable_execute_async``, by which time
+    the owning long term memory may already have switched to another partition
+    key, so they take the context from the set rather than from it. A set must
+    therefore be obtained per action and not reused across actions.
+
     Attributes:
         name: The name of this memory set.
+        partition_key: The partition key this set is scoped to.
+        observation_id: Identifier for the owning action's observations.
+        observation_suppressed: Whether observation is suppressed for the owning
+            action.
     """
 
     name: str
     ltm: "BaseLongTermMemory" = Field(default=None, exclude=True)
+    partition_key: str | None = Field(default=None, exclude=True)
+    observation_id: str = Field(default="", exclude=True)
+    observation_suppressed: bool = Field(default=False, exclude=True)
 
     def add(
         self,
@@ -150,6 +163,12 @@ class BaseLongTermMemory(ABC, BaseModel):
     def get_memory_set(self, name: str) -> MemorySet:
         """Get the memory set by name. If it does not exist, create it.
 
+        The returned set is bound to the calling action, so call this from the action
+        body itself, not from a callback running on another thread, and obtain one per
+        action rather than holding one across actions. Operating on a set that carries
+        no binding raises rather than silently widening the operation to every
+        partition key.
+
         Args:
             name: The name of the memory set.
 
@@ -160,6 +179,11 @@ class BaseLongTermMemory(ABC, BaseModel):
     @abstractmethod
     def delete_memory_set(self, name: str) -> bool:
         """Delete the memory set.
+
+        Unlike the set-scoped operations, this takes a name and applies to the key
+        currently in scope, so it must be called from the action body rather than from
+        another thread, and can target a different key than ``MemorySet.delete`` on a
+        same-named set would.
 
         Args:
             name: The name of the memory set.

--- a/python/flink_agents/api/memory/long_term_memory.py
+++ b/python/flink_agents/api/memory/long_term_memory.py
@@ -165,9 +165,10 @@ class BaseLongTermMemory(ABC, BaseModel):
 
         The returned set is bound to the calling action, so call this from the action
         body itself, not from a callback running on another thread, and obtain one per
-        action rather than holding one across actions. Operating on a set that carries
-        no binding raises rather than silently widening the operation to every
-        partition key.
+        action rather than holding one across actions. Operating on a set whose
+        partition key is absent or empty raises rather than silently widening the
+        operation to every partition key, and this method itself raises unless a
+        non-empty partition key is in scope.
 
         Args:
             name: The name of the memory set.
@@ -183,7 +184,7 @@ class BaseLongTermMemory(ABC, BaseModel):
         Unlike the set-scoped operations, this takes a name and applies to the key
         currently in scope, so it must be called from the action body rather than from
         another thread, and can target a different key than ``MemorySet.delete`` on a
-        same-named set would.
+        same-named set would. It raises unless a non-empty partition key is in scope.
 
         Args:
             name: The name of the memory set.

--- a/python/flink_agents/runtime/flink_runner_context.py
+++ b/python/flink_agents/runtime/flink_runner_context.py
@@ -1271,6 +1271,7 @@ def _init_long_term_memory(
         chat_model_name=chat_model_name,
         embedding_model_name=embedding_model_name,
         vector_store_name=vector_store_name,
+        mailbox_thread_checker=lambda: ctx._j_runner_context.checkMailboxThread(),
     )
 
 

--- a/python/flink_agents/runtime/memory/mem0/mem0_long_term_memory.py
+++ b/python/flink_agents/runtime/memory/mem0/mem0_long_term_memory.py
@@ -123,12 +123,30 @@ def _create_flink_agents_config_classes() -> tuple:
     return _FlinkAgentsLlmConfig, _FlinkAgentsEmbedderConfig
 
 
+def _reject_empty_partition_key(key: str) -> str:
+    """Return ``key`` unless it is empty, which cannot scope an operation.
+
+    Mem0 matches on ``agent_id`` only when it is truthy, so an empty key widens
+    every operation to all keys sharing the job id and set name, and stores added
+    items with no ``agent_id`` at all.
+    """
+    if not key:
+        msg = (
+            "Long-term memory cannot be scoped to an empty partition key. Mem0 "
+            "ignores an empty agent_id, so the operation would reach every key "
+            "sharing the job id and set name, and added items would be stored "
+            "unattributed. Key the stream by a non-empty value."
+        )
+        raise ValueError(msg)
+    return key
+
+
 def _bound_partition_key(memory_set: MemorySet) -> str:
     """Return the partition key the set is scoped to.
 
-    Mem0 ignores a falsy ``agent_id`` rather than matching on it, so an unbound set
-    would widen every operation to all keys sharing the job id and set name, which
-    for a delete means deleting another key's items. Refuse the operation instead.
+    An unbound set would widen every operation to all keys sharing the job id and
+    set name, which for a delete means deleting another key's items. Refuse the
+    operation instead.
     """
     if memory_set.partition_key is None:
         msg = (
@@ -137,7 +155,7 @@ def _bound_partition_key(memory_set: MemorySet) -> str:
             "than constructing it directly or reusing one across actions."
         )
         raise ValueError(msg)
-    return memory_set.partition_key
+    return _reject_empty_partition_key(memory_set.partition_key)
 
 
 class Mem0LongTermMemory(InternalBaseLongTermMemory):
@@ -155,8 +173,10 @@ class Mem0LongTermMemory(InternalBaseLongTermMemory):
 
     job_id: str = Field(description="Unique identifier for the job.")
 
-    key: str = Field(
-        default="", description="Unique identifier for the keyed partition."
+    key: str | None = Field(
+        default=None,
+        description="Keyed partition currently in scope, or None before the first "
+        "context switch.",
     )
 
     chat_model_name: str = Field(
@@ -442,6 +462,21 @@ class Mem0LongTermMemory(InternalBaseLongTermMemory):
 
         return json.dumps([record.to_wire() for record in records], ensure_ascii=False)
 
+    def _current_partition_key(self) -> str:
+        """Return the partition key currently in scope.
+
+        Whole-set management operations read the key from the memory rather than
+        from a set, so they are only correct once an action has switched context.
+        """
+        if self.key is None:
+            msg = (
+                "Long-term memory has no partition key in scope. Call this from "
+                "an action body, which always runs under a partition key, rather "
+                "than before the first action has run."
+            )
+            raise ValueError(msg)
+        return _reject_empty_partition_key(self.key)
+
     @override
     def get_memory_set(self, name: str) -> MemorySet:
         """Get the memory set by name.
@@ -455,11 +490,14 @@ class Mem0LongTermMemory(InternalBaseLongTermMemory):
 
         Returns:
             The memory set.
+
+        Raises:
+            ValueError: If no non-empty partition key is in scope.
         """
         return MemorySet(
             name=name,
             ltm=self,
-            partition_key=self.key,
+            partition_key=self._current_partition_key(),
             observation_id=self._observation_id,
             observation_suppressed=self._observation_suppressed,
         )
@@ -478,8 +516,11 @@ class Mem0LongTermMemory(InternalBaseLongTermMemory):
 
         Returns:
             True if the memory set was deleted.
+
+        Raises:
+            ValueError: If no non-empty partition key is in scope.
         """
-        observation_key = self.key
+        observation_key = self._current_partition_key()
         observation_id = self._observation_id
         observation_enabled = (
             self._update_observation_enabled and not self._observation_suppressed

--- a/python/flink_agents/runtime/memory/mem0/mem0_long_term_memory.py
+++ b/python/flink_agents/runtime/memory/mem0/mem0_long_term_memory.py
@@ -24,7 +24,7 @@ import queue
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 from pydantic import ConfigDict, Field, PrivateAttr, field_validator
 from typing_extensions import override
@@ -171,6 +171,13 @@ class Mem0LongTermMemory(InternalBaseLongTermMemory):
         description="The runner context to retrieve resources.", exclude=True
     )
 
+    mailbox_thread_checker: Callable[[], None] = Field(
+        description="Raises when called off the Flink mailbox thread. Whole-memory-set "
+        "management reads the partition key currently in scope, which only the mailbox "
+        "thread can read consistently.",
+        exclude=True,
+    )
+
     job_id: str = Field(description="Unique identifier for the job.")
 
     key: str | None = Field(
@@ -221,6 +228,7 @@ class Mem0LongTermMemory(InternalBaseLongTermMemory):
         chat_model_name: str,
         embedding_model_name: str,
         vector_store_name: str,
+        mailbox_thread_checker: Callable[[], None],
     ) -> None:
         """Initialize the Mem0-based Long-Term Memory.
 
@@ -231,6 +239,8 @@ class Mem0LongTermMemory(InternalBaseLongTermMemory):
             embedding_model_name: Resource name of the embedding model.
             vector_store_name: Resource name of a
                 ``CollectionManageableVectorStore`` to back Mem0.
+            mailbox_thread_checker: Callable that raises when invoked off the
+                Flink mailbox thread.
         """
         # Resolve metric group upfront on the main thread so that it is
         # safe to use from any thread later.
@@ -242,6 +252,7 @@ class Mem0LongTermMemory(InternalBaseLongTermMemory):
         )
         super().__init__(
             ctx=ctx,
+            mailbox_thread_checker=mailbox_thread_checker,
             job_id=job_id,
             chat_model_name=chat_model_name,
             embedding_model_name=embedding_model_name,
@@ -483,7 +494,8 @@ class Mem0LongTermMemory(InternalBaseLongTermMemory):
 
         The current partition key and observation context are copied onto the set
         so that operations submitted to a worker thread stay scoped to the action
-        that obtained it. Must be called on the mailbox thread.
+        that obtained it. Only the mailbox thread reads that context consistently,
+        so this method refuses to run on any other thread.
 
         Args:
             name: The name of the memory set.
@@ -492,8 +504,12 @@ class Mem0LongTermMemory(InternalBaseLongTermMemory):
             The memory set.
 
         Raises:
-            ValueError: If no non-empty partition key is in scope.
+            ValueError: If the partition key in scope is absent or empty.
+            Exception: Called from a thread other than the mailbox thread. The
+                refusal originates on the Java side and reaches Python through the
+                bridge, so the concrete type is whatever that marshals to.
         """
+        self.mailbox_thread_checker()
         return MemorySet(
             name=name,
             ltm=self,
@@ -507,7 +523,7 @@ class Mem0LongTermMemory(InternalBaseLongTermMemory):
         """Delete a memory set and all its items.
 
         Takes a name rather than a ``MemorySet``, so it has no bound context to read
-        and uses the key currently in scope. It is therefore only correct on the
+        and uses the key currently in scope. It therefore refuses to run outside the
         mailbox thread, and deleting a whole set can target a different key than
         ``MemorySet.delete`` on a set of the same name would.
 
@@ -518,8 +534,12 @@ class Mem0LongTermMemory(InternalBaseLongTermMemory):
             True if the memory set was deleted.
 
         Raises:
-            ValueError: If no non-empty partition key is in scope.
+            ValueError: If the partition key in scope is absent or empty.
+            Exception: Called from a thread other than the mailbox thread. The
+                refusal originates on the Java side and reaches Python through the
+                bridge, so the concrete type is whatever that marshals to.
         """
+        self.mailbox_thread_checker()
         observation_key = self._current_partition_key()
         observation_id = self._observation_id
         observation_enabled = (

--- a/python/flink_agents/runtime/memory/mem0/mem0_long_term_memory.py
+++ b/python/flink_agents/runtime/memory/mem0/mem0_long_term_memory.py
@@ -123,6 +123,23 @@ def _create_flink_agents_config_classes() -> tuple:
     return _FlinkAgentsLlmConfig, _FlinkAgentsEmbedderConfig
 
 
+def _bound_partition_key(memory_set: MemorySet) -> str:
+    """Return the partition key the set is scoped to.
+
+    Mem0 ignores a falsy ``agent_id`` rather than matching on it, so an unbound set
+    would widen every operation to all keys sharing the job id and set name, which
+    for a delete means deleting another key's items. Refuse the operation instead.
+    """
+    if memory_set.partition_key is None:
+        msg = (
+            f"Memory set {memory_set.name!r} is not bound to a partition key. "
+            "Obtain it with get_memory_set inside the action that uses it, rather "
+            "than constructing it directly or reusing one across actions."
+        )
+        raise ValueError(msg)
+    return memory_set.partition_key
+
+
 class Mem0LongTermMemory(InternalBaseLongTermMemory):
     """Long-Term Memory backed by Mem0.
 
@@ -429,17 +446,32 @@ class Mem0LongTermMemory(InternalBaseLongTermMemory):
     def get_memory_set(self, name: str) -> MemorySet:
         """Get the memory set by name.
 
+        The current partition key and observation context are copied onto the set
+        so that operations submitted to a worker thread stay scoped to the action
+        that obtained it. Must be called on the mailbox thread.
+
         Args:
             name: The name of the memory set.
 
         Returns:
             The memory set.
         """
-        return MemorySet(name=name, ltm=self)
+        return MemorySet(
+            name=name,
+            ltm=self,
+            partition_key=self.key,
+            observation_id=self._observation_id,
+            observation_suppressed=self._observation_suppressed,
+        )
 
     @override
     def delete_memory_set(self, name: str) -> bool:
         """Delete a memory set and all its items.
+
+        Takes a name rather than a ``MemorySet``, so it has no bound context to read
+        and uses the key currently in scope. It is therefore only correct on the
+        mailbox thread, and deleting a whole set can target a different key than
+        ``MemorySet.delete`` on a set of the same name would.
 
         Args:
             name: The name of the memory set.
@@ -485,10 +517,10 @@ class Mem0LongTermMemory(InternalBaseLongTermMemory):
         Returns:
             List of IDs of the added memories.
         """
-        observation_key = self.key
-        observation_id = self._observation_id
+        observation_key = _bound_partition_key(memory_set)
+        observation_id = memory_set.observation_id
         observation_enabled = (
-            self._update_observation_enabled and not self._observation_suppressed
+            self._update_observation_enabled and not memory_set.observation_suppressed
         )
         if isinstance(memory_items, str):
             memory_items = [memory_items]
@@ -550,10 +582,10 @@ class Mem0LongTermMemory(InternalBaseLongTermMemory):
         Returns:
             List of memory items.
         """
-        observation_key = self.key
-        observation_id = self._observation_id
+        observation_key = _bound_partition_key(memory_set)
+        observation_id = memory_set.observation_id
         observation_enabled = (
-            self._get_observation_enabled and not self._observation_suppressed
+            self._get_observation_enabled and not memory_set.observation_suppressed
         )
         if ids is not None:
             if isinstance(ids, str):
@@ -605,10 +637,10 @@ class Mem0LongTermMemory(InternalBaseLongTermMemory):
             memory_set: The memory set to delete from.
             ids: Optional ID or list of IDs. If None, deletes all items.
         """
-        observation_key = self.key
-        observation_id = self._observation_id
+        observation_key = _bound_partition_key(memory_set)
+        observation_id = memory_set.observation_id
         observation_enabled = (
-            self._update_observation_enabled and not self._observation_suppressed
+            self._update_observation_enabled and not memory_set.observation_suppressed
         )
         if ids is None:
             self._mem0_instance.delete_all(
@@ -662,10 +694,10 @@ class Mem0LongTermMemory(InternalBaseLongTermMemory):
         Returns:
             List of matching memory items.
         """
-        observation_key = self.key
-        observation_id = self._observation_id
+        observation_key = _bound_partition_key(memory_set)
+        observation_id = memory_set.observation_id
         observation_enabled = (
-            self._search_observation_enabled and not self._observation_suppressed
+            self._search_observation_enabled and not memory_set.observation_suppressed
         )
         result = self._mem0_instance.search(
             query=query,

--- a/python/flink_agents/runtime/memory/mem0/tests/test_mem0_long_term_memory.py
+++ b/python/flink_agents/runtime/memory/mem0/tests/test_mem0_long_term_memory.py
@@ -172,6 +172,7 @@ def ltm(mock_ctx):
         chat_model_name="test_chat_model",
         embedding_model_name="test_embedding_model",
         vector_store_name="test_vector_store",
+        mailbox_thread_checker=lambda: None,
     )
     # Operations refuse an absent or empty key, so the fixture runs under the key an
     # action would have switched to.
@@ -460,6 +461,7 @@ def test_token_usage_reported_on_switch_context() -> None:
         chat_model_name="test_chat_model",
         embedding_model_name="test_embedding_model",
         vector_store_name="test_vector_store",
+        mailbox_thread_checker=lambda: None,
     )
 
     # First switch_context triggers lazy init; no metrics yet.
@@ -520,6 +522,7 @@ def test_token_usage_flushed_on_close() -> None:
         chat_model_name="test_chat_model",
         embedding_model_name="test_embedding_model",
         vector_store_name="test_vector_store",
+        mailbox_thread_checker=lambda: None,
     )
 
     ltm.switch_context("key_1", observation_id="action-1")

--- a/python/flink_agents/runtime/memory/mem0/tests/test_mem0_long_term_memory.py
+++ b/python/flink_agents/runtime/memory/mem0/tests/test_mem0_long_term_memory.py
@@ -330,11 +330,12 @@ def test_switch_context(ltm) -> None:
     memory_set.add(items="Data for key_a")
 
     ltm.switch_context("key_b", observation_id="action-b")
-    # key_b should have no items in the same memory set name
-    items = memory_set.get()
-    # Items from key_a should not be visible under key_b
-    # (They have different agent_id scoping)
-    assert len(items) == 0
+    # The set stays scoped to key_a, so it still reads key_a's item after the
+    # switch rather than following the current context.
+    assert len(memory_set.get()) == 1
+    # A set obtained under key_b is scoped to key_b, so key_a's items in the
+    # same-named set are not visible through it.
+    assert len(ltm.get_memory_set(name="context_set").get()) == 0
 
     # Reset context
     ltm.switch_context("", observation_id="action-empty")

--- a/python/flink_agents/runtime/memory/mem0/tests/test_mem0_long_term_memory.py
+++ b/python/flink_agents/runtime/memory/mem0/tests/test_mem0_long_term_memory.py
@@ -173,6 +173,9 @@ def ltm(mock_ctx):
         embedding_model_name="test_embedding_model",
         vector_store_name="test_vector_store",
     )
+    # Operations refuse an absent or empty key, so the fixture runs under the key an
+    # action would have switched to.
+    mem0_ltm.switch_context("test_key", observation_id="test-action")
     return mem0_ltm
 
 
@@ -336,9 +339,6 @@ def test_switch_context(ltm) -> None:
     # A set obtained under key_b is scoped to key_b, so key_a's items in the
     # same-named set are not visible through it.
     assert len(ltm.get_memory_set(name="context_set").get()) == 0
-
-    # Reset context
-    ltm.switch_context("", observation_id="action-empty")
 
 
 class MockChatModelWithTokenUsage:

--- a/python/flink_agents/runtime/memory/mem0/tests/test_mem0_op_recording.py
+++ b/python/flink_agents/runtime/memory/mem0/tests/test_mem0_op_recording.py
@@ -24,6 +24,9 @@ from threading import Event
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
+from flink_agents.api.memory.long_term_memory import MemorySet
 from flink_agents.runtime.memory.internal_base_long_term_memory import (
     InternalBaseLongTermMemory,
 )
@@ -172,16 +175,15 @@ def test_context_switch_changes_observation_owner_and_current_suppression() -> N
         "results": [{"event": "ADD", "id": "m1", "memory": "value"}]
     }
     ltm = _make_ltm(mem0)
-    memory_set = ltm.get_memory_set("prefs")
 
     ltm.switch_context(
         "suppressed", observation_id="suppressed-action", observation_suppressed=True
     )
-    ltm.add(memory_set, "ignored")
+    ltm.add(ltm.get_memory_set("prefs"), "ignored")
     assert _drain(ltm, "suppressed", "suppressed-action") == []
 
     ltm.switch_context("observed", observation_id="observed-action")
-    ltm.add(memory_set, "recorded")
+    ltm.add(ltm.get_memory_set("prefs"), "recorded")
     assert [record["id"] for record in _drain(ltm, "observed", "observed-action")] == [
         "m1"
     ]
@@ -196,9 +198,9 @@ def test_empty_context_key_is_used_consistently_for_mem0_operations() -> None:
     mem0.get_all.return_value = {"results": []}
     mem0.search.return_value = {"results": []}
     ltm = _make_ltm(mem0)
-    memory_set = ltm.get_memory_set("prefs")
 
     ltm.switch_context("", observation_id="empty-action")
+    memory_set = ltm.get_memory_set("prefs")
     ltm.add(memory_set, "input")
     ltm.get(memory_set)
     ltm.search(memory_set, "query", limit=5)
@@ -212,3 +214,99 @@ def test_empty_context_key_is_used_consistently_for_mem0_operations() -> None:
         "",
         "",
     ]
+
+
+def test_memory_set_stays_on_its_own_key_after_the_owner_switches() -> None:
+    mem0 = MagicMock()
+    mem0.add.return_value = {"results": []}
+    mem0.get_all.return_value = {"results": []}
+    mem0.search.return_value = {"results": []}
+    ltm = _make_ltm(mem0)
+
+    ltm.switch_context("owner", observation_id="owner-action")
+    memory_set = ltm.get_memory_set("prefs")
+
+    ltm.switch_context("other", observation_id="other-action")
+    ltm.add(memory_set, "input")
+    ltm.get(memory_set)
+    ltm.search(memory_set, "query", limit=5)
+    ltm.delete(memory_set)
+
+    assert mem0.add.call_args.kwargs["agent_id"] == "owner"
+    assert mem0.get_all.call_args.kwargs["agent_id"] == "owner"
+    assert mem0.search.call_args.kwargs["agent_id"] == "owner"
+    assert mem0.delete_all.call_args.kwargs["agent_id"] == "owner"
+
+
+def test_observations_stay_with_the_action_that_obtained_the_set() -> None:
+    mem0 = MagicMock()
+    mem0.add.return_value = {
+        "results": [{"event": "ADD", "id": "m1", "memory": "value"}]
+    }
+    mem0.get_all.return_value = {"results": [{"id": "m2", "memory": "stored"}]}
+    mem0.search.return_value = {"results": []}
+    ltm = _make_ltm(mem0)
+
+    ltm.switch_context("owner", observation_id="owner-action")
+    memory_set = ltm.get_memory_set("prefs")
+
+    ltm.switch_context("other", observation_id="other-action")
+    ltm.add(memory_set, "input")
+    ltm.get(memory_set)
+    ltm.search(memory_set, "query", limit=5)
+    ltm.delete(memory_set)
+
+    assert _drain(ltm, "other", "other-action") == []
+    assert [record["op"] for record in _drain(ltm, "owner", "owner-action")] == [
+        "ADD",
+        "GET",
+        "SEARCH",
+        "DELETE_SET",
+    ]
+
+
+def test_unbound_memory_set_is_refused_rather_than_widened() -> None:
+    mem0 = MagicMock()
+    ltm = _make_ltm(mem0)
+    unbound = MemorySet(name="prefs", ltm=ltm)
+
+    for op in (
+        lambda: ltm.add(unbound, "input"),
+        lambda: ltm.get(unbound),
+        lambda: ltm.delete(unbound),
+        lambda: ltm.search(unbound, "query", limit=5),
+    ):
+        with pytest.raises(ValueError, match="not bound to a partition key"):
+            op()
+
+    mem0.add.assert_not_called()
+    mem0.get_all.assert_not_called()
+    mem0.delete_all.assert_not_called()
+    mem0.search.assert_not_called()
+
+
+def test_suppression_follows_the_set_not_the_current_context() -> None:
+    mem0 = MagicMock()
+    mem0.add.return_value = {
+        "results": [{"event": "ADD", "id": "m1", "memory": "value"}]
+    }
+    ltm = _make_ltm(mem0)
+
+    # Obtained while suppressed, used while the current context is not: the set's
+    # own flag decides, so nothing is recorded.
+    ltm.switch_context(
+        "owner", observation_id="owner-action", observation_suppressed=True
+    )
+    suppressed_set = ltm.get_memory_set("prefs")
+    ltm.switch_context("owner", observation_id="live-action")
+    ltm.add(suppressed_set, "input")
+    assert _drain(ltm, "owner", "owner-action") == []
+
+    # And the reverse: obtained unsuppressed, used while the current context is
+    # suppressed, so the operation is still recorded.
+    unsuppressed_set = ltm.get_memory_set("prefs")
+    ltm.switch_context(
+        "owner", observation_id="quiet-action", observation_suppressed=True
+    )
+    ltm.add(unsuppressed_set, "input")
+    assert [record["id"] for record in _drain(ltm, "owner", "live-action")] == ["m1"]

--- a/python/flink_agents/runtime/memory/mem0/tests/test_mem0_op_recording.py
+++ b/python/flink_agents/runtime/memory/mem0/tests/test_mem0_op_recording.py
@@ -37,7 +37,11 @@ def _make_ltm(mem0: Any) -> Mem0LongTermMemory:
     ctx = MagicMock()
     ctx.agent_metric_group = None
     ltm = Mem0LongTermMemory.model_construct(
-        ctx=ctx, job_id="job", key="partition", metric_group=None
+        ctx=ctx,
+        job_id="job",
+        key="partition",
+        metric_group=None,
+        mailbox_thread_checker=lambda: None,
     )
     ltm._mem0 = mem0
     ltm._observation_id = "action"
@@ -227,7 +231,10 @@ def test_empty_partition_key_is_refused_by_memory_set_management() -> None:
 
 def test_memory_set_management_before_any_context_switch_is_refused() -> None:
     ltm = Mem0LongTermMemory.model_construct(
-        ctx=MagicMock(), job_id="job", metric_group=None
+        ctx=MagicMock(),
+        job_id="job",
+        metric_group=None,
+        mailbox_thread_checker=lambda: None,
     )
 
     with pytest.raises(ValueError, match="no partition key in scope"):
@@ -328,3 +335,53 @@ def test_suppression_follows_the_set_not_the_current_context() -> None:
     )
     ltm.add(unsuppressed_set, "input")
     assert [record["id"] for record in _drain(ltm, "owner", "live-action")] == ["m1"]
+
+
+def test_memory_set_management_is_refused_off_the_mailbox_thread() -> None:
+    def _refuse() -> None:
+        msg = "Expected to be running on the task mailbox thread, but was not."
+        raise RuntimeError(msg)
+
+    # No key in scope: only a checker that runs before the key is read can produce the
+    # mailbox-thread message. That pins the intended order, because off the mailbox
+    # thread the key read is itself unreliable.
+    mem0 = MagicMock()
+    ltm = Mem0LongTermMemory.model_construct(
+        ctx=MagicMock(),
+        job_id="job",
+        metric_group=None,
+        mailbox_thread_checker=_refuse,
+    )
+    ltm._mem0 = mem0
+
+    with pytest.raises(RuntimeError, match="task mailbox thread"):
+        ltm.get_memory_set("prefs")
+    with pytest.raises(RuntimeError, match="task mailbox thread"):
+        ltm.delete_memory_set("prefs")
+
+    mem0.delete_all.assert_not_called()
+
+
+def test_set_scoped_operations_run_without_the_mailbox_thread() -> None:
+    # A set carries the context it was obtained under, so operations on it are safe
+    # to forward to a worker thread. Gating them would break durable async execution.
+    calls = []
+    mem0 = MagicMock()
+    mem0.add.return_value = {"results": []}
+    mem0.get_all.return_value = {"results": []}
+    mem0.search.return_value = {"results": []}
+    ltm = _make_ltm(mem0)
+    ltm.mailbox_thread_checker = lambda: calls.append(None)
+    ltm.switch_context("owner", observation_id="owner-action")
+
+    memory_set = ltm.get_memory_set("prefs")
+    # Guards the assertion below from passing vacuously on a checker that never runs.
+    assert len(calls) == 1
+    calls.clear()
+
+    ltm.add(memory_set, "input")
+    ltm.get(memory_set)
+    ltm.search(memory_set, "query", limit=5)
+    ltm.delete(memory_set)
+
+    assert calls == []

--- a/python/flink_agents/runtime/memory/mem0/tests/test_mem0_op_recording.py
+++ b/python/flink_agents/runtime/memory/mem0/tests/test_mem0_op_recording.py
@@ -192,28 +192,46 @@ def test_context_switch_changes_observation_owner_and_current_suppression() -> N
     assert ltm._search_observation_enabled is True
 
 
-def test_empty_context_key_is_used_consistently_for_mem0_operations() -> None:
+def test_empty_partition_key_is_refused_by_set_operations() -> None:
     mem0 = MagicMock()
-    mem0.add.return_value = {"results": []}
-    mem0.get_all.return_value = {"results": []}
-    mem0.search.return_value = {"results": []}
     ltm = _make_ltm(mem0)
+    empty_keyed = MemorySet(name="prefs", ltm=ltm, partition_key="")
 
+    for op in (
+        lambda: ltm.add(empty_keyed, "input"),
+        lambda: ltm.get(empty_keyed),
+        lambda: ltm.delete(empty_keyed),
+        lambda: ltm.search(empty_keyed, "query", limit=5),
+    ):
+        with pytest.raises(ValueError, match="empty partition key"):
+            op()
+
+    mem0.add.assert_not_called()
+    mem0.get_all.assert_not_called()
+    mem0.delete_all.assert_not_called()
+    mem0.search.assert_not_called()
+
+
+def test_empty_partition_key_is_refused_by_memory_set_management() -> None:
+    mem0 = MagicMock()
+    ltm = _make_ltm(mem0)
     ltm.switch_context("", observation_id="empty-action")
-    memory_set = ltm.get_memory_set("prefs")
-    ltm.add(memory_set, "input")
-    ltm.get(memory_set)
-    ltm.search(memory_set, "query", limit=5)
-    ltm.delete(memory_set)
-    ltm.delete_memory_set("prefs")
 
-    assert mem0.add.call_args.kwargs["agent_id"] == ""
-    assert mem0.get_all.call_args.kwargs["agent_id"] == ""
-    assert mem0.search.call_args.kwargs["agent_id"] == ""
-    assert [call.kwargs["agent_id"] for call in mem0.delete_all.call_args_list] == [
-        "",
-        "",
-    ]
+    with pytest.raises(ValueError, match="empty partition key"):
+        ltm.get_memory_set("prefs")
+    with pytest.raises(ValueError, match="empty partition key"):
+        ltm.delete_memory_set("prefs")
+
+    mem0.delete_all.assert_not_called()
+
+
+def test_memory_set_management_before_any_context_switch_is_refused() -> None:
+    ltm = Mem0LongTermMemory.model_construct(
+        ctx=MagicMock(), job_id="job", metric_group=None
+    )
+
+    with pytest.raises(ValueError, match="no partition key in scope"):
+        ltm.get_memory_set("prefs")
 
 
 def test_memory_set_stays_on_its_own_key_after_the_owner_switches() -> None:

--- a/python/flink_agents/runtime/memory/mem0/tests/test_mem0_recording_hook.py
+++ b/python/flink_agents/runtime/memory/mem0/tests/test_mem0_recording_hook.py
@@ -32,7 +32,11 @@ def _make_ltm() -> Mem0LongTermMemory:
     ctx = MagicMock()
     ctx.agent_metric_group = None
     return Mem0LongTermMemory.model_construct(
-        ctx=ctx, job_id="job", key="shared-partition", metric_group=None
+        ctx=ctx,
+        job_id="job",
+        key="shared-partition",
+        metric_group=None,
+        mailbox_thread_checker=lambda: None,
     )
 
 

--- a/python/flink_agents/runtime/python_java_utils.py
+++ b/python/flink_agents/runtime/python_java_utils.py
@@ -385,12 +385,23 @@ def get_long_term_memory(ctx: Any) -> Any:
     return ctx.long_term_memory
 
 
-def to_python_memory_set(name: str) -> MemorySet:
-    """Build a Python ``MemorySet`` from its name. Used by the Java
-    ``Mem0LongTermMemory`` wrapper to forward calls into Python ``Mem0LongTermMemory``,
-    which expects a ``MemorySet`` instance but only reads its ``name`` field.
+def to_python_memory_set(
+    name: str,
+    partition_key: str,
+    observation_id: str = "",
+    observation_suppressed: bool = False,  # noqa: FBT001
+) -> MemorySet:
+    """Build a Python ``MemorySet`` from the fields the Java side holds. Used by the
+    Java ``Mem0LongTermMemory`` wrapper to forward calls into Python
+    ``Mem0LongTermMemory``, which reads the action context off the set rather than
+    off itself, so the context has to travel with each forwarded call.
     """
-    return MemorySet(name=name)
+    return MemorySet(
+        name=name,
+        partition_key=partition_key,
+        observation_id=observation_id,
+        observation_suppressed=observation_suppressed,
+    )
 
 
 def mem0_items_to_java(

--- a/python/flink_agents/runtime/tests/test_python_java_utils.py
+++ b/python/flink_agents/runtime/tests/test_python_java_utils.py
@@ -30,6 +30,7 @@ from flink_agents.runtime.python_java_utils import (
     call_embedding_with_usage,
     convert_to_python_key_text,
     get_python_tool_metadata,
+    to_python_memory_set,
     wrap_to_input_event,
 )
 
@@ -99,3 +100,12 @@ def test_convert_to_python_key_text_uses_python_str() -> None:
 def test_convert_to_python_key_text_does_not_unpickle_explicit_bytes() -> None:
     assert convert_to_python_key_text(b"N.", "explicit") == "b'N.'"
     assert convert_to_python_key_text(b"\x80\x04N.", "explicit") == "b'\\x80\\x04N.'"
+
+
+def test_to_python_memory_set_carries_the_action_context() -> None:
+    memory_set = to_python_memory_set("prefs", "owner", "owner-action", True)
+
+    assert memory_set.name == "prefs"
+    assert memory_set.partition_key == "owner"
+    assert memory_set.observation_id == "owner-action"
+    assert memory_set.observation_suppressed is True

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/memory/Mem0LongTermMemory.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/memory/Mem0LongTermMemory.java
@@ -46,6 +46,12 @@ public class Mem0LongTermMemory implements InteranlBaseLongTermMemory {
     private final PythonResourceAdapter adapter;
     private PyObject pyMem0;
 
+    // Defaults mirror the Python side's own defaults, so a set obtained before any
+    // context switch forwards the same values Python would have used itself.
+    private String partitionKey = "";
+    private String observationId = "";
+    private boolean observationSuppressed;
+
     public Mem0LongTermMemory(PythonResourceAdapter adapter, PyObject pyMem0) {
         this.adapter = adapter;
         this.pyMem0 = pyMem0;
@@ -54,14 +60,20 @@ public class Mem0LongTermMemory implements InteranlBaseLongTermMemory {
     @Override
     public MemorySet getMemorySet(String name) {
         // Mirrors Python's `Mem0LongTermMemory.get_memory_set`: a pure factory that
-        // returns a new MemorySet bound to this ltm; no Python call is needed.
+        // returns a new MemorySet bound to this ltm; no Python call is needed. The
+        // current action context is copied onto the set so that operations forwarded
+        // from a worker thread stay scoped to the action that obtained it.
         MemorySet ms = new MemorySet(name);
         ms.setLtm(this);
+        ms.setActionContext(partitionKey, observationId, observationSuppressed);
         return ms;
     }
 
     @Override
     public boolean deleteMemorySet(String name) {
+        // Takes a name rather than a MemorySet, so it has no bound context and the Python
+        // side uses the key currently in scope. It is therefore only correct on the mailbox
+        // thread, and can target a different key than MemorySet.delete on a same-named set.
         return (Boolean) adapter.callMethod(pyMem0, "delete_memory_set", Map.of("name", name));
     }
 
@@ -149,6 +161,9 @@ public class Mem0LongTermMemory implements InteranlBaseLongTermMemory {
     @Override
     public void switchContext(
             String partitionKey, String observationId, boolean observationSuppressed) {
+        this.partitionKey = partitionKey;
+        this.observationId = observationId;
+        this.observationSuppressed = observationSuppressed;
         adapter.callMethod(
                 pyMem0,
                 "switch_context",
@@ -180,7 +195,23 @@ public class Mem0LongTermMemory implements InteranlBaseLongTermMemory {
     }
 
     private Object buildPyMemorySet(MemorySet memorySet) {
-        return adapter.invoke(TO_PYTHON_MEMORY_SET, memorySet.getName());
+        // Mem0 ignores a falsy agent_id rather than matching on it, so forwarding an
+        // unbound set would widen the operation to every key sharing the job id and set
+        // name, which for a delete means deleting another key's items.
+        if (memorySet.getPartitionKey() == null) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Memory set '%s' is not bound to a partition key. Obtain it with"
+                                    + " getMemorySet inside the action that uses it, rather than"
+                                    + " constructing it directly or reusing one across actions.",
+                            memorySet.getName()));
+        }
+        return adapter.invoke(
+                TO_PYTHON_MEMORY_SET,
+                memorySet.getName(),
+                memorySet.getPartitionKey(),
+                memorySet.getObservationId(),
+                memorySet.isObservationSuppressed());
     }
 
     @SuppressWarnings("unchecked")

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/memory/Mem0LongTermMemory.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/memory/Mem0LongTermMemory.java
@@ -46,6 +46,12 @@ public class Mem0LongTermMemory implements InteranlBaseLongTermMemory {
     private final PythonResourceAdapter adapter;
     private final PyObject pyMem0;
 
+    // Defaults mirror the Python side's own defaults, so a set obtained before any
+    // context switch forwards the same values Python would have used itself.
+    private String partitionKey = "";
+    private String observationId = "";
+    private boolean observationSuppressed;
+
     public Mem0LongTermMemory(PythonResourceAdapter adapter, PyObject pyMem0) {
         this.adapter = adapter;
         this.pyMem0 = pyMem0;
@@ -54,14 +60,20 @@ public class Mem0LongTermMemory implements InteranlBaseLongTermMemory {
     @Override
     public MemorySet getMemorySet(String name) {
         // Mirrors Python's `Mem0LongTermMemory.get_memory_set`: a pure factory that
-        // returns a new MemorySet bound to this ltm; no Python call is needed.
+        // returns a new MemorySet bound to this ltm; no Python call is needed. The
+        // current action context is copied onto the set so that operations forwarded
+        // from a worker thread stay scoped to the action that obtained it.
         MemorySet ms = new MemorySet(name);
         ms.setLtm(this);
+        ms.setActionContext(partitionKey, observationId, observationSuppressed);
         return ms;
     }
 
     @Override
     public boolean deleteMemorySet(String name) {
+        // Takes a name rather than a MemorySet, so it has no bound context and the Python
+        // side uses the key currently in scope. It is therefore only correct on the mailbox
+        // thread, and can target a different key than MemorySet.delete on a same-named set.
         return (Boolean) adapter.callMethod(pyMem0, "delete_memory_set", Map.of("name", name));
     }
 
@@ -149,6 +161,9 @@ public class Mem0LongTermMemory implements InteranlBaseLongTermMemory {
     @Override
     public void switchContext(
             String partitionKey, String observationId, boolean observationSuppressed) {
+        this.partitionKey = partitionKey;
+        this.observationId = observationId;
+        this.observationSuppressed = observationSuppressed;
         adapter.callMethod(
                 pyMem0,
                 "switch_context",
@@ -173,7 +188,23 @@ public class Mem0LongTermMemory implements InteranlBaseLongTermMemory {
     }
 
     private Object buildPyMemorySet(MemorySet memorySet) {
-        return adapter.invoke(TO_PYTHON_MEMORY_SET, memorySet.getName());
+        // Mem0 ignores a falsy agent_id rather than matching on it, so forwarding an
+        // unbound set would widen the operation to every key sharing the job id and set
+        // name, which for a delete means deleting another key's items.
+        if (memorySet.getPartitionKey() == null) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Memory set '%s' is not bound to a partition key. Obtain it with"
+                                    + " getMemorySet inside the action that uses it, rather than"
+                                    + " constructing it directly or reusing one across actions.",
+                            memorySet.getName()));
+        }
+        return adapter.invoke(
+                TO_PYTHON_MEMORY_SET,
+                memorySet.getName(),
+                memorySet.getPartitionKey(),
+                memorySet.getObservationId(),
+                memorySet.isObservationSuppressed());
     }
 
     @SuppressWarnings("unchecked")

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/memory/Mem0LongTermMemory.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/memory/Mem0LongTermMemory.java
@@ -46,9 +46,9 @@ public class Mem0LongTermMemory implements InteranlBaseLongTermMemory {
     private final PythonResourceAdapter adapter;
     private PyObject pyMem0;
 
-    // Defaults mirror the Python side's own defaults, so a set obtained before any
-    // context switch forwards the same values Python would have used itself.
-    private String partitionKey = "";
+    // Null until the first context switch, mirroring the Python side's own default. A
+    // memory set obtained before then carries no key and is refused rather than forwarded.
+    private String partitionKey;
     private String observationId = "";
     private boolean observationSuppressed;
 
@@ -65,7 +65,7 @@ public class Mem0LongTermMemory implements InteranlBaseLongTermMemory {
         // from a worker thread stay scoped to the action that obtained it.
         MemorySet ms = new MemorySet(name);
         ms.setLtm(this);
-        ms.setActionContext(partitionKey, observationId, observationSuppressed);
+        ms.setActionContext(currentPartitionKey(), observationId, observationSuppressed);
         return ms;
     }
 
@@ -74,6 +74,9 @@ public class Mem0LongTermMemory implements InteranlBaseLongTermMemory {
         // Takes a name rather than a MemorySet, so it has no bound context and the Python
         // side uses the key currently in scope. It is therefore only correct on the mailbox
         // thread, and can target a different key than MemorySet.delete on a same-named set.
+        // Checked here so a Java caller gets the failure in Java rather than marshalled
+        // back from Python, which reads the same key on its own side.
+        currentPartitionKey();
         return (Boolean) adapter.callMethod(pyMem0, "delete_memory_set", Map.of("name", name));
     }
 
@@ -196,8 +199,8 @@ public class Mem0LongTermMemory implements InteranlBaseLongTermMemory {
 
     private Object buildPyMemorySet(MemorySet memorySet) {
         // Mem0 ignores a falsy agent_id rather than matching on it, so forwarding an
-        // unbound set would widen the operation to every key sharing the job id and set
-        // name, which for a delete means deleting another key's items.
+        // unbound or empty-keyed set would widen the operation to every key sharing the job
+        // id and set name, which for a delete means deleting another key's items.
         if (memorySet.getPartitionKey() == null) {
             throw new IllegalStateException(
                     String.format(
@@ -206,12 +209,35 @@ public class Mem0LongTermMemory implements InteranlBaseLongTermMemory {
                                     + " constructing it directly or reusing one across actions.",
                             memorySet.getName()));
         }
+        requireNonEmptyPartitionKey(memorySet.getPartitionKey());
         return adapter.invoke(
                 TO_PYTHON_MEMORY_SET,
                 memorySet.getName(),
                 memorySet.getPartitionKey(),
                 memorySet.getObservationId(),
                 memorySet.isObservationSuppressed());
+    }
+
+    /** Returns the partition key in scope, refusing what Mem0 cannot scope an operation to. */
+    private String currentPartitionKey() {
+        if (partitionKey == null) {
+            throw new IllegalStateException(
+                    "Long-term memory has no partition key in scope. Call this from an action"
+                            + " body, which always runs under a partition key, rather than before"
+                            + " the first action has run.");
+        }
+        return requireNonEmptyPartitionKey(partitionKey);
+    }
+
+    private static String requireNonEmptyPartitionKey(String key) {
+        if (key.isEmpty()) {
+            throw new IllegalStateException(
+                    "Long-term memory cannot be scoped to an empty partition key. Mem0 ignores"
+                            + " an empty agent_id, so the operation would reach every key sharing"
+                            + " the job id and set name, and added items would be stored"
+                            + " unattributed. Key the stream by a non-empty value.");
+        }
+        return key;
     }
 
     @SuppressWarnings("unchecked")

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/memory/Mem0LongTermMemory.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/memory/Mem0LongTermMemory.java
@@ -45,6 +45,7 @@ public class Mem0LongTermMemory implements InteranlBaseLongTermMemory {
 
     private final PythonResourceAdapter adapter;
     private PyObject pyMem0;
+    private final Runnable mailboxThreadChecker;
 
     // Null until the first context switch, mirroring the Python side's own default. A
     // memory set obtained before then carries no key and is refused rather than forwarded.
@@ -52,9 +53,11 @@ public class Mem0LongTermMemory implements InteranlBaseLongTermMemory {
     private String observationId = "";
     private boolean observationSuppressed;
 
-    public Mem0LongTermMemory(PythonResourceAdapter adapter, PyObject pyMem0) {
+    public Mem0LongTermMemory(
+            PythonResourceAdapter adapter, PyObject pyMem0, Runnable mailboxThreadChecker) {
         this.adapter = adapter;
         this.pyMem0 = pyMem0;
+        this.mailboxThreadChecker = mailboxThreadChecker;
     }
 
     @Override
@@ -62,7 +65,9 @@ public class Mem0LongTermMemory implements InteranlBaseLongTermMemory {
         // Mirrors Python's `Mem0LongTermMemory.get_memory_set`: a pure factory that
         // returns a new MemorySet bound to this ltm; no Python call is needed. The
         // current action context is copied onto the set so that operations forwarded
-        // from a worker thread stay scoped to the action that obtained it.
+        // from a worker thread stay scoped to the action that obtained it, which is
+        // only the right context to copy when the caller is the action itself.
+        mailboxThreadChecker.run();
         MemorySet ms = new MemorySet(name);
         ms.setLtm(this);
         ms.setActionContext(currentPartitionKey(), observationId, observationSuppressed);
@@ -74,8 +79,9 @@ public class Mem0LongTermMemory implements InteranlBaseLongTermMemory {
         // Takes a name rather than a MemorySet, so it has no bound context and the Python
         // side uses the key currently in scope. It is therefore only correct on the mailbox
         // thread, and can target a different key than MemorySet.delete on a same-named set.
-        // Checked here so a Java caller gets the failure in Java rather than marshalled
-        // back from Python, which reads the same key on its own side.
+        // Both checks run here so a Java caller gets the failure in Java rather than
+        // marshalled back from Python, which repeats them on its own side.
+        mailboxThreadChecker.run();
         currentPartitionKey();
         return (Boolean) adapter.callMethod(pyMem0, "delete_memory_set", Map.of("name", name));
     }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PythonBridgeManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PythonBridgeManager.java
@@ -193,7 +193,7 @@ class PythonBridgeManager implements AutoCloseable {
                 initPythonActionExecutor(agentPlan, jobIdentifier);
             }
             if (mem0Configured) {
-                wireLongTermMemory(agentPlan);
+                wireLongTermMemory(agentPlan, mailboxThreadChecker);
             }
             initialized = true;
         }
@@ -240,7 +240,7 @@ class PythonBridgeManager implements AutoCloseable {
      * {@code create_flink_runner_context} already initialised via {@code _init_long_term_memory})
      * and wrap it as a Java {@link Mem0LongTermMemory}.
      */
-    private void wireLongTermMemory(AgentPlan agentPlan) {
+    private void wireLongTermMemory(AgentPlan agentPlan, Runnable mailboxThreadChecker) {
         PyObject pyCtx = pythonActionExecutor.getPythonRunnerContext();
         Object pyLtm = pythonInterpreter.invoke("python_java_utils.get_long_term_memory", pyCtx);
         if (pyLtm == null) {
@@ -254,7 +254,9 @@ class PythonBridgeManager implements AutoCloseable {
                             LongTermMemoryOptions.Mem0.EMBEDDING_MODEL_SETUP.getKey(),
                             LongTermMemoryOptions.Mem0.VECTOR_STORE.getKey()));
         }
-        longTermMemory = new Mem0LongTermMemory(pythonResourceAdapter, (PyObject) pyLtm);
+        longTermMemory =
+                new Mem0LongTermMemory(
+                        pythonResourceAdapter, (PyObject) pyLtm, mailboxThreadChecker);
         MemoryEventSettings settings = MemoryEventSettings.from(agentPlan.getConfigData());
         longTermMemory.configureObservation(
                 settings.generate(MemoryEventSettings.MemoryOp.LONG_TERM_UPDATE),

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/memory/Mem0LongTermMemoryTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/memory/Mem0LongTermMemoryTest.java
@@ -30,6 +30,7 @@ import pemja.core.object.PyObject;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -51,7 +52,7 @@ public class Mem0LongTermMemoryTest {
     @BeforeEach
     void setUp() {
         mocks = MockitoAnnotations.openMocks(this);
-        ltm = new Mem0LongTermMemory(mockAdapter, mockPyMem0);
+        ltm = new Mem0LongTermMemory(mockAdapter, mockPyMem0, () -> {});
         // Operations refuse an absent or empty key, so every test that does not manage its
         // own context runs under the key an action would have switched to.
         ltm.switchContext("a-key", "an-action", false);
@@ -282,7 +283,7 @@ public class Mem0LongTermMemoryTest {
 
     @Test
     void testMemorySetIsRefusedBeforeAnyContextSwitch() {
-        Mem0LongTermMemory fresh = new Mem0LongTermMemory(mockAdapter, mockPyMem0);
+        Mem0LongTermMemory fresh = new Mem0LongTermMemory(mockAdapter, mockPyMem0, () -> {});
 
         assertThatThrownBy(() -> fresh.getMemorySet("notes"))
                 .isInstanceOf(IllegalStateException.class)
@@ -304,5 +305,50 @@ public class Mem0LongTermMemoryTest {
                         eq("owner"),
                         eq("owner-action"),
                         eq(false));
+    }
+
+    @Test
+    void testMemorySetManagementIsRefusedOffTheMailboxThread() {
+        Mem0LongTermMemory guarded =
+                new Mem0LongTermMemory(
+                        mockAdapter,
+                        mockPyMem0,
+                        () -> {
+                            throw new IllegalStateException(
+                                    "Expected to be running on the task mailbox thread, but was"
+                                            + " not.");
+                        });
+        // No context switch: with no key in scope, only a checker that runs before the key
+        // is read can produce the mailbox-thread message. That pins the intended order,
+        // because off the mailbox thread the key read is itself unreliable.
+
+        assertThatThrownBy(() -> guarded.getMemorySet("notes"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("task mailbox thread");
+        assertThatThrownBy(() -> guarded.deleteMemorySet("notes"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("task mailbox thread");
+        verify(mockAdapter, never()).callMethod(eq(mockPyMem0), eq("delete_memory_set"), any());
+    }
+
+    @Test
+    void testSetScopedOperationsRunWithoutTheMailboxThread() {
+        // A set carries the context it was obtained under, so operations on it are safe to
+        // forward to a worker thread. Gating them would break durable async execution.
+        AtomicInteger checkerCalls = new AtomicInteger();
+        Mem0LongTermMemory counting =
+                new Mem0LongTermMemory(mockAdapter, mockPyMem0, checkerCalls::incrementAndGet);
+        counting.switchContext("a-key", "an-action", false);
+        MemorySet ms = counting.getMemorySet("notes");
+        // Guards the assertion below from passing vacuously on a checker that never runs.
+        assertThat(checkerCalls.get()).isOne();
+        checkerCalls.set(0);
+
+        counting.add(ms, List.of("hello"), null);
+        counting.get(ms, null, null, null);
+        counting.delete(ms, null);
+        counting.search(ms, "query", 5, null, Map.of());
+
+        assertThat(checkerCalls.get()).isZero();
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/memory/Mem0LongTermMemoryTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/memory/Mem0LongTermMemoryTest.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -51,7 +52,8 @@ public class Mem0LongTermMemoryTest {
     void setUp() {
         mocks = MockitoAnnotations.openMocks(this);
         ltm = new Mem0LongTermMemory(mockAdapter, mockPyMem0);
-        when(mockAdapter.invoke(eq("python_java_utils.to_python_memory_set"), any()))
+        when(mockAdapter.invoke(
+                        eq("python_java_utils.to_python_memory_set"), any(), any(), any(), any()))
                 .thenReturn(mockPyMemorySet);
     }
 
@@ -235,5 +237,33 @@ public class Mem0LongTermMemoryTest {
 
         verify(mockAdapter).callMethod(mockPyMem0, "close", Map.of());
         verify(mockPyMem0).close();
+    }
+
+    @Test
+    void testUnboundSetIsRefusedRatherThanWidened() {
+        MemorySet unbound = new MemorySet("notes");
+        unbound.setLtm(ltm);
+
+        assertThatThrownBy(() -> ltm.add(unbound, List.of("hello"), null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not bound to a partition key");
+        verify(mockAdapter, never()).callMethod(eq(mockPyMem0), eq("add"), any());
+    }
+
+    @Test
+    void testForwardedSetCarriesTheContextItWasObtainedIn() throws Exception {
+        ltm.switchContext("owner", "owner-action", false);
+        MemorySet ms = ltm.getMemorySet("notes");
+
+        ltm.switchContext("other", "other-action", true);
+        ltm.add(ms, List.of("hello"), null);
+
+        verify(mockAdapter)
+                .invoke(
+                        eq("python_java_utils.to_python_memory_set"),
+                        eq("notes"),
+                        eq("owner"),
+                        eq("owner-action"),
+                        eq(false));
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/memory/Mem0LongTermMemoryTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/memory/Mem0LongTermMemoryTest.java
@@ -32,8 +32,10 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -49,7 +51,8 @@ public class Mem0LongTermMemoryTest {
     void setUp() {
         mocks = MockitoAnnotations.openMocks(this);
         ltm = new Mem0LongTermMemory(mockAdapter, mockPyMem0);
-        when(mockAdapter.invoke(eq("python_java_utils.to_python_memory_set"), any()))
+        when(mockAdapter.invoke(
+                        eq("python_java_utils.to_python_memory_set"), any(), any(), any(), any()))
                 .thenReturn(mockPyMemorySet);
     }
 
@@ -219,5 +222,33 @@ public class Mem0LongTermMemoryTest {
                         eq("drain_ltm_observation_records"),
                         eq(Map.of("key", "k1", "observation_id", "observation-1")));
         verify(mockAdapter).callMethod(eq(mockPyMem0), eq("close"), eq(Map.of()));
+    }
+
+    @Test
+    void testUnboundSetIsRefusedRatherThanWidened() {
+        MemorySet unbound = new MemorySet("notes");
+        unbound.setLtm(ltm);
+
+        assertThatThrownBy(() -> ltm.add(unbound, List.of("hello"), null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not bound to a partition key");
+        verify(mockAdapter, never()).callMethod(eq(mockPyMem0), eq("add"), any());
+    }
+
+    @Test
+    void testForwardedSetCarriesTheContextItWasObtainedIn() throws Exception {
+        ltm.switchContext("owner", "owner-action", false);
+        MemorySet ms = ltm.getMemorySet("notes");
+
+        ltm.switchContext("other", "other-action", true);
+        ltm.add(ms, List.of("hello"), null);
+
+        verify(mockAdapter)
+                .invoke(
+                        eq("python_java_utils.to_python_memory_set"),
+                        eq("notes"),
+                        eq("owner"),
+                        eq("owner-action"),
+                        eq(false));
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/memory/Mem0LongTermMemoryTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/memory/Mem0LongTermMemoryTest.java
@@ -52,6 +52,9 @@ public class Mem0LongTermMemoryTest {
     void setUp() {
         mocks = MockitoAnnotations.openMocks(this);
         ltm = new Mem0LongTermMemory(mockAdapter, mockPyMem0);
+        // Operations refuse an absent or empty key, so every test that does not manage its
+        // own context runs under the key an action would have switched to.
+        ltm.switchContext("a-key", "an-action", false);
         when(mockAdapter.invoke(
                         eq("python_java_utils.to_python_memory_set"), any(), any(), any(), any()))
                 .thenReturn(mockPyMemorySet);
@@ -247,7 +250,43 @@ public class Mem0LongTermMemoryTest {
         assertThatThrownBy(() -> ltm.add(unbound, List.of("hello"), null))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("not bound to a partition key");
-        verify(mockAdapter, never()).callMethod(eq(mockPyMem0), eq("add"), any());
+        verify(mockAdapter, never())
+                .invoke(eq("python_java_utils.to_python_memory_set"), any(), any(), any(), any());
+    }
+
+    @Test
+    void testEmptyKeyedSetIsRefusedRatherThanWidened() {
+        MemorySet emptyKeyed = new MemorySet("notes");
+        emptyKeyed.setLtm(ltm);
+        emptyKeyed.setActionContext("", "an-action", false);
+
+        assertThatThrownBy(() -> ltm.add(emptyKeyed, List.of("hello"), null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("empty partition key");
+        verify(mockAdapter, never())
+                .invoke(eq("python_java_utils.to_python_memory_set"), any(), any(), any(), any());
+    }
+
+    @Test
+    void testMemorySetManagementIsRefusedForAnEmptyKey() {
+        ltm.switchContext("", "an-action", false);
+
+        assertThatThrownBy(() -> ltm.getMemorySet("notes"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("empty partition key");
+        assertThatThrownBy(() -> ltm.deleteMemorySet("notes"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("empty partition key");
+        verify(mockAdapter, never()).callMethod(eq(mockPyMem0), eq("delete_memory_set"), any());
+    }
+
+    @Test
+    void testMemorySetIsRefusedBeforeAnyContextSwitch() {
+        Mem0LongTermMemory fresh = new Mem0LongTermMemory(mockAdapter, mockPyMem0);
+
+        assertThatThrownBy(() -> fresh.getMemorySet("notes"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("no partition key in scope");
     }
 
     @Test

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperatorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperatorTest.java
@@ -804,7 +804,7 @@ public class ActionExecutionOperatorTest {
         private RuntimeException drainFailure;
 
         private RecordingMem0LongTermMemory() {
-            super(null, null);
+            super(null, null, () -> {});
         }
 
         @Override


### PR DESCRIPTION
Linked issue: #998

### Purpose of change

`Mem0LongTermMemory` is shared across partition keys and holds the current key, observation id and suppression flag in mutable fields. `switch_context` writes them on the mailbox thread before each action, while `add`, `get`, `search` and `delete` can run on a worker thread when an action passes them to `durable_execute_async`, and those operations read the fields themselves. The key they see is whatever the mailbox thread wrote most recently, not the key of the action that submitted the work.

The key is the isolation boundary rather than observability metadata: it reaches Mem0 as `agent_id`, and two keys sharing a job id and a memory set name are separated by `agent_id` alone. Reading the wrong one means one key's items land in, or are read from, another key's set. The observation id and suppression flag come from the same fields, so observations can be misattributed independently.

This binds the partition key, observation id and suppression flag onto the `MemorySet` when it is created, and has the four operations take them from the set. The four already receive `memory_set` as their first parameter, so nothing new is threaded through. A set is consequently scoped to one action and must not be held across actions.

Java is covered in the same change rather than separately. Its operations all delegate into the same Python object, and the bridge rebuilt the Python set from its name alone, so once the Python side sources the key from the set, a Java-originated call would arrive without one. The Java wrapper now records the context when it switches and carries it across the bridge, and `to_python_memory_set` requires the key rather than defaulting it.

#### Refusing a key Mem0 cannot isolate

Mem0 tests `agent_id` for truthiness instead of matching on it, so both an unbound key and an empty one would drop the filter entirely and widen an operation to every key sharing the job id and set name, which for a delete would remove another key's items. An `add` under such a key would be worse than mis-filtered: Mem0 omits `agent_id` from the stored metadata, leaving the item unattributed to any key.

The empty string is a legal Flink key, reachable by keying a stream on a string field that can be empty, so both states are now refused at the point of use. They carry separate messages because the remedies differ. Encoding the empty key instead was rejected: keeping already-stored memories readable requires the mapping to be the identity on non-empty keys, which leaves no unoccupied non-empty value for the empty key to take. Reserving a sentinel only moves which key fails, since a Flink key arrives as `String.valueOf(key)` and can be any string. A collision-free encoding would therefore have to transform every key and orphan every memory already written.

The unbound state is now `None` and `null` in both languages. Both previously defaulted the memory's own key to the empty string, so neither could distinguish an absent context from the empty key, and the Java wrapper additionally stamped that value onto a `MemorySet` whose own default was null, so an unbound set originating in Java arrived in Python looking bound and passed both guards.

Validation deliberately stays out of `switch_context`, so a job carrying an empty key still runs unless it actually uses long-term memory.

#### Scoping the management operations to the mailbox thread

Binding context onto the set makes the four set-scoped operations safe on a worker thread, but obtaining or deleting a set still reads the key currently in scope. Submitting either to `durable_execute_async` therefore preserved the same cross-key race one call earlier. `getMemorySet` and `deleteMemorySet` now run the runner context's mailbox-thread check, the same one `getResource` uses. The four set-scoped operations stay unchecked, since being usable from a worker thread is the point of binding the context to the set.

The check fires in Java as well as Python. Java's `getMemorySet` is a pure factory that stamps the Java-side fields and never crosses into Python, so a Python-only check would leave Java agents unguarded. Python receives the checker through the constructor rather than through a new method on the `RunnerContext` ABC, because Java's `checkMailboxThread` lives on the runtime class rather than on the API interface, and adding one to the Python ABC would put a user-facing API method there with no Java counterpart.

`delete_memory_set` keeps its name-based signature. It has no bound context and applies to the key currently in scope, which the mailbox-thread check now makes correct, so closing the gap no longer requires a public signature change. Its documentation records that it can target a different key than `MemorySet.delete` on a same-named set.

#### CI

The cross-language `Mem0LongTermMemoryTest` and `SkillsIntegrationTest` both skip themselves unless `ACTION_API_KEY` is set. The python-it job passes the secret; the java-it and cross-language jobs set only `LOG_LEVEL`, so both Java suites went green with every case skipped. Both jobs now receive it. Repository secrets are still withheld from `pull_request` runs on forks, so this restores the coverage for push builds and same-repository pull requests, matching what python-it already gets.

### Tests

| Test | What it pins |
|---|---|
| `test_memory_set_stays_on_its_own_key_after_the_owner_switches` | all four operations keep the set's key after the owner switches |
| `test_observations_stay_with_the_action_that_obtained_the_set` | observation ownership follows the set for add, get, search and delete |
| `test_suppression_follows_the_set_not_the_current_context` | the set's own suppression flag decides, in both directions |
| `test_unbound_memory_set_is_refused_rather_than_widened` | all four operations raise, and none reaches Mem0 |
| `test_empty_partition_key_is_refused_by_set_operations` | an empty key is refused on all four, and none reaches Mem0 |
| `test_empty_partition_key_is_refused_by_memory_set_management` | obtaining and deleting a set are refused under an empty key |
| `test_memory_set_management_before_any_context_switch_is_refused` | the unbound state is refused rather than treated as a key |
| `test_memory_set_management_is_refused_off_the_mailbox_thread` | both management operations run the check |
| `test_set_scoped_operations_run_without_the_mailbox_thread` | the four set-scoped operations stay usable off the mailbox thread |
| `testForwardedSetCarriesTheContextItWasObtainedIn` | the Java bridge forwards the context bound at creation |
| `testUnboundSetIsRefusedRatherThanWidened` | the Java guard throws before forwarding |
| `testMemorySetIsRefusedBeforeAnyContextSwitch` | the unbound state is refused in Java rather than treated as a key |
| `test_to_python_memory_set_carries_the_action_context` | the bridge helper carries all four fields, not just the name |
| `testEmptyKeyedSetIsRefusedRatherThanWidened` | the Java guard refuses an empty key before marshalling the set |
| `testMemorySetManagementIsRefusedForAnEmptyKey` | obtaining and deleting are refused under an empty key in Java |
| `testMemorySetManagementIsRefusedOffTheMailboxThread` | both Java management operations run the check |
| `testSetScopedOperationsRunWithoutTheMailboxThread` | the four Java set-scoped operations stay usable off the mailbox thread |

`test_switch_context` and `test_context_switch_changes_observation_owner_and_current_suppression` reused a single set across a context switch and expected the current key to apply. They now assert that a set keeps its own key, and obtain one per context. `test_empty_context_key_is_used_consistently_for_mem0_operations` asserted that an empty `agent_id` is forwarded to Mem0, recording the widening as intended. It is replaced by `test_empty_partition_key_is_refused_by_set_operations`, which asserts refusal and that Mem0 is never reached.

Every assertion was checked against a deliberately reverted implementation. Reverting the suppression binding, the observation id binding, any of the refusal guards, the key binding itself, either mailbox check, or the order in which the thread check precedes the key check each leaves at least one test failing.

126 Python tests pass across `api/memory`, `runtime/memory` and `runtime/tests`. 80 Java tests pass across `MemorySetTest`, the runtime `Mem0LongTermMemoryTest`, `MemoryRefTest`, `TestMemoryObservationFlush`, `ActionTaskContextManagerTest` and `ActionExecutionOperatorTest`. `ruff check` and `spotless:check` are clean, and the touched Python files are `ruff format` clean.

The long-term memory e2e test is gated on `ACTION_API_KEY` and needs a Flink cluster plus a local Ollama embedding model, so end-to-end coverage comes from CI on push builds.

### API

`MemorySet` gains three fields in both languages, excluded from serialization like the existing long term memory back-reference. Java adds `setActionContext` and three getters. `BaseLongTermMemory.get_memory_set` / `getMemorySet` and `delete_memory_set` / `deleteMemorySet` keep their signatures and gain a documented per-action, mailbox-thread scope. The runtime bridge helper `to_python_memory_set` now requires the partition key; its only caller is the Java wrapper, and a version mismatch fails loudly with a missing-argument error rather than silently.

`Mem0LongTermMemory` gains a mailbox-thread checker parameter in both languages. It is a runtime class rather than public API, and the public `RunnerContext` interface is unchanged in both languages.

Existing code that obtains a memory set inside the action using it is unaffected. Code that cached one across actions was already reading whichever key happened to be current, and now raises or stays on its original key instead. Code that obtains or deletes a memory set inside a `DurableCallable` or a `durable_execute_async` callable now raises on Python and on Java under JDK 21 and above; under JDK 11 the callable runs inline on the mailbox thread, so it does not raise there yet. A job keyed on a value that can be the empty string now raises when it uses long-term memory, rather than silently sharing one memory set across every key.

### Documentation

- [ ] `doc-needed`
- [ ] `doc-not-needed`
- [x] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

Generated-by: Claude Code 2.1.251 (Claude Opus 5)

The first commit on the branch predates the model half of that convention and carries `Generated-by: Claude Code 2.1.228`.
