### PR TITLE
[hotfix][docs] Point the community sync link at the 2026 discussion

### DIFF
--- a/docs/content.zh/_index.md
+++ b/docs/content.zh/_index.md
@@ -41,7 +41,7 @@ under the License.
 
 ### Community Sync
 
-我们每周会举行一次在线同步会议，欢迎所有人参与。请查看此 [GitHub 讨论页面](https://github.com/apache/flink-agents/discussions/66) 获取下次会议的时间表、议程以及往期会议记录。
+我们每周会举行一次在线同步会议，欢迎所有人参与。请查看此 [GitHub 讨论页面](https://github.com/apache/flink-agents/discussions/419) 获取下次会议的时间表、议程以及往期会议记录。
 
 {{< /columns >}}
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -44,7 +44,7 @@ See the [Apache Flink website](https://flink.apache.org/what-is-flink/community/
 
 ### Community Sync
 
-There is a weekly online sync. Everyone is welcome to join. Please find the schedule, agenda for the next sync, and records of previous syncs in this [github discussion page](https://github.com/apache/flink-agents/discussions/66).
+There is a weekly online sync. Everyone is welcome to join. Please find the schedule, agenda for the next sync, and records of previous syncs in this [github discussion page](https://github.com/apache/flink-agents/discussions/419).
 
 {{< /columns >}}
 


### PR DESCRIPTION
<!-- Hotfix, no linked issue. -->

### Purpose of change

The index page links the weekly community sync to [discussion 66](https://github.com/apache/flink-agents/discussions/66), which covers the 2025 syncs. That thread now opens with "This page is outdated. Please find information about the latest community syncs at: #419".

This is the `release-0.3` counterpart of the change on `main`. The current schedule, agenda and minutes live in [discussion 419](https://github.com/apache/flink-agents/discussions/419). This updates the link on both the English and Chinese index pages so readers reach the live thread directly instead of landing on the 2025 archive first.

### Tests

Documentation link change only. Verified no `discussions/66` reference remains under `docs/content` or `docs/content.zh`.

### API

No public API change. Documentation only.

### Documentation

- [ ] `doc-needed`
- [ ] `doc-not-needed`
- [X] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [X] Yes
- [ ] No

Generated-by: Claude Code 2.1.233 (Claude Opus 5)
