### PR TITLE
[docs] Improve the documentation index page and build instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,11 +22,15 @@ $ docker run -v $(pwd):/src -p 1313:1313 jakejarvis/hugo-extended:latest server 
 
 #### Local Hugo installation:
 
-Make sure you have installed [Hugo](https://gohugo.io/getting-started/installing/) on your system.
+The build requires the *extended* version of Hugo 0.110.0, which is what `setup_hugo.sh` installs. A newer Hugo release removed the internal template that the pinned `hugo-book` theme calls, so building with a current version fails with `no such template "_internal/google_analytics_async.html"`.
+
+On Linux, install it with:
 
 ```sh
 $ ./setup_hugo.sh
 ```
+
+`setup_hugo.sh` downloads the Linux binary only. On other platforms, install the extended Hugo 0.110.0 from the [Hugo releases page](https://github.com/gohugoio/hugo/releases/tag/v0.110.0) yourself.
 
 Then build the docs from source:
 

--- a/docs/content.zh/_index.md
+++ b/docs/content.zh/_index.md
@@ -41,7 +41,7 @@ under the License.
 
 ### Community Sync
 
-我们每周会举行一次在线同步会议，欢迎所有人参与。请查看此 [GitHub 讨论页面](https://github.com/apache/flink-agents/discussions/66) 获取下次会议的时间表、议程以及往期会议记录。
+我们每周会举行一次在线同步会议，欢迎所有人参与。请查看此 [GitHub 讨论页面](https://github.com/apache/flink-agents/discussions/419) 获取下次会议的时间表、议程以及往期会议记录。
 
 {{< /columns >}}
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -30,6 +30,18 @@ under the License.
 If you’re interested in playing around with Flink Agents, check out our [get started documentation]({{< ref "docs/get-started/overview" >}}). 
 It provides a step by step introduction on how to install Flink Agents and build agents with it.
 
+### Quickstart
+
+* [Workflow Agent]({{< ref "docs/get-started/quickstart/workflow_agent" >}}) - Define agent logic as an explicit event-driven workflow
+* [ReAct Agent]({{< ref "docs/get-started/quickstart/react_agent" >}}) - Let the model plan and call tools in a reason-act loop
+* [YAML Agent]({{< ref "docs/get-started/quickstart/yaml_agent" >}}) - Declare an agent without writing code
+
+### Build and Operate
+
+* [Chat Models]({{< ref "docs/development/chat_models" >}}), [Tools]({{< ref "docs/development/tool_use" >}}) and [Memory]({{< ref "docs/development/memory/overview" >}}) - The building blocks of an agent
+* [Integrate with Flink]({{< ref "docs/development/integrate_with_flink" >}}) - Run an agent inside a Flink job
+* [Deployment]({{< ref "docs/operations/deployment" >}}) and [Monitoring]({{< ref "docs/operations/monitoring" >}}) - Take an agent to production
+
 <--->
 
 ## Get Help with Flink Agents

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -56,7 +56,7 @@ See the [Apache Flink website](https://flink.apache.org/what-is-flink/community/
 
 ### Community Sync
 
-There is a weekly online sync. Everyone is welcome to join. Please find the schedule, agenda for the next sync, and records of previous syncs in this [github discussion page](https://github.com/apache/flink-agents/discussions/66).
+There is a weekly online sync. Everyone is welcome to join. Please find the schedule, agenda for the next sync, and records of previous syncs in this [github discussion page](https://github.com/apache/flink-agents/discussions/419).
 
 {{< /columns >}}
 


### PR DESCRIPTION
Linked issue: #1017

### Purpose of change

Three fixes to the documentation, grouped because they are all small and touch only `docs/`. This is the `release-0.3` counterpart of #1018 on `main`.

**1. The index page left column is nearly empty.** The page splits into two columns through the `columns` shortcode. The left "Try Flink Agents" column held a single sentence, while the right "Get Help with Flink Agents" column carries the Slack and Community Sync sections. The shortcode renders both as flex items, so they stretch to the height of the taller one and the closing "developed under the umbrella of Apache Flink" paragraph sits below both. The left column ended about 260px above that paragraph, leaving a large blank area in the middle of the landing page.

This adds two short link lists to the left column, one for the three quickstart agents and one for the main development and operations pages. The columns now end within about 15px of each other, and the docs root offers real navigation instead of a single link. This follows the Apache Flink documentation index, which lists its tutorials as a bulleted list with a one line description each.

**2. The community sync link points at the 2025 thread.** The page links to [discussion 66](https://github.com/apache/flink-agents/discussions/66), which covers the 2025 syncs and now opens with "This page is outdated. Please find information about the latest community syncs at: #419". The current schedule, agenda and minutes live in [discussion 419](https://github.com/apache/flink-agents/discussions/419). The link is updated on both the English and Chinese index pages so readers reach the live thread directly.

**3. `docs/README.md` does not name the required Hugo version.** It links the generic Hugo install page and says to make sure Hugo is installed. `setup_hugo.sh` pins the extended Hugo 0.110.0, and a newer Hugo release removed the internal template that the pinned `hugo-book` theme calls in `layouts/404.html` and `layouts/partials/docs/html-head.html`. A contributor who installs a current Hugo gets `no such template "_internal/google_analytics_async.html"` with no indication of why. The README now states the required version and that failure, and notes that `setup_hugo.sh` downloads the Linux binary only.

### Tests

Built the site with Hugo 0.110.0 extended and rendered the index locally.

- No errors or warnings in the build output.
- All nine new links resolve and return 200.
- Confirmed against a render of the unmodified page that the blank area is gone.
- No `discussions/66` reference remains under `docs/content` or `docs/content.zh`.
- The `no such template` failure was reproduced on a current Hugo before writing the README note.

### API

No public API change. Documentation only.

### Documentation

- [ ] `doc-needed`
- [ ] `doc-not-needed`
- [X] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [X] Yes
- [ ] No

Generated-by: Claude Code 2.1.233 (Claude Opus 5)
