### PR TITLE
[hotfix][e2e] Derive recovery test version from project

### DIFF
--- a/e2e-test/test-scripts/test_checkpoint_recovery.sh
+++ b/e2e-test/test-scripts/test_checkpoint_recovery.sh
@@ -66,7 +66,22 @@ FLINK_MAJOR_MINOR="${FLINK_VERSION%.*}"
 REST_URL="${REST_URL:-http://localhost:8081}"
 
 JOB_MODULE="flink_agents/e2e_tests/e2e_tests_integration/checkpoint_recovery_job.py"
-EXPECTED_AGENTS_VERSION="${EXPECTED_AGENTS_VERSION:-0.3.dev0}"
+
+read_agents_project_version() {
+    local pyproject="$ROOT_DIR/python/pyproject.toml"
+    local version
+    version=$(sed -n 's/^version = "\([^"]*\)"$/\1/p' "$pyproject" | head -n 1)
+    if [[ -z "$version" ]]; then
+        log_error "Could not read the project version from $pyproject"
+        return 1
+    fi
+    printf '%s' "$version"
+}
+
+# Read the expected version from the checkout rather than pinning a release-line
+# value here. The assertion below then proves that the distribution metadata the
+# TaskManager imported belongs to the same source tree this run built.
+EXPECTED_AGENTS_VERSION="${EXPECTED_AGENTS_VERSION:-$(read_agents_project_version)}"
 
 # Checkpoint interval is deliberately short: the run is parked while we wait for two
 # checkpoints to complete, and that wait is charged against the tool's own deadline.
@@ -1034,9 +1049,9 @@ assert_runtime_identity() {
     fi
 
     # The version alone comes from distribution metadata and cannot tell two trees
-    # apart that both call themselves 0.3.dev0 — an installed wheel and this working
-    # tree would report the same string. The api-file probe is what identifies the
-    # tree, so assert it points inside the checkout -pypath was pointed at.
+    # apart when they declare the same project version — an installed wheel and this
+    # working tree would report the same string. The api-file probe is what identifies
+    # the tree, so assert it points inside the checkout -pypath was pointed at.
     local expected_prefix="$ROOT_DIR/python/flink_agents/api/"
     if [[ "$module_file" != "$expected_prefix"* ]]; then
         log_error "runtime-identity: the TaskManager imported flink_agents.api from '$module_file', which is not under '$expected_prefix'. The job exercised a different copy of the code than the one in this checkout, so a pass would not be evidence about these sources."

--- a/tools/test/helpers/recovery.bash
+++ b/tools/test/helpers/recovery.bash
@@ -49,7 +49,6 @@ reset_recovery_sh_state() {
     CHECKPOINT_INTERVAL_MS="5000"
     RESTART_ATTEMPTS="3"
     STANDALONE_STARTUP_TIME="600s"
-    EXPECTED_AGENTS_VERSION="0.3.dev0"
     # Keep the polls short; every wait under test is given a small budget.
     POLL_INTERVAL=1
 }

--- a/tools/test/unit/checkpoint_recovery_harness.bats
+++ b/tools/test/unit/checkpoint_recovery_harness.bats
@@ -20,8 +20,20 @@ bats_require_minimum_version 1.5.0
 
 setup() {
     load '../helpers/recovery'
+    # The production script supports an explicit override, but unit tests must
+    # exercise its default: deriving the expectation from this checkout.
+    unset EXPECTED_AGENTS_VERSION
     load_recovery_sh
     reset_recovery_sh_state
+}
+
+@test "runtime identity: expected version follows the current Python project" {
+    local declared_version
+    declared_version=$(sed -n 's/^version = "\([^"]*\)"$/\1/p' \
+        "$REPO_ROOT/python/pyproject.toml" | head -n 1)
+
+    [ -n "$declared_version" ]
+    [ "$EXPECTED_AGENTS_VERSION" = "$declared_version" ]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Linked issue: N/A (hotfix)

### Purpose of change

The nightly checkpoint-recovery job failed its runtime identity check because the expected Flink Agents version was hard-coded to `0.3.dev0`, while the current project version is `0.4.dev0`.

This change derives the expected version from `python/pyproject.toml` by default, keeps the `EXPECTED_AGENTS_VERSION` environment override, and adds regression coverage for future version updates.

### Tests

- `bash -n e2e-test/test-scripts/test_checkpoint_recovery.sh`
- `bash -n tools/test/helpers/recovery.bash`
- Targeted checkpoint-recovery Bats tests: 83 passed
- `/opt/homebrew/bin/bash tools/test/run.sh`: completed 315 tests without failures (5 environment-dependent tests skipped)

### API

No. This change only updates an end-to-end test script and its test helpers.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

Generated-by: Codex CLI 0.144.5 (GPT-5.6-sol)
