### PR TITLE
[plan] Map long/float and other numeric tool parameters to proper JSON Schema types

### DIFF
--- a/plan/src/main/java/org/apache/flink/agents/plan/tools/SchemaUtils.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/tools/SchemaUtils.java
@@ -102,9 +102,19 @@ public class SchemaUtils {
 
         if (paramType == String.class) {
             paramSchema.put("type", "string");
-        } else if (paramType == int.class || paramType == Integer.class) {
+        } else if (paramType == int.class
+                || paramType == Integer.class
+                || paramType == long.class
+                || paramType == Long.class
+                || paramType == short.class
+                || paramType == Short.class
+                || paramType == byte.class
+                || paramType == Byte.class) {
             paramSchema.put("type", "integer");
-        } else if (paramType == double.class || paramType == Double.class) {
+        } else if (paramType == double.class
+                || paramType == Double.class
+                || paramType == float.class
+                || paramType == Float.class) {
             paramSchema.put("type", "number");
         } else if (paramType == boolean.class || paramType == Boolean.class) {
             paramSchema.put("type", "boolean");

--- a/plan/src/test/java/org/apache/flink/agents/plan/tools/SchemaUtilsTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/tools/SchemaUtilsTest.java
@@ -44,6 +44,15 @@ class SchemaUtilsTest {
 
         public void methodWithoutAnnotations(String param1, int param2) {}
 
+        public void methodWithWideNumericTypes(
+                @ToolParam(name = "longParam", description = "A long parameter") long longParam,
+                @ToolParam(name = "boxedLongParam", description = "A boxed long") Long boxedLong,
+                @ToolParam(name = "floatParam", description = "A float parameter") float floatParam,
+                @ToolParam(name = "boxedFloatParam", description = "A boxed float")
+                        Float boxedFloat,
+                @ToolParam(name = "shortParam", description = "A short parameter") short shortParam,
+                @ToolParam(name = "byteParam", description = "A byte parameter") byte byteParam) {}
+
         public void methodWithCustomObject(
                 @ToolParam(name = "objectParam", description = "A custom object parameter")
                         Object customObject) {}
@@ -54,6 +63,34 @@ class SchemaUtilsTest {
     }
 
     private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void testGenerateSchemaWithWideNumericTypes() throws Exception {
+        Method method =
+                TestClass.class.getMethod(
+                        "methodWithWideNumericTypes",
+                        long.class,
+                        Long.class,
+                        float.class,
+                        Float.class,
+                        short.class,
+                        byte.class);
+        String schema = SchemaUtils.generateSchema(method);
+        final JsonNode jsonNode = mapper.readTree(schema);
+        JsonNode properties = jsonNode.get("properties");
+
+        // Integral types map to "integer" (#1015): previously these all fell back to "object",
+        // which models either follow (producing object-shaped arguments) or treat as an
+        // uncallable tool.
+        assertEquals("integer", properties.get("longParam").get("type").asText());
+        assertEquals("integer", properties.get("boxedLongParam").get("type").asText());
+        assertEquals("integer", properties.get("shortParam").get("type").asText());
+        assertEquals("integer", properties.get("byteParam").get("type").asText());
+
+        // Floating-point types map to "number".
+        assertEquals("number", properties.get("floatParam").get("type").asText());
+        assertEquals("number", properties.get("boxedFloatParam").get("type").asText());
+    }
 
     @Test
     void testGenerateSchemaWithBasicTypes() throws Exception {


### PR DESCRIPTION
<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #1015

### Purpose of change

<!-- What is the purpose of this change? -->

`SchemaUtils.getParamSchema` maps Java parameter types to JSON Schema with a small if/else chain that only handled `String`, `int`/`Integer`, `double`/`Double`, and `boolean`/`Boolean` — everything else fell back to `"object"`. Common numeric types such as `long`, `Long`, `float`, `Float`, `short`, and `byte` were therefore advertised to the model as objects (e.g. `getOrder(long orderId)` generated `"type": "object"` for `orderId`), causing models to produce the wrong argument shape or avoid the tool call entirely, with the failure looking like a model/tool-calling issue rather than a schema-generation bug.

This extends the numeric mappings: `long`/`Long`/`short`/`Short`/`byte`/`Byte` → `"integer"`, `float`/`Float` → `"number"`. Arrays, collections, and POJOs keep the `"object"` fallback for now, per the issue.

### Tests

<!-- How is this change verified? -->

New `SchemaUtilsTest#testGenerateSchemaWithWideNumericTypes` covering all six types (primitive and boxed), asserting `"integer"` for the integral types and `"number"` for the floating-point types. Existing SchemaUtils tests pass unchanged.

### API

<!-- Does this change touches any public APIs? -->

None. Generated schemas for previously-"object" numeric parameters change to the correct JSON Schema types, which is the fix.

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->

### Was this patch authored or co-authored using generative AI tooling?

<!-- Do not remove this section. Check the proper box only. -->

- [x] Yes
- [ ] No

If yes, include a `Generated-by: <tool name and version> (<model name and version>)` line, for example `Generated-by: Claude Code 2.1.226 (Claude Opus 4.6)`, in the commit message so it reaches Git history. Repeat the same line here for reviewer visibility. See the [ASF generative tooling guidance](https://www.apache.org/legal/generative-tooling.html).

Generated-by Claude Fable 5