### PR TITLE
[docs] Document preview status and security risks

### DIFF
--- a/docs/content/docs/get-started/overview.md
+++ b/docs/content/docs/get-started/overview.md
@@ -47,3 +47,15 @@ To get started with Apache Flink Agents, you can checkout the following quicksta
 - [ReAct Agent Quickstart]({{< ref "docs/get-started/quickstart/react_agent" >}})
 - [Skills Agent Quickstart]({{< ref "docs/get-started/quickstart/skills_agent" >}})
 - [YAML Agent Quickstart]({{< ref "docs/get-started/quickstart/yaml_agent" >}})
+
+## Preview Status
+
+{{< hint warning >}}
+Apache Flink Agents 0.x releases are preview versions. They may contain known
+or unknown issues, including potential security risks. The APIs and
+configuration are experimental and may change in backward-incompatible ways
+before 1.0. Review the [publicly disclosed known issues](https://github.com/apache/flink-agents/issues)
+and assess these risks before production use. Report suspected undisclosed
+security vulnerabilities privately through the [ASF Security Team](https://www.apache.org/security/)
+instead of creating a public GitHub issue.
+{{< /hint >}}


### PR DESCRIPTION
Linked issues: #1003, #1004

### Purpose of change

Apache Flink Agents 0.x releases are preview versions, but this maturity and
risk expectation was only stated in release announcements and was not explicit
in the user documentation.

This change adds a Preview Status section to the Overview page. It clarifies
that 0.x releases may contain known or unknown issues, including potential
security risks, and that APIs and configuration may change incompatibly before
1.0. It also directs users to public issues and the ASF private disclosure
process so they can assess the risks before production use and report
undisclosed vulnerabilities responsibly.

### Tests

- Built all 48 documentation pages with Hugo 0.110.0.
- Verified the warning and its links in the generated Overview HTML.
- Ran `git diff --check`.

### API

No public APIs are changed.

### Documentation

- [ ] `doc-needed`
- [ ] `doc-not-needed`
- [x] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

Generated-by: OpenAI Codex Desktop 26.803.41515 (GPT-5)
