### PR TITLE
[docs] Improve the documentation index page and build instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,11 +22,15 @@ $ docker run -v $(pwd):/src -p 1313:1313 jakejarvis/hugo-extended:latest server 
 
 #### Local Hugo installation:
 
-Make sure you have installed [Hugo](https://gohugo.io/getting-started/installing/) on your system.
+`setup_hugo.sh` installs Hugo 0.110.0, the version the docs build is pinned to. A newer Hugo release removed an internal template the pinned `hugo-book` theme calls, so building with a current Hugo fails with `no such template "_internal/google_analytics_async.html"`.
+
+On Linux, install it with:
 
 ```sh
 $ ./setup_hugo.sh
 ```
+
+`setup_hugo.sh` downloads the Linux binary only. On other platforms, install the extended Hugo 0.110.0 from the [Hugo releases page](https://github.com/gohugoio/hugo/releases/tag/v0.110.0) yourself.
 
 Then build the docs from source:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ On Linux, install it with:
 $ ./setup_hugo.sh
 ```
 
-`setup_hugo.sh` downloads the Linux binary only. On other platforms, install the extended Hugo 0.110.0 from the [Hugo releases page](https://github.com/gohugoio/hugo/releases/tag/v0.110.0) yourself.
+`setup_hugo.sh` downloads a Linux binary, x86_64 or ARM64. On other platforms, install the extended Hugo 0.110.0 from the [Hugo releases page](https://github.com/gohugoio/hugo/releases/tag/v0.110.0) yourself.
 
 Then build the docs from source:
 

--- a/docs/content.zh/_index.md
+++ b/docs/content.zh/_index.md
@@ -41,7 +41,7 @@ under the License.
 
 ### Community Sync
 
-我们每周会举行一次在线同步会议，欢迎所有人参与。请查看此 [GitHub 讨论页面](https://github.com/apache/flink-agents/discussions/66) 获取下次会议的时间表、议程以及往期会议记录。
+我们每周会举行一次在线同步会议，欢迎所有人参与。请查看此 [GitHub 讨论页面](https://github.com/apache/flink-agents/discussions/419) 获取下次会议的时间表、议程以及往期会议记录。
 
 {{< /columns >}}
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -30,6 +30,18 @@ under the License.
 If you’re interested in playing around with Flink Agents, check out our [get started documentation]({{< ref "docs/get-started/overview" >}}). 
 It provides a step by step introduction on how to install Flink Agents and build agents with it.
 
+### Quickstart
+
+* [Workflow Agent]({{< ref "docs/get-started/quickstart/workflow_agent" >}}) - Define agent logic as an explicit event-driven workflow
+* [ReAct Agent]({{< ref "docs/get-started/quickstart/react_agent" >}}) - Let the model plan and call tools in a reason-act loop
+* [YAML Agent]({{< ref "docs/get-started/quickstart/yaml_agent" >}}) - Declare an agent without writing code
+
+### Build and Operate
+
+* [Chat Models]({{< ref "docs/development/chat_models" >}}), [Tools]({{< ref "docs/development/tool_use" >}}) and [Memory]({{< ref "docs/development/memory/overview" >}}) - The building blocks of an agent
+* [Integrate with Flink]({{< ref "docs/development/integrate_with_flink" >}}) - Run an agent inside a Flink job
+* [Deployment]({{< ref "docs/operations/deployment" >}}) and [Monitoring]({{< ref "docs/operations/monitoring" >}}) - Take an agent to production
+
 <--->
 
 ## Get Help with Flink Agents

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -34,7 +34,7 @@ It provides a step by step introduction on how to install Flink Agents and build
 
 * [Workflow Agent]({{< ref "docs/get-started/quickstart/workflow_agent" >}}) - Define agent logic as an explicit event-driven workflow
 * [ReAct Agent]({{< ref "docs/get-started/quickstart/react_agent" >}}) - Let the model plan and call tools in a reason-act loop
-* [YAML Agent]({{< ref "docs/get-started/quickstart/yaml_agent" >}}) - Declare an agent without writing code
+* [YAML Agent]({{< ref "docs/get-started/quickstart/yaml_agent" >}}) - Configure an agent declaratively in YAML
 
 ### Build and Operate
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -56,7 +56,7 @@ See the [Apache Flink website](https://flink.apache.org/what-is-flink/community/
 
 ### Community Sync
 
-There is a weekly online sync. Everyone is welcome to join. Please find the schedule, agenda for the next sync, and records of previous syncs in this [github discussion page](https://github.com/apache/flink-agents/discussions/66).
+There is a weekly online sync. Everyone is welcome to join. Please find the schedule, agenda for the next sync, and records of previous syncs in this [github discussion page](https://github.com/apache/flink-agents/discussions/419).
 
 {{< /columns >}}
 

--- a/docs/setup_hugo.sh
+++ b/docs/setup_hugo.sh
@@ -18,8 +18,13 @@
 ################################################################################
 
 # setup hugo
-HUGO_REPO=https://github.com/gohugoio/hugo/releases/download/v0.110.0/hugo_extended_0.110.0_Linux-64bit.tar.gz
-HUGO_ARTIFACT=hugo_extended_0.110.0_Linux-64bit.tar.gz
+case "$(uname -m)" in
+	x86_64)  HUGO_ARCH=Linux-64bit ;;
+	aarch64) HUGO_ARCH=linux-arm64 ;;
+	*) echo "No Hugo binary for architecture $(uname -m)" ; exit 1 ;;
+esac
+HUGO_ARTIFACT=hugo_extended_0.110.0_${HUGO_ARCH}.tar.gz
+HUGO_REPO=https://github.com/gohugoio/hugo/releases/download/v0.110.0/${HUGO_ARTIFACT}
 if ! curl --fail -OL $HUGO_REPO ; then
 	echo "Failed to download Hugo binary"
 	exit 1


### PR DESCRIPTION
Linked issue: #1017

### Purpose of change

Four small documentation fixes, all under `docs/`.

**1. The index page left column is nearly empty.** The `columns` shortcode renders both halves as flex items, so they stretch to the height of the taller one. The left "Try Flink Agents" column held a single sentence against the right column's Slack and Community Sync sections, leaving about 260px of blank space above the closing paragraph.

Two short link lists now fill it, one for the three quickstart agents and one for the main development and operations pages. The columns end within about 15px of each other, and the docs root gets real navigation instead of a single link. The Apache Flink documentation index lists its tutorials the same way.

**2. The community sync link points at the 2025 thread.** [Discussion 66](https://github.com/apache/flink-agents/discussions/66) now opens with "This page is outdated" and redirects to [discussion 419](https://github.com/apache/flink-agents/discussions/419), which carries the current schedule, agenda and minutes. Updated on both the English and Chinese index pages.

**3. `docs/README.md` does not name the required Hugo version.** `setup_hugo.sh` pins extended Hugo 0.110.0, but the README only links the generic install page. A newer Hugo removed an internal template the pinned `hugo-book` theme calls, so a contributor who installs a current Hugo gets `no such template "_internal/google_analytics_async.html"` with no hint why. The README now names the version, that failure, and where to get the binary on platforms the script does not cover.

**4. `setup_hugo.sh` installs an x86_64 binary on every Linux host.** It hard-coded `hugo_extended_0.110.0_Linux-64bit.tar.gz`, the legacy name for the amd64 build, so Linux ARM64 got a binary that cannot run. The script now selects `Linux-64bit` or `linux-arm64` from `uname -m`, and exits naming the architecture when neither matches.

### Tests

Built the site locally with extended Hugo 0.110.0.

- Build clean: 48 pages, no errors or warnings.
- All 26 docs links on the rendered index resolve to a built page, including the nine new ones.
- Compared against a render of the unmodified page, the blank area is gone.
- No `discussions/66` reference remains under `docs/content` or `docs/content.zh`.
- A current Hugo reproduces the `no such template` failure named in the README.
- `setup_hugo.sh` passes `bash -n` and `shellcheck`. `x86_64` selects `Linux-64bit`, `aarch64` selects `linux-arm64`, anything else exits 1. Both artifact URLs return 200 at the sizes the release lists.

The ARM64 binary itself was not executed, as no ARM64 Linux host was available.

### API

No public API change. Documentation only.

### Documentation

- [ ] `doc-needed`
- [ ] `doc-not-needed`
- [X] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [X] Yes
- [ ] No

Generated-by: Claude Code 2.1.233 (Claude Opus 5)
