### PR TITLE
[api][integrations][java][python] Raise a clear error for an output schema that cannot be rendered

### DIFF
--- a/api/src/main/java/org/apache/flink/agents/api/agents/OutputSchema.java
+++ b/api/src/main/java/org/apache/flink/agents/api/agents/OutputSchema.java
@@ -93,13 +93,17 @@ public class OutputSchema {
      * member yields an object with no properties and genuinely constrains nothing. Declare the
      * member as a concrete type, or give the base the fields every subtype shares.
      *
+     * <p>Package-private: the rendered document is the deliverable only on the ReAct prompt path,
+     * which lives in this package. A connection sends its document to a provider that judges it,
+     * and refusing one there would fail a request the provider accepts.
+     *
      * @param schema the rendered JSON Schema to inspect.
      * @param schemaName the name of the schema, quoted in the error to identify the offending
      *     class.
      * @throws IllegalArgumentException if any object at or below {@code schema} carries a {@code
      *     properties} member that is present and empty.
      */
-    public static void rejectUnconstrainedSchema(JsonNode schema, String schemaName) {
+    static void rejectUnconstrainedSchema(JsonNode schema, String schemaName) {
         rejectEmptyObjects(schema, "$", schemaName);
     }
 

--- a/api/src/main/java/org/apache/flink/agents/api/agents/OutputSchema.java
+++ b/api/src/main/java/org/apache/flink/agents/api/agents/OutputSchema.java
@@ -37,9 +37,7 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Helper class for {@link RowTypeInfo} serialization.
@@ -64,83 +62,6 @@ public class OutputSchema {
 
     public RowTypeInfo getSchema() {
         return schema;
-    }
-
-    /**
-     * Rejects a rendered JSON Schema that cannot constrain a response.
-     *
-     * <p>An object declaring {@code properties} that is present and empty admits every response and
-     * rejects none, so a chat model given such a schema returns text that conforms to nothing. That
-     * happens whenever a member has a type carrying no serializable state, such as a functional
-     * interface. An object whose {@code properties} is <em>absent</em> is a different shape: it is
-     * how a free-form map such as {@code Map<String, String>} renders, which is a legitimate
-     * constraint and is accepted. Only the present-and-empty form is refused.
-     *
-     * <p>The walk descends through {@code properties} values and {@code items}, so a member that
-     * constrains nothing is found however deeply it is nested. {@code items} is descended even
-     * though the generator used here only ever puts a primitive schema there, because a subschema
-     * under {@code items} is universal across JSON Schema drafts and a document produced by any
-     * other generator will carry one. The path reported for such a subschema names the array
-     * member, since neither this walk nor its Python counterpart extends the path across {@code
-     * items}.
-     *
-     * <p>A class exposing its state through {@code @JsonAnyGetter} is a known false positive: it
-     * renders byte-identically to a class whose only member cannot be rendered, so no inspection of
-     * the rendered document can separate the two.
-     *
-     * <p>A member whose declared type is a {@code @JsonTypeInfo} base that carries no fields of its
-     * own is refused. The generator renders the declared type rather than the subtypes, so such a
-     * member yields an object with no properties and genuinely constrains nothing. Declare the
-     * member as a concrete type, or give the base the fields every subtype shares.
-     *
-     * <p>Package-private: the rendered document is the deliverable only on the ReAct prompt path,
-     * which lives in this package. A connection sends its document to a provider that judges it,
-     * and refusing one there would fail a request the provider accepts.
-     *
-     * @param schema the rendered JSON Schema to inspect.
-     * @param schemaName the name of the schema, quoted in the error to identify the offending
-     *     class.
-     * @throws IllegalArgumentException if any object at or below {@code schema} carries a {@code
-     *     properties} member that is present and empty.
-     */
-    static void rejectUnconstrainedSchema(JsonNode schema, String schemaName) {
-        rejectEmptyObjects(schema, "$", schemaName);
-    }
-
-    /**
-     * Raises if any object at or below {@code node} declares an empty {@code properties}.
-     *
-     * <p>The walk carries no visited set, because a Jackson-generated schema cannot contain a
-     * cycle: a self-referential class exhausts the stack inside the generator before any node is
-     * returned, and the generator emits a fresh node per member rather than sharing one. The
-     * document is therefore a finite tree and a cycle guard would never fire.
-     */
-    private static void rejectEmptyObjects(JsonNode node, String path, String schemaName) {
-        if (node == null || !node.isObject()) {
-            return;
-        }
-
-        JsonNode properties = node.get("properties");
-        boolean declaresNoProperties =
-                properties != null && properties.isObject() && properties.size() == 0;
-        if ("object".equals(node.path("type").asText()) && declaresNoProperties) {
-            throw new IllegalArgumentException(
-                    String.format(
-                            "Output schema %s renders to a JSON Schema that cannot constrain the"
-                                    + " response: the object at path %s has no properties. Use a schema"
-                                    + " whose objects each declare at least one field, or pass no output"
-                                    + " schema.",
-                            schemaName, path));
-        }
-
-        if (properties != null && properties.isObject()) {
-            Iterator<Map.Entry<String, JsonNode>> members = properties.fields();
-            while (members.hasNext()) {
-                Map.Entry<String, JsonNode> member = members.next();
-                rejectEmptyObjects(member.getValue(), path + "." + member.getKey(), schemaName);
-            }
-        }
-        rejectEmptyObjects(node.get("items"), path, schemaName);
     }
 
     public static class OutputSchemaJsonSerializer extends StdSerializer<OutputSchema> {

--- a/api/src/main/java/org/apache/flink/agents/api/agents/OutputSchema.java
+++ b/api/src/main/java/org/apache/flink/agents/api/agents/OutputSchema.java
@@ -37,7 +37,9 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Helper class for {@link RowTypeInfo} serialization.
@@ -62,6 +64,79 @@ public class OutputSchema {
 
     public RowTypeInfo getSchema() {
         return schema;
+    }
+
+    /**
+     * Rejects a rendered JSON Schema that cannot constrain a response.
+     *
+     * <p>An object declaring {@code properties} that is present and empty admits every response and
+     * rejects none, so a chat model given such a schema returns text that conforms to nothing. That
+     * happens whenever a member has a type carrying no serializable state, such as a functional
+     * interface. An object whose {@code properties} is <em>absent</em> is a different shape: it is
+     * how a free-form map such as {@code Map<String, String>} renders, which is a legitimate
+     * constraint and is accepted. Only the present-and-empty form is refused.
+     *
+     * <p>The walk descends through {@code properties} values and {@code items}, so a member that
+     * constrains nothing is found however deeply it is nested. {@code items} is descended even
+     * though the generator used here only ever puts a primitive schema there, because a subschema
+     * under {@code items} is universal across JSON Schema drafts and a document produced by any
+     * other generator will carry one. The path reported for such a subschema names the array
+     * member, since neither this walk nor its Python counterpart extends the path across {@code
+     * items}.
+     *
+     * <p>A class exposing its state through {@code @JsonAnyGetter} is a known false positive: it
+     * renders byte-identically to a class whose only member cannot be rendered, so no inspection of
+     * the rendered document can separate the two.
+     *
+     * <p>A member whose declared type is a {@code @JsonTypeInfo} base that carries no fields of its
+     * own is refused. The generator renders the declared type rather than the subtypes, so such a
+     * member yields an object with no properties and genuinely constrains nothing. Declare the
+     * member as a concrete type, or give the base the fields every subtype shares.
+     *
+     * @param schema the rendered JSON Schema to inspect.
+     * @param schemaName the name of the schema, quoted in the error to identify the offending
+     *     class.
+     * @throws IllegalArgumentException if any object at or below {@code schema} carries a {@code
+     *     properties} member that is present and empty.
+     */
+    public static void rejectUnconstrainedSchema(JsonNode schema, String schemaName) {
+        rejectEmptyObjects(schema, "$", schemaName);
+    }
+
+    /**
+     * Raises if any object at or below {@code node} declares an empty {@code properties}.
+     *
+     * <p>The walk carries no visited set, because a Jackson-generated schema cannot contain a
+     * cycle: a self-referential class exhausts the stack inside the generator before any node is
+     * returned, and the generator emits a fresh node per member rather than sharing one. The
+     * document is therefore a finite tree and a cycle guard would never fire.
+     */
+    private static void rejectEmptyObjects(JsonNode node, String path, String schemaName) {
+        if (node == null || !node.isObject()) {
+            return;
+        }
+
+        JsonNode properties = node.get("properties");
+        boolean declaresNoProperties =
+                properties != null && properties.isObject() && properties.size() == 0;
+        if ("object".equals(node.path("type").asText()) && declaresNoProperties) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Output schema %s renders to a JSON Schema that cannot constrain the"
+                                    + " response: the object at path %s has no properties. Use a schema"
+                                    + " whose objects each declare at least one field, or pass no output"
+                                    + " schema.",
+                            schemaName, path));
+        }
+
+        if (properties != null && properties.isObject()) {
+            Iterator<Map.Entry<String, JsonNode>> members = properties.fields();
+            while (members.hasNext()) {
+                Map.Entry<String, JsonNode> member = members.next();
+                rejectEmptyObjects(member.getValue(), path + "." + member.getKey(), schemaName);
+            }
+        }
+        rejectEmptyObjects(node.get("items"), path, schemaName);
     }
 
     public static class OutputSchemaJsonSerializer extends StdSerializer<OutputSchema> {

--- a/api/src/main/java/org/apache/flink/agents/api/agents/ReActAgent.java
+++ b/api/src/main/java/org/apache/flink/agents/api/agents/ReActAgent.java
@@ -20,6 +20,7 @@ package org.apache.flink.agents.api.agents;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.flink.agents.api.Event;
@@ -69,11 +70,28 @@ public class ReActAgent extends Agent {
                 jsonSchema = outputSchema.toString();
                 outputSchema = new OutputSchema((RowTypeInfo) outputSchema);
             } else if (outputSchema instanceof Class) {
+                Class<?> schemaClass = (Class<?>) outputSchema;
+                JsonNode schemaNode;
                 try {
-                    jsonSchema = mapper.generateJsonSchema((Class<?>) outputSchema).toString();
-                } catch (JsonMappingException e) {
-                    throw new RuntimeException(e);
+                    schemaNode = mapper.generateJsonSchema(schemaClass).getSchemaNode();
+                } catch (JsonMappingException | IllegalArgumentException e) {
+                    // Both are reachable: a class whose getters disagree on a property name fails
+                    // the mapping, and one that would not serialize as a JSON object at all is
+                    // refused by the generator with an IllegalArgumentException naming no remedy.
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "Output schema %s cannot be rendered as a JSON Schema, so it"
+                                            + " cannot constrain the response. Use a schema whose"
+                                            + " fields are all JSON-Schema-renderable, or pass no"
+                                            + " output schema. Rendering it reported: %s",
+                                    schemaClass.getName(), e.getMessage()),
+                            e);
                 }
+                // Deliberately outside the catch above: the check throws an
+                // IllegalArgumentException of its own naming the offending member's path, and
+                // re-wrapping it would bury that path in the cause.
+                OutputSchema.rejectUnconstrainedSchema(schemaNode, schemaClass.getName());
+                jsonSchema = schemaNode.toString();
             } else {
                 throw new IllegalArgumentException(
                         "Output schema must be RowTypeInfo or Pojo class.");

--- a/api/src/main/java/org/apache/flink/agents/api/agents/ReActAgent.java
+++ b/api/src/main/java/org/apache/flink/agents/api/agents/ReActAgent.java
@@ -20,7 +20,6 @@ package org.apache.flink.agents.api.agents;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.flink.agents.api.Event;
@@ -71,9 +70,8 @@ public class ReActAgent extends Agent {
                 outputSchema = new OutputSchema((RowTypeInfo) outputSchema);
             } else if (outputSchema instanceof Class) {
                 Class<?> schemaClass = (Class<?>) outputSchema;
-                JsonNode schemaNode;
                 try {
-                    schemaNode = mapper.generateJsonSchema(schemaClass).getSchemaNode();
+                    jsonSchema = mapper.generateJsonSchema(schemaClass).getSchemaNode().toString();
                 } catch (JsonMappingException | IllegalArgumentException e) {
                     // Both are reachable: a class whose getters disagree on a property name fails
                     // the mapping, and one that would not serialize as a JSON object at all is
@@ -87,14 +85,12 @@ public class ReActAgent extends Agent {
                                     schemaClass.getName(), e.getMessage()),
                             e);
                 }
-                // Deliberately outside the catch above: the check throws an
-                // IllegalArgumentException of its own naming the offending member's path, and
-                // re-wrapping it would bury that path in the cause.
-                OutputSchema.rejectUnconstrainedSchema(schemaNode, schemaClass.getName());
-                jsonSchema = schemaNode.toString();
             } else {
                 throw new IllegalArgumentException(
-                        "Output schema must be RowTypeInfo or Pojo class.");
+                        String.format(
+                                "Output schema %s is not supported. It must be a RowTypeInfo or"
+                                        + " a Pojo class.",
+                                outputSchema.getClass().getName()));
             }
             Prompt schemaPrompt =
                     Prompt.fromText(

--- a/api/src/main/java/org/apache/flink/agents/api/agents/ReActAgent.java
+++ b/api/src/main/java/org/apache/flink/agents/api/agents/ReActAgent.java
@@ -84,6 +84,19 @@ public class ReActAgent extends Agent {
                                             + " output schema. Rendering it reported: %s",
                                     schemaClass.getName(), e.getMessage()),
                             e);
+                } catch (StackOverflowError e) {
+                    // The generator carries no cycle guard, so a class that reaches itself
+                    // through its own members recurses until the stack is gone. A separate clause
+                    // rather than another type on the union above because the error carries no
+                    // message to quote, so this case has to name the cause itself.
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "Output schema %s is self-referential, so rendering it as a"
+                                            + " JSON Schema does not terminate and it cannot"
+                                            + " constrain the response. Use a schema that does not"
+                                            + " refer back to itself, or pass no output schema.",
+                                    schemaClass.getName()),
+                            e);
                 }
             } else {
                 throw new IllegalArgumentException(

--- a/api/src/main/java/org/apache/flink/agents/api/chat/model/BaseChatModelConnection.java
+++ b/api/src/main/java/org/apache/flink/agents/api/chat/model/BaseChatModelConnection.java
@@ -109,12 +109,10 @@ public abstract class BaseChatModelConnection extends Resource {
      * connections wrap that. A schema the SDK does render is sent as rendered even when it declares
      * no properties; whether such a document is usable is the receiving provider's to judge.
      *
-     * <p>The ReAct prompt path is the one place either failure is refused, and it renders through a
-     * different generator, Jackson, rather than through any provider SDK. Its output is pasted
-     * verbatim into the instruction prompt and is therefore the deliverable, so a POJO Jackson
-     * cannot render, and one it renders without constraining anything, are both rejected there.
-     * Because the two paths use different generators, neither rejection says anything about what a
-     * connection does with the same POJO.
+     * <p>The ReAct prompt path renders through a different generator, Jackson, rather than through
+     * any provider SDK, and a POJO Jackson cannot render is rejected there rather than reaching the
+     * prompt. Because the two paths use different generators, that rejection says nothing about
+     * what a connection does with the same POJO.
      *
      * @param messages the input chat messages
      * @param tools the tools can be called by the model

--- a/api/src/main/java/org/apache/flink/agents/api/chat/model/BaseChatModelConnection.java
+++ b/api/src/main/java/org/apache/flink/agents/api/chat/model/BaseChatModelConnection.java
@@ -93,6 +93,29 @@ public abstract class BaseChatModelConnection extends Resource {
      * schema into a native provider parameter overrides this overload, and reports its capability
      * via {@link #supportsNativeStructuredOutput(String)}.
      *
+     * <p>No connection translates an {@link org.apache.flink.agents.api.agents.OutputSchema}, and
+     * so a {@code RowTypeInfo}, natively, and what follows differs by connection. One that
+     * overrides this overload applies its native parameter only for a POJO {@link Class}, so it
+     * skips the {@code RowTypeInfo} and leaves the request unchanged, and the caller keeps the
+     * prompt-engineering fallback. One that does not override it rejects the {@code RowTypeInfo}
+     * through the default body above, which refuses every non-null schema alike. The skip is a
+     * deliberate, permanent fallback rather than a translation still to be written; the rejection
+     * is the separate case of a connection that could otherwise only drop the schema silently.
+     *
+     * <p>An overriding connection renders a POJO with its provider SDK's own schema generator, and
+     * a render failure is not reported here because those generators produce a schema for every
+     * class they are handed. The asymmetry with the Python side is imposed by the vendor libraries
+     * rather than chosen: Pydantic genuinely raises on a model it cannot express, and the Python
+     * connections wrap that. A schema the SDK does render is sent as rendered even when it declares
+     * no properties; whether such a document is usable is the receiving provider's to judge.
+     *
+     * <p>The ReAct prompt path is the one place either failure is refused, and it renders through a
+     * different generator, Jackson, rather than through any provider SDK. Its output is pasted
+     * verbatim into the instruction prompt and is therefore the deliverable, so a POJO Jackson
+     * cannot render, and one it renders without constraining anything, are both rejected there.
+     * Because the two paths use different generators, neither rejection says anything about what a
+     * connection does with the same POJO.
+     *
      * @param messages the input chat messages
      * @param tools the tools can be called by the model
      * @param modelParams the additional arguments passed to the model

--- a/api/src/test/java/org/apache/flink/agents/api/agents/ReActAgentTest.java
+++ b/api/src/test/java/org/apache/flink/agents/api/agents/ReActAgentTest.java
@@ -18,10 +18,15 @@
 
 package org.apache.flink.agents.api.agents;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.agents.api.prompt.Prompt;
+import org.apache.flink.agents.api.resource.ResourceDescriptor;
+import org.apache.flink.agents.api.resource.ResourceType;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
@@ -32,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 import java.util.function.Function;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -127,6 +133,100 @@ public class ReActAgentTest {
                 .hasMessageContaining("WithRows")
                 .hasMessageContaining("at path $.rows has no properties");
     }
+
+    @Test
+    @DisplayName("An agent built on an unrenderable schema names the offending path, unwrapped")
+    public void testAgentRejectsUnrenderableSchemaByPath() {
+        // The path is what identifies the offending member, so it has to survive to the message the
+        // caller reads. A catch that also covers the check would bury it one getCause() down.
+        assertThatThrownBy(() -> agentWithSchema(WithNestedCallback.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("WithNestedCallback")
+                .hasMessageContaining("$.inner.callback")
+                // No cause: a schema that renders but constrains nothing is not a render
+                // failure, and a wrapper over the check would relabel it as one.
+                .hasNoCause();
+    }
+
+    @Test
+    @DisplayName("An agent built on a schema Jackson cannot render reports it with the cause kept")
+    public void testAgentRejectsSchemaThatCannotRender() {
+        assertThatThrownBy(() -> agentWithSchema(FieldLess.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("FieldLess")
+                .hasMessageContaining("cannot be rendered as a JSON Schema")
+                .hasCauseInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("An agent built on a free-form map member still prompts with the full schema")
+    public void testAgentAcceptsMapMemberSchema() {
+        assertThat(schemaPromptOf(agentWithSchema(WithMap.class)))
+                .contains("\"count\":{\"type\":\"integer\"}")
+                .contains("\"entries\":{\"type\":\"object\"}");
+    }
+
+    @Test
+    @DisplayName("An agent built on a renderable schema prompts with the schema it always did")
+    public void testAgentAcceptsRenderableSchema() {
+        assertThat(schemaPromptOf(agentWithSchema(WithCount.class)))
+                .contains(
+                        "{\"type\":\"object\",\"properties\":{\"count\":{\"type\":\"integer\"}}}");
+    }
+
+    @Test
+    @DisplayName("An agent built on a polymorphic member with a field-less base is rejected")
+    public void testAgentRejectsPolymorphicMemberWithFieldLessBase() {
+        // The generator renders the declared type rather than its subtypes, so a base declaring no
+        // fields of its own reaches the prompt as an object that constrains nothing. Giving the
+        // base a single shared field flips this to accepted, so it is the field-less form that is
+        // pinned here.
+        assertThatThrownBy(() -> agentWithSchema(Owner.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Owner")
+                .hasMessageContaining("$.pet");
+    }
+
+    private static ReActAgent agentWithSchema(Class<?> outputSchema) {
+        return new ReActAgent(
+                ResourceDescriptor.Builder.newBuilder("com.example.ChatModel").build(),
+                null,
+                outputSchema);
+    }
+
+    private static String schemaPromptOf(ReActAgent agent) {
+        Prompt schemaPrompt =
+                (Prompt)
+                        agent.getResources().get(ResourceType.PROMPT).get("_default_schema_prompt");
+        return schemaPrompt.formatString(Map.of());
+    }
+
+    /** A polymorphic base declaring no fields of its own, so it renders to an empty object. */
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = Dog.class, name = "dog"),
+        @JsonSubTypes.Type(value = Cat.class, name = "cat")
+    })
+    public abstract static class Pet {}
+
+    /** One arm of the {@link Pet} union. */
+    public static class Dog extends Pet {
+        public String bark;
+    }
+
+    /** The other arm of the {@link Pet} union. */
+    public static class Cat extends Pet {
+        public String meow;
+    }
+
+    /** Holds a polymorphic member whose base declares no fields. */
+    public static class Owner {
+        public String name;
+        public Pet pet;
+    }
+
+    /** A class with no members at all, which Jackson refuses to render rather than rendering. */
+    public static class FieldLess {}
 
     private static JsonNode renderSchema(Class<?> pojo) throws JsonMappingException {
         return new ObjectMapper().generateJsonSchema(pojo).getSchemaNode();

--- a/api/src/test/java/org/apache/flink/agents/api/agents/ReActAgentTest.java
+++ b/api/src/test/java/org/apache/flink/agents/api/agents/ReActAgentTest.java
@@ -19,12 +19,21 @@
 package org.apache.flink.agents.api.agents;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ReActAgentTest {
     @Test
@@ -40,5 +49,109 @@ public class ReActAgentTest {
         String json = mapper.writeValueAsString(schema);
         OutputSchema deserialized = mapper.readValue(json, OutputSchema.class);
         Assertions.assertEquals(typeInfo, deserialized.getSchema());
+    }
+
+    @Test
+    @DisplayName("A member that renders to an object with no properties is rejected by path")
+    public void testUnrenderableMemberIsRejected() throws JsonMappingException {
+        assertThatThrownBy(
+                        () ->
+                                OutputSchema.rejectUnconstrainedSchema(
+                                        renderSchema(WithCallback.class), "WithCallback"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("WithCallback")
+                .hasMessageContaining("$.callback");
+    }
+
+    @Test
+    @DisplayName("An unrenderable member nested below the root is still found")
+    public void testNestedUnrenderableMemberIsRejected() throws JsonMappingException {
+        assertThatThrownBy(
+                        () ->
+                                OutputSchema.rejectUnconstrainedSchema(
+                                        renderSchema(WithNestedCallback.class),
+                                        "WithNestedCallback"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("$.inner.callback");
+    }
+
+    @Test
+    @DisplayName("A root object with no properties is rejected at the root path")
+    public void testRootWithoutPropertiesIsRejected() throws JsonProcessingException {
+        JsonNode schema = new ObjectMapper().readTree("{\"type\":\"object\",\"properties\":{}}");
+
+        assertThatThrownBy(() -> OutputSchema.rejectUnconstrainedSchema(schema, "FieldLess"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("FieldLess")
+                .hasMessageContaining("at path $ has no properties");
+    }
+
+    @Test
+    @DisplayName("A free-form map member is accepted because its properties are absent, not empty")
+    public void testMapMemberIsAccepted() throws JsonMappingException {
+        JsonNode schema = renderSchema(WithMap.class);
+
+        assertThatCode(() -> OutputSchema.rejectUnconstrainedSchema(schema, "WithMap"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("A schema whose members all render is accepted")
+    public void testRenderableSchemaIsAccepted() throws JsonMappingException {
+        JsonNode schema = renderSchema(WithCount.class);
+
+        assertThatCode(() -> OutputSchema.rejectUnconstrainedSchema(schema, "WithCount"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("An empty properties member on a node that is not an object is left alone")
+    public void testNonObjectWithEmptyPropertiesIsAccepted() throws JsonProcessingException {
+        JsonNode schema = new ObjectMapper().readTree("{\"type\":\"array\",\"properties\":{}}");
+
+        assertThatCode(() -> OutputSchema.rejectUnconstrainedSchema(schema, "ArrayNode"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("An array whose item schema constrains nothing is rejected")
+    public void testUnconstrainedItemSchemaIsRejected() throws JsonProcessingException {
+        JsonNode schema =
+                new ObjectMapper()
+                        .readTree(
+                                "{\"type\":\"object\",\"properties\":{\"rows\":{\"type\":\"array\","
+                                        + "\"items\":{\"type\":\"object\",\"properties\":{}}}}}");
+
+        assertThatThrownBy(() -> OutputSchema.rejectUnconstrainedSchema(schema, "WithRows"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("WithRows")
+                .hasMessageContaining("at path $.rows has no properties");
+    }
+
+    private static JsonNode renderSchema(Class<?> pojo) throws JsonMappingException {
+        return new ObjectMapper().generateJsonSchema(pojo).getSchemaNode();
+    }
+
+    /** A member whose type carries no serializable state, so it renders to an empty object. */
+    public static class WithCallback {
+        public int count;
+        public Function<String, String> callback;
+    }
+
+    /** Holds {@link WithCallback} one level down, out of reach of a root-only check. */
+    public static class WithNestedCallback {
+        public int count;
+        public WithCallback inner;
+    }
+
+    /** A free-form map, which renders without a {@code properties} member at all. */
+    public static class WithMap {
+        public int count;
+        public Map<String, String> entries;
+    }
+
+    /** A member that renders to a concrete type. */
+    public static class WithCount {
+        public int count;
     }
 }

--- a/api/src/test/java/org/apache/flink/agents/api/agents/ReActAgentTest.java
+++ b/api/src/test/java/org/apache/flink/agents/api/agents/ReActAgentTest.java
@@ -63,6 +63,16 @@ public class ReActAgentTest {
     }
 
     @Test
+    @DisplayName("An agent built on a self-referential schema reports the self-reference")
+    public void testAgentRejectsSelfReferentialSchema() {
+        assertThatThrownBy(() -> agentWithSchema(SelfReferential.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("SelfReferential")
+                .hasMessageContaining("self-referential")
+                .hasCauseInstanceOf(StackOverflowError.class);
+    }
+
+    @Test
     @DisplayName("An agent built on a member that renders to no properties still prompts with it")
     public void testAgentAcceptsSchemaWithFieldLessMember() {
         assertThat(schemaPromptOf(agentWithSchema(WithCallback.class)))
@@ -113,5 +123,11 @@ public class ReActAgentTest {
     /** A member that renders to a concrete type. */
     public static class WithCount {
         public int count;
+    }
+
+    /** A class reachable from itself, which the generator recurses on until the stack is gone. */
+    public static class SelfReferential {
+        public String name;
+        public SelfReferential next;
     }
 }

--- a/api/src/test/java/org/apache/flink/agents/api/agents/ReActAgentTest.java
+++ b/api/src/test/java/org/apache/flink/agents/api/agents/ReActAgentTest.java
@@ -18,11 +18,7 @@
 
 package org.apache.flink.agents.api.agents;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.agents.api.prompt.Prompt;
 import org.apache.flink.agents.api.resource.ResourceDescriptor;
@@ -38,7 +34,6 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ReActAgentTest {
@@ -58,97 +53,6 @@ public class ReActAgentTest {
     }
 
     @Test
-    @DisplayName("A member that renders to an object with no properties is rejected by path")
-    public void testUnrenderableMemberIsRejected() throws JsonMappingException {
-        assertThatThrownBy(
-                        () ->
-                                OutputSchema.rejectUnconstrainedSchema(
-                                        renderSchema(WithCallback.class), "WithCallback"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("WithCallback")
-                .hasMessageContaining("$.callback");
-    }
-
-    @Test
-    @DisplayName("An unrenderable member nested below the root is still found")
-    public void testNestedUnrenderableMemberIsRejected() throws JsonMappingException {
-        assertThatThrownBy(
-                        () ->
-                                OutputSchema.rejectUnconstrainedSchema(
-                                        renderSchema(WithNestedCallback.class),
-                                        "WithNestedCallback"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("$.inner.callback");
-    }
-
-    @Test
-    @DisplayName("A root object with no properties is rejected at the root path")
-    public void testRootWithoutPropertiesIsRejected() throws JsonProcessingException {
-        JsonNode schema = new ObjectMapper().readTree("{\"type\":\"object\",\"properties\":{}}");
-
-        assertThatThrownBy(() -> OutputSchema.rejectUnconstrainedSchema(schema, "FieldLess"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("FieldLess")
-                .hasMessageContaining("at path $ has no properties");
-    }
-
-    @Test
-    @DisplayName("A free-form map member is accepted because its properties are absent, not empty")
-    public void testMapMemberIsAccepted() throws JsonMappingException {
-        JsonNode schema = renderSchema(WithMap.class);
-
-        assertThatCode(() -> OutputSchema.rejectUnconstrainedSchema(schema, "WithMap"))
-                .doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("A schema whose members all render is accepted")
-    public void testRenderableSchemaIsAccepted() throws JsonMappingException {
-        JsonNode schema = renderSchema(WithCount.class);
-
-        assertThatCode(() -> OutputSchema.rejectUnconstrainedSchema(schema, "WithCount"))
-                .doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("An empty properties member on a node that is not an object is left alone")
-    public void testNonObjectWithEmptyPropertiesIsAccepted() throws JsonProcessingException {
-        JsonNode schema = new ObjectMapper().readTree("{\"type\":\"array\",\"properties\":{}}");
-
-        assertThatCode(() -> OutputSchema.rejectUnconstrainedSchema(schema, "ArrayNode"))
-                .doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("An array whose item schema constrains nothing is rejected")
-    public void testUnconstrainedItemSchemaIsRejected() throws JsonProcessingException {
-        JsonNode schema =
-                new ObjectMapper()
-                        .readTree(
-                                "{\"type\":\"object\",\"properties\":{\"rows\":{\"type\":\"array\","
-                                        + "\"items\":{\"type\":\"object\",\"properties\":{}}}}}");
-
-        assertThatThrownBy(() -> OutputSchema.rejectUnconstrainedSchema(schema, "WithRows"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("WithRows")
-                .hasMessageContaining("at path $.rows has no properties");
-    }
-
-    @Test
-    @DisplayName("An agent built on an unrenderable schema names the offending path, unwrapped")
-    public void testAgentRejectsUnrenderableSchemaByPath() {
-        // The path is what identifies the offending member, so it has to survive to the message the
-        // caller reads. A catch that also covers the check would bury it one getCause() down.
-        assertThatThrownBy(() -> agentWithSchema(WithNestedCallback.class))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("WithNestedCallback")
-                .hasMessageContaining("$.inner.callback")
-                // No cause: a schema that renders but constrains nothing is not a render
-                // failure, and a wrapper over the check would relabel it as one.
-                .hasNoCause();
-    }
-
-    @Test
     @DisplayName("An agent built on a schema Jackson cannot render reports it with the cause kept")
     public void testAgentRejectsSchemaThatCannotRender() {
         assertThatThrownBy(() -> agentWithSchema(FieldLess.class))
@@ -159,15 +63,15 @@ public class ReActAgentTest {
     }
 
     @Test
-    @DisplayName("An agent built on a free-form map member still prompts with the full schema")
-    public void testAgentAcceptsMapMemberSchema() {
-        assertThat(schemaPromptOf(agentWithSchema(WithMap.class)))
+    @DisplayName("An agent built on a member that renders to no properties still prompts with it")
+    public void testAgentAcceptsSchemaWithFieldLessMember() {
+        assertThat(schemaPromptOf(agentWithSchema(WithCallback.class)))
                 .contains("\"count\":{\"type\":\"integer\"}")
-                .contains("\"entries\":{\"type\":\"object\"}");
+                .contains("\"callback\":{\"type\":\"object\",\"properties\":{}}");
     }
 
     @Test
-    @DisplayName("An agent built on a renderable schema prompts with the schema it always did")
+    @DisplayName("An agent built on a renderable schema prompts with its rendered JSON Schema")
     public void testAgentAcceptsRenderableSchema() {
         assertThat(schemaPromptOf(agentWithSchema(WithCount.class)))
                 .contains(
@@ -175,19 +79,15 @@ public class ReActAgentTest {
     }
 
     @Test
-    @DisplayName("An agent built on a polymorphic member with a field-less base is rejected")
-    public void testAgentRejectsPolymorphicMemberWithFieldLessBase() {
-        // The generator renders the declared type rather than its subtypes, so a base declaring no
-        // fields of its own reaches the prompt as an object that constrains nothing. Giving the
-        // base a single shared field flips this to accepted, so it is the field-less form that is
-        // pinned here.
-        assertThatThrownBy(() -> agentWithSchema(Owner.class))
+    @DisplayName("An output schema of neither supported kind reports the type it received")
+    public void testUnsupportedOutputSchemaTypeReportsTheType() {
+        assertThatThrownBy(() -> agentWithSchema("not-a-schema"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Owner")
-                .hasMessageContaining("$.pet");
+                .hasMessageContaining("java.lang.String")
+                .hasMessageContaining("must be a RowTypeInfo or a Pojo class");
     }
 
-    private static ReActAgent agentWithSchema(Class<?> outputSchema) {
+    private static ReActAgent agentWithSchema(Object outputSchema) {
         return new ReActAgent(
                 ResourceDescriptor.Builder.newBuilder("com.example.ChatModel").build(),
                 null,
@@ -201,53 +101,13 @@ public class ReActAgentTest {
         return schemaPrompt.formatString(Map.of());
     }
 
-    /** A polymorphic base declaring no fields of its own, so it renders to an empty object. */
-    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
-    @JsonSubTypes({
-        @JsonSubTypes.Type(value = Dog.class, name = "dog"),
-        @JsonSubTypes.Type(value = Cat.class, name = "cat")
-    })
-    public abstract static class Pet {}
-
-    /** One arm of the {@link Pet} union. */
-    public static class Dog extends Pet {
-        public String bark;
-    }
-
-    /** The other arm of the {@link Pet} union. */
-    public static class Cat extends Pet {
-        public String meow;
-    }
-
-    /** Holds a polymorphic member whose base declares no fields. */
-    public static class Owner {
-        public String name;
-        public Pet pet;
-    }
-
     /** A class with no members at all, which Jackson refuses to render rather than rendering. */
     public static class FieldLess {}
-
-    private static JsonNode renderSchema(Class<?> pojo) throws JsonMappingException {
-        return new ObjectMapper().generateJsonSchema(pojo).getSchemaNode();
-    }
 
     /** A member whose type carries no serializable state, so it renders to an empty object. */
     public static class WithCallback {
         public int count;
         public Function<String, String> callback;
-    }
-
-    /** Holds {@link WithCallback} one level down, out of reach of a root-only check. */
-    public static class WithNestedCallback {
-        public int count;
-        public WithCallback inner;
-    }
-
-    /** A free-form map, which renders without a {@code properties} member at all. */
-    public static class WithMap {
-        public int count;
-        public Map<String, String> entries;
     }
 
     /** A member that renders to a concrete type. */

--- a/integrations/chat-models/anthropic/src/test/java/org/apache/flink/agents/integrations/chatmodels/anthropic/AnthropicChatModelConnectionTest.java
+++ b/integrations/chat-models/anthropic/src/test/java/org/apache/flink/agents/integrations/chatmodels/anthropic/AnthropicChatModelConnectionTest.java
@@ -24,6 +24,8 @@ import com.anthropic.models.messages.Model;
 import com.anthropic.models.messages.OutputConfig;
 import com.anthropic.models.messages.TextBlock;
 import com.anthropic.models.messages.Usage;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.agents.api.chat.messages.ChatMessage;
@@ -263,6 +265,30 @@ class AnthropicChatModelConnectionTest {
         public String verdict;
     }
 
+    /** A polymorphic member, which the SDK renders as a discriminated union. */
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = Dog.class, name = "dog"),
+        @JsonSubTypes.Type(value = Cat.class, name = "cat")
+    })
+    public abstract static class Pet {}
+
+    /** One arm of the {@link Pet} union. */
+    public static class Dog extends Pet {
+        public String bark;
+    }
+
+    /** The other arm of the {@link Pet} union. */
+    public static class Cat extends Pet {
+        public String meow;
+    }
+
+    /** Holds a polymorphic member. */
+    public static class Owner {
+        public String verdict;
+        public Pet pet;
+    }
+
     private static Map<String, Object> paramsWithModel(String model, Object jsonPrefill) {
         Map<String, Object> params = params(jsonPrefill);
         params.put("model", model);
@@ -289,6 +315,15 @@ class AnthropicChatModelConnectionTest {
                 .map(schema -> schema.get("properties"))
                 .map(properties -> MAPPER.convertValue(properties, MAP_TYPE).keySet())
                 .orElse(Set.of());
+    }
+
+    /** The JSON Schema the request carries, as the SDK holds it on the output config. */
+    private static String nativeSchemaPayload(AnthropicChatModelConnection.BuiltRequest built) {
+        return built.params
+                .outputConfig()
+                .flatMap(OutputConfig::format)
+                .map(format -> format.schema()._additionalProperties().toString())
+                .orElseThrow();
     }
 
     @ParameterizedTest
@@ -380,6 +415,18 @@ class AnthropicChatModelConnectionTest {
                 .isEqualTo(connection().supportsNativeStructuredOutput(INCAPABLE_MODEL));
         assertThat(configuredCapable.supportsNativeStructuredOutput(CAPABLE_MODEL))
                 .isEqualTo(connection().supportsNativeStructuredOutput(CAPABLE_MODEL));
+    }
+
+    @Test
+    @DisplayName("a polymorphic member is sent as the discriminated union the SDK derives")
+    void testPolymorphicMemberSchemaIsSent() {
+        // Jackson renders this member as an object declaring no properties, while the SDK derives
+        // the full union the provider accepts. Reading a Jackson-rendered schema here would refuse
+        // a request that works.
+        assertThat(nativeSchemaPayload(build(CAPABLE_MODEL, Owner.class, null)))
+                .contains("bark={type=string}")
+                .contains("meow={type=string}")
+                .contains("kind={const=dog}");
     }
 
     @Test

--- a/integrations/chat-models/openai/src/test/java/org/apache/flink/agents/integrations/chatmodels/openai/AzureOpenAIChatModelConnectionTest.java
+++ b/integrations/chat-models/openai/src/test/java/org/apache/flink/agents/integrations/chatmodels/openai/AzureOpenAIChatModelConnectionTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.agents.integrations.chatmodels.openai;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.openai.errors.BadRequestException;
 import com.openai.models.ChatModel;
@@ -82,6 +84,40 @@ class AzureOpenAIChatModelConnectionTest {
     public static class Person {
         public String name;
         public int age;
+    }
+
+    /** A polymorphic member, which the SDK renders as a discriminated union. */
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = Dog.class, name = "dog"),
+        @JsonSubTypes.Type(value = Cat.class, name = "cat")
+    })
+    public abstract static class Pet {}
+
+    /** One arm of the {@link Pet} union. */
+    public static class Dog extends Pet {
+        public String bark;
+    }
+
+    /** The other arm of the {@link Pet} union. */
+    public static class Cat extends Pet {
+        public String meow;
+    }
+
+    /** Holds a polymorphic member. */
+    public static class Owner {
+        public String name;
+        public Pet pet;
+    }
+
+    /** The JSON Schema the request carries, as the SDK holds it on the response format. */
+    private static String nativeSchemaPayload(ChatCompletionCreateParams params) {
+        return params.responseFormat()
+                .orElseThrow()
+                .asJsonSchema()
+                .jsonSchema()
+                ._schema()
+                .toString();
     }
 
     private static AzureOpenAIChatModelConnection connection(String apiVersion) {
@@ -270,6 +306,27 @@ class AzureOpenAIChatModelConnectionTest {
         // equal to the class name.
         assertThat(jsonSchema.jsonSchema().name()).contains("Person");
         assertThat(jsonSchema.jsonSchema().strict()).contains(true);
+        // Asserting the members rather than only the flags: a schema declaring no properties
+        // would satisfy strict() and the derived name while constraining nothing at all.
+        assertThat(nativeSchemaPayload(request))
+                .contains("name={type=string}")
+                .contains("age={type=integer}");
+    }
+
+    @Test
+    @DisplayName("A polymorphic member is sent as the discriminated union the SDK derives")
+    void testPolymorphicMemberSchemaIsSent() {
+        // Jackson renders this member as an object declaring no properties, while the SDK derives
+        // the full union the provider accepts. Reading a Jackson-rendered schema here would refuse
+        // a request that works.
+        ChatCompletionCreateParams request =
+                connection()
+                        .buildRequest(userMessage(), List.of(), params("gpt-4o-mini"), Owner.class);
+
+        assertThat(nativeSchemaPayload(request))
+                .contains("bark={type=string}")
+                .contains("meow={type=string}")
+                .contains("kind={const=dog}");
     }
 
     @Test

--- a/integrations/chat-models/openai/src/test/java/org/apache/flink/agents/integrations/chatmodels/openai/OpenAICompletionsConnectionTest.java
+++ b/integrations/chat-models/openai/src/test/java/org/apache/flink/agents/integrations/chatmodels/openai/OpenAICompletionsConnectionTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.agents.integrations.chatmodels.openai;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.openai.errors.BadRequestException;
 import com.openai.models.ResponseFormatJsonSchema;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
@@ -56,6 +58,40 @@ class OpenAICompletionsConnectionTest {
     public static class Person {
         public String name;
         public int age;
+    }
+
+    /** A polymorphic member, which the SDK renders as a discriminated union. */
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = Dog.class, name = "dog"),
+        @JsonSubTypes.Type(value = Cat.class, name = "cat")
+    })
+    public abstract static class Pet {}
+
+    /** One arm of the {@link Pet} union. */
+    public static class Dog extends Pet {
+        public String bark;
+    }
+
+    /** The other arm of the {@link Pet} union. */
+    public static class Cat extends Pet {
+        public String meow;
+    }
+
+    /** Holds a polymorphic member. */
+    public static class Owner {
+        public String name;
+        public Pet pet;
+    }
+
+    /** The JSON Schema the request carries, as the SDK holds it on the response format. */
+    private static String nativeSchemaPayload(ChatCompletionCreateParams params) {
+        return params.responseFormat()
+                .orElseThrow()
+                .asJsonSchema()
+                .jsonSchema()
+                ._schema()
+                .toString();
     }
 
     private static OpenAICompletionsConnection connection() {
@@ -156,6 +192,26 @@ class OpenAICompletionsConnectionTest {
         assertThat(params.responseFormat()).isPresent();
         ResponseFormatJsonSchema jsonSchema = params.responseFormat().get().asJsonSchema();
         assertThat(jsonSchema.jsonSchema().strict()).contains(true);
+        // Asserting the members rather than only the flags: a schema declaring no properties
+        // would satisfy strict() and the derived name while constraining nothing at all.
+        assertThat(nativeSchemaPayload(params))
+                .contains("name={type=string}")
+                .contains("age={type=integer}");
+    }
+
+    @Test
+    @DisplayName("A polymorphic member is sent as the discriminated union the SDK derives")
+    void testPolymorphicMemberSchemaIsSent() {
+        // Jackson renders this member as an object declaring no properties, while the SDK derives
+        // the full union the provider accepts. Reading a Jackson-rendered schema here would refuse
+        // a request that works.
+        ChatCompletionCreateParams request =
+                connection().buildRequest(userMessage(), List.of(), params("gpt-4o"), Owner.class);
+
+        assertThat(nativeSchemaPayload(request))
+                .contains("bark={type=string}")
+                .contains("meow={type=string}")
+                .contains("kind={const=dog}");
     }
 
     @Test

--- a/python/flink_agents/api/agents/react_agent.py
+++ b/python/flink_agents/api/agents/react_agent.py
@@ -24,10 +24,7 @@ from pyflink.common import Row
 from pyflink.common.typeinfo import RowTypeInfo
 
 from flink_agents.api.agents.agent import STRUCTURED_OUTPUT, Agent
-from flink_agents.api.agents.types import (
-    OutputSchema,
-    render_constraining_output_schema,
-)
+from flink_agents.api.agents.types import OutputSchema, render_output_schema
 from flink_agents.api.chat_message import (
     ChatMessage,
     MessageRole,
@@ -129,16 +126,14 @@ class ReActAgent(Agent):
         ------
         TypeError
             If the schema is neither a RowTypeInfo nor a BaseModel subclass, or if a
-            BaseModel schema cannot be rendered as a JSON Schema, or renders to one
-            that constrains nothing. Instructing the model to match such a schema
-            would leave every response acceptable.
+            BaseModel schema cannot be rendered as a JSON Schema.
         """
         super().__init__()
         self.add_resource(_DEFAULT_CHAT_MODEL, ResourceType.CHAT_MODEL, chat_model)
 
         if output_schema:
             if isinstance(output_schema, type) and issubclass(output_schema, BaseModel):
-                json_schema = render_constraining_output_schema(
+                json_schema = render_output_schema(
                     output_schema, lambda model: model.model_json_schema()
                 )
             elif isinstance(output_schema, RowTypeInfo):

--- a/python/flink_agents/api/agents/react_agent.py
+++ b/python/flink_agents/api/agents/react_agent.py
@@ -24,7 +24,10 @@ from pyflink.common import Row
 from pyflink.common.typeinfo import RowTypeInfo
 
 from flink_agents.api.agents.agent import STRUCTURED_OUTPUT, Agent
-from flink_agents.api.agents.types import OutputSchema, render_output_schema
+from flink_agents.api.agents.types import (
+    OutputSchema,
+    render_constraining_output_schema,
+)
 from flink_agents.api.chat_message import (
     ChatMessage,
     MessageRole,
@@ -135,7 +138,7 @@ class ReActAgent(Agent):
 
         if output_schema:
             if isinstance(output_schema, type) and issubclass(output_schema, BaseModel):
-                json_schema = render_output_schema(
+                json_schema = render_constraining_output_schema(
                     output_schema, lambda model: model.model_json_schema()
                 )
             elif isinstance(output_schema, RowTypeInfo):

--- a/python/flink_agents/api/agents/react_agent.py
+++ b/python/flink_agents/api/agents/react_agent.py
@@ -24,7 +24,7 @@ from pyflink.common import Row
 from pyflink.common.typeinfo import RowTypeInfo
 
 from flink_agents.api.agents.agent import STRUCTURED_OUTPUT, Agent
-from flink_agents.api.agents.types import OutputSchema
+from flink_agents.api.agents.types import OutputSchema, render_output_schema
 from flink_agents.api.chat_message import (
     ChatMessage,
     MessageRole,
@@ -121,13 +121,23 @@ class ReActAgent(Agent):
             The schema should be RowTypeInfo or subclass of BaseModel. When user
             provide output schema, ReAct agent will add system prompt to instruct
             response format of llm, and add output parser according to the schema.
+
+        Raises:
+        ------
+        TypeError
+            If the schema is neither a RowTypeInfo nor a BaseModel subclass, or if a
+            BaseModel schema cannot be rendered as a JSON Schema, or renders to one
+            that constrains nothing. Instructing the model to match such a schema
+            would leave every response acceptable.
         """
         super().__init__()
         self.add_resource(_DEFAULT_CHAT_MODEL, ResourceType.CHAT_MODEL, chat_model)
 
         if output_schema:
             if isinstance(output_schema, type) and issubclass(output_schema, BaseModel):
-                json_schema = output_schema.model_json_schema()
+                json_schema = render_output_schema(
+                    output_schema, lambda model: model.model_json_schema()
+                )
             elif isinstance(output_schema, RowTypeInfo):
                 json_schema = str(output_schema)
             else:

--- a/python/flink_agents/api/agents/tests/test_output_schema_render.py
+++ b/python/flink_agents/api/agents/tests/test_output_schema_render.py
@@ -21,7 +21,10 @@ import pytest
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.errors import PydanticInvalidForJsonSchema
 
-from flink_agents.api.agents.types import render_output_schema
+from flink_agents.api.agents.types import (
+    render_constraining_output_schema,
+    render_provider_output_schema,
+)
 
 
 def _render(model: type[BaseModel]) -> dict[str, Any]:
@@ -150,7 +153,7 @@ class Renderable(BaseModel):
 def test_unrenderable_member_raises_naming_the_model() -> None:
     """A member the renderer cannot express fails with a clear, chained error."""
     with pytest.raises(TypeError, match="Unrenderable") as exc_info:
-        render_output_schema(Unrenderable, _render)
+        render_provider_output_schema(Unrenderable, _render)
 
     assert "pass no output schema" in str(exc_info.value)
     assert isinstance(exc_info.value.__cause__, PydanticInvalidForJsonSchema)
@@ -159,19 +162,28 @@ def test_unrenderable_member_raises_naming_the_model() -> None:
 def test_nested_unrenderable_member_raises() -> None:
     """The failure of a nested member surfaces as the same clear error."""
     with pytest.raises(TypeError, match="NestsUnrenderable"):
-        render_output_schema(NestsUnrenderable, _render)
+        render_provider_output_schema(NestsUnrenderable, _render)
 
 
 def test_renderer_returning_no_document_raises() -> None:
     """A renderer yielding something other than a document fails as a TypeError."""
     with pytest.raises(TypeError, match="rather than a JSON Schema document"):
-        render_output_schema(Renderable, lambda model: "{}")
+        render_provider_output_schema(Renderable, lambda model: "{}")
+
+
+def test_field_less_model_is_accepted_without_the_constraint_check() -> None:
+    """A model with no fields renders and is returned, since nothing checks it here.
+
+    Callers that send the document to a provider render through this function, and a
+    schema the provider accepts must not be refused before the request is made.
+    """
+    assert render_provider_output_schema(FieldLess, _render) == _render(FieldLess)
 
 
 def test_field_less_model_raises_naming_the_root_path() -> None:
     """A model with no fields renders to a schema that constrains nothing."""
     with pytest.raises(TypeError, match=r"path \$ has no properties"):
-        render_output_schema(FieldLess, _render)
+        render_constraining_output_schema(FieldLess, _render)
 
 
 def test_field_less_model_raises_under_a_strict_renderer() -> None:
@@ -179,7 +191,7 @@ def test_field_less_model_raises_under_a_strict_renderer() -> None:
     assert _render_strict(FieldLess)["additionalProperties"] is False
 
     with pytest.raises(TypeError, match=r"path \$ has no properties"):
-        render_output_schema(FieldLess, _render_strict)
+        render_constraining_output_schema(FieldLess, _render_strict)
 
 
 def test_field_less_model_forbidding_extra_fields_raises() -> None:
@@ -187,31 +199,31 @@ def test_field_less_model_forbidding_extra_fields_raises() -> None:
     assert _render(ForbidsExtra)["additionalProperties"] is False
 
     with pytest.raises(TypeError, match=r"path \$ has no properties"):
-        render_output_schema(ForbidsExtra, _render)
+        render_constraining_output_schema(ForbidsExtra, _render)
 
 
 def test_nested_field_less_model_raises_naming_the_nested_path() -> None:
     """The walker resolves ``$ref`` into ``$defs`` and reports the member path."""
     with pytest.raises(TypeError, match=r"path \$\.inner has no properties"):
-        render_output_schema(NestsFieldLess, _render)
+        render_constraining_output_schema(NestsFieldLess, _render)
 
 
 def test_field_less_model_in_a_list_raises() -> None:
     """A list member is descended through ``items``."""
     with pytest.raises(TypeError, match=r"path \$\.xs has no properties"):
-        render_output_schema(ListsFieldLess, _render)
+        render_constraining_output_schema(ListsFieldLess, _render)
 
 
 def test_field_less_model_in_a_tuple_raises() -> None:
     """A tuple member is descended through ``prefixItems``."""
     with pytest.raises(TypeError, match=r"path \$\.t has no properties"):
-        render_output_schema(TuplesFieldLess, _render)
+        render_constraining_output_schema(TuplesFieldLess, _render)
 
 
 def test_field_less_model_as_a_map_value_raises() -> None:
     """A schema-valued ``additionalProperties`` is descended through."""
     with pytest.raises(TypeError, match=r"path \$\.m has no properties"):
-        render_output_schema(MapsToFieldLess, _render)
+        render_constraining_output_schema(MapsToFieldLess, _render)
 
 
 @pytest.mark.parametrize("model", [AnyOfsFieldLess, OneOfsFieldLess, AllOfsFieldLess])
@@ -220,20 +232,20 @@ def test_field_less_model_under_a_branch_keyword_raises(
 ) -> None:
     """Every branch keyword is descended through, not just the one a union emits."""
     with pytest.raises(TypeError, match=r"path \$\.u has no properties"):
-        render_output_schema(model, _render)
+        render_constraining_output_schema(model, _render)
 
 
 def test_map_member_is_accepted_under_a_normalizing_renderer() -> None:
     """A renderer that empties a map member must not turn it into a rejection."""
     # Fails if the emptiness check is ever moved back onto the renderer's output.
-    assert render_output_schema(TypedMap, _render_anthropic_style) == (
+    assert render_constraining_output_schema(TypedMap, _render_anthropic_style) == (
         _render_anthropic_style(TypedMap)
     )
 
 
 def test_return_value_is_the_renderer_output_not_the_model_schema() -> None:
     """Callers receive the wire format they asked for, not the model's own schema."""
-    schema = render_output_schema(Renderable, _render_strict)
+    schema = render_provider_output_schema(Renderable, _render_strict)
 
     assert schema == _render_strict(Renderable)
     assert schema != _render(Renderable)
@@ -242,54 +254,60 @@ def test_return_value_is_the_renderer_output_not_the_model_schema() -> None:
 def test_renderer_failure_raises_chained() -> None:
     """A renderer that fails is reported against the model, with the cause kept."""
     with pytest.raises(TypeError, match="Renderable") as exc_info:
-        render_output_schema(Renderable, _render_failing)
+        render_provider_output_schema(Renderable, _render_failing)
 
     assert isinstance(exc_info.value.__cause__, ValueError)
 
 
 def test_typed_map_member_is_accepted() -> None:
     """A ``dict[str, str]`` member omits ``properties``, which is not a defect."""
-    assert render_output_schema(TypedMap, _render) == _render(TypedMap)
+    assert render_constraining_output_schema(TypedMap, _render) == _render(TypedMap)
 
 
 def test_free_form_map_member_is_accepted() -> None:
     """A ``dict[str, Any]`` member is free-form by intent, not unconstrained."""
-    assert render_output_schema(FreeFormMap, _render) == _render(FreeFormMap)
+    assert render_constraining_output_schema(FreeFormMap, _render) == _render(
+        FreeFormMap
+    )
 
 
 def test_typed_extras_model_is_accepted() -> None:
     """An empty ``properties`` beside a schema-valued map still bounds every field."""
     assert _render(TypedExtras)["additionalProperties"] == {"type": "string"}
 
-    assert render_output_schema(TypedExtras, _render) == _render(TypedExtras)
+    assert render_constraining_output_schema(TypedExtras, _render) == _render(
+        TypedExtras
+    )
 
 
 def test_empty_schema_valued_additional_properties_is_accepted() -> None:
     """``{}`` is a schema, and falsy in Python, so the test must be an identity."""
     assert _render(OpenExtras)["additionalProperties"] == {}
 
-    assert render_output_schema(OpenExtras, _render) == _render(OpenExtras)
+    assert render_constraining_output_schema(OpenExtras, _render) == _render(OpenExtras)
 
 
 def test_object_member_without_properties_is_accepted() -> None:
     """An object that never declares ``properties`` is never the rejected shape."""
     assert "properties" not in _render(ObjectTypedMember)["properties"]["m"]
 
-    assert render_output_schema(ObjectTypedMember, _render) == _render(
+    assert render_constraining_output_schema(ObjectTypedMember, _render) == _render(
         ObjectTypedMember
     )
 
 
 def test_model_allowing_extra_fields_is_accepted() -> None:
     """``extra="allow"`` renders empty properties beside a permissive map."""
-    assert render_output_schema(ExtraAllowed, _render) == _render(ExtraAllowed)
+    assert render_constraining_output_schema(ExtraAllowed, _render) == _render(
+        ExtraAllowed
+    )
 
 
 def test_self_referential_model_is_accepted() -> None:
     """A model referencing itself terminates instead of recursing forever."""
-    assert render_output_schema(Node, _render) == _render(Node)
+    assert render_constraining_output_schema(Node, _render) == _render(Node)
 
 
 def test_renderable_model_returns_the_rendered_schema() -> None:
     """A schema that constrains the response is returned as the renderer built it."""
-    assert render_output_schema(Renderable, _render) == _render(Renderable)
+    assert render_provider_output_schema(Renderable, _render) == _render(Renderable)

--- a/python/flink_agents/api/agents/tests/test_output_schema_render.py
+++ b/python/flink_agents/api/agents/tests/test_output_schema_render.py
@@ -66,6 +66,19 @@ class Renderable(BaseModel):
     x: int
 
 
+class SelfReferential(BaseModel):
+    name: str
+    child: "SelfReferential | None" = None
+
+
+class MutualA(BaseModel):
+    b: "MutualB | None" = None
+
+
+class MutualB(BaseModel):
+    a: "MutualA | None" = None
+
+
 def test_unrenderable_member_raises_naming_the_model() -> None:
     """A member no JSON Schema can express is reported as a failure to render it.
 
@@ -102,6 +115,23 @@ def test_field_less_model_is_returned_as_rendered() -> None:
     not refused here.
     """
     assert render_output_schema(FieldLess, _render) == _render(FieldLess)
+
+
+@pytest.mark.parametrize("model", [SelfReferential, MutualA], ids=["direct", "mutual"])
+def test_self_referential_model_is_returned_as_rendered(
+    model: type[BaseModel],
+) -> None:
+    """A model reachable from itself renders and is returned as rendered.
+
+    Pydantic emits the cycle as a ``$ref`` into ``$defs`` and terminates, so there
+    is nothing to report. It hoists the root into ``$defs`` and renders it as a bare
+    ``$ref`` only when the root itself lies on the cycle, which is what separates
+    these models from one that merely nests another.
+    """
+    schema = render_output_schema(model, _render)
+
+    assert "$ref" in schema
+    assert schema == _render(model)
 
 
 def test_return_value_is_the_renderer_output_not_the_model_schema() -> None:

--- a/python/flink_agents/api/agents/tests/test_output_schema_render.py
+++ b/python/flink_agents/api/agents/tests/test_output_schema_render.py
@@ -15,16 +15,13 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 #################################################################################
-from typing import Any, Callable, Dict
+from typing import Any, Callable
 
 import pytest
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel
 from pydantic.errors import PydanticInvalidForJsonSchema
 
-from flink_agents.api.agents.types import (
-    render_constraining_output_schema,
-    render_provider_output_schema,
-)
+from flink_agents.api.agents.types import render_output_schema
 
 
 def _render(model: type[BaseModel]) -> dict[str, Any]:
@@ -47,20 +44,6 @@ def _close_objects(node: Any) -> Any:
     return closed
 
 
-def _render_anthropic_style(model: type[BaseModel]) -> dict[str, Any]:
-    """Empty every map member's properties, as one vendor renderer normalizes them.
-
-    A local stand-in: ``api`` may not depend on an integration's SDK.
-    """
-    return {
-        "type": "object",
-        "properties": {
-            "m": {"type": "object", "properties": {}, "additionalProperties": False}
-        },
-        "additionalProperties": False,
-    }
-
-
 def _render_failing(model: type[BaseModel]) -> dict[str, Any]:
     """Fail the way a vendor renderer does on a schema it cannot translate."""
     msg = "unsupported by this provider"
@@ -79,81 +62,20 @@ class FieldLess(BaseModel):
     pass
 
 
-class NestsFieldLess(BaseModel):
-    inner: FieldLess
-
-
-class ListsFieldLess(BaseModel):
-    xs: list[FieldLess]
-
-
-class TuplesFieldLess(BaseModel):
-    t: tuple[FieldLess, int]
-
-
-class MapsToFieldLess(BaseModel):
-    m: dict[str, FieldLess]
-
-
-_EMPTY_OBJECT = {"type": "object", "properties": {}}
-
-
-class AnyOfsFieldLess(BaseModel):
-    u: FieldLess | int
-
-
-class OneOfsFieldLess(BaseModel):
-    u: int = Field(json_schema_extra={"oneOf": [_EMPTY_OBJECT]})
-
-
-class AllOfsFieldLess(BaseModel):
-    u: int = Field(json_schema_extra={"allOf": [_EMPTY_OBJECT]})
-
-
-class TypedMap(BaseModel):
-    m: dict[str, str]
-
-
-class FreeFormMap(BaseModel):
-    m: dict[str, Any]
-
-
-class TypedExtras(BaseModel):
-    model_config = ConfigDict(extra="allow")
-    __pydantic_extra__: Dict[str, str]
-
-
-class OpenExtras(BaseModel):
-    model_config = ConfigDict(
-        extra="allow", json_schema_extra={"additionalProperties": {}}
-    )
-
-
-class ObjectTypedMember(BaseModel):
-    m: int = Field(json_schema_extra={"type": "object"})
-
-
-class ForbidsExtra(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-
-class ExtraAllowed(BaseModel):
-    model_config = ConfigDict(extra="allow")
-
-
-class Node(BaseModel):
-    name: str
-    children: list["Node"] = []
-
-
 class Renderable(BaseModel):
     x: int
 
 
 def test_unrenderable_member_raises_naming_the_model() -> None:
-    """A member the renderer cannot express fails with a clear, chained error."""
-    with pytest.raises(TypeError, match="Unrenderable") as exc_info:
-        render_provider_output_schema(Unrenderable, _render)
+    """A member no JSON Schema can express is reported as a failure to render it.
+
+    The wording separates that from a renderer refusing a model the model's own
+    render accepts, which is a different failure carrying a different remedy.
+    """
+    with pytest.raises(
+        TypeError, match="Unrenderable cannot be rendered as a JSON Schema"
+    ) as exc_info:
+        render_output_schema(Unrenderable, _render)
 
     assert "pass no output schema" in str(exc_info.value)
     assert isinstance(exc_info.value.__cause__, PydanticInvalidForJsonSchema)
@@ -161,153 +83,44 @@ def test_unrenderable_member_raises_naming_the_model() -> None:
 
 def test_nested_unrenderable_member_raises() -> None:
     """The failure of a nested member surfaces as the same clear error."""
-    with pytest.raises(TypeError, match="NestsUnrenderable"):
-        render_provider_output_schema(NestsUnrenderable, _render)
+    with pytest.raises(
+        TypeError, match="NestsUnrenderable cannot be rendered as a JSON Schema"
+    ):
+        render_output_schema(NestsUnrenderable, _render)
 
 
 def test_renderer_returning_no_document_raises() -> None:
     """A renderer yielding something other than a document fails as a TypeError."""
     with pytest.raises(TypeError, match="rather than a JSON Schema document"):
-        render_provider_output_schema(Renderable, lambda model: "{}")
+        render_output_schema(Renderable, lambda model: "{}")
 
 
-def test_field_less_model_is_accepted_without_the_constraint_check() -> None:
-    """A model with no fields renders and is returned, since nothing checks it here.
+def test_field_less_model_is_returned_as_rendered() -> None:
+    """A model declaring no fields renders and is returned as rendered.
 
-    Callers that send the document to a provider render through this function, and a
-    schema the provider accepts must not be refused before the request is made.
+    Whether such a document is usable belongs to whatever consumes it, so it is
+    not refused here.
     """
-    assert render_provider_output_schema(FieldLess, _render) == _render(FieldLess)
-
-
-def test_field_less_model_raises_naming_the_root_path() -> None:
-    """A model with no fields renders to a schema that constrains nothing."""
-    with pytest.raises(TypeError, match=r"path \$ has no properties"):
-        render_constraining_output_schema(FieldLess, _render)
-
-
-def test_field_less_model_raises_under_a_strict_renderer() -> None:
-    """A closed object, which is what three of the render sites emit, still fires."""
-    assert _render_strict(FieldLess)["additionalProperties"] is False
-
-    with pytest.raises(TypeError, match=r"path \$ has no properties"):
-        render_constraining_output_schema(FieldLess, _render_strict)
-
-
-def test_field_less_model_forbidding_extra_fields_raises() -> None:
-    """``extra="forbid"`` closes the object with ``False``; it is still empty."""
-    assert _render(ForbidsExtra)["additionalProperties"] is False
-
-    with pytest.raises(TypeError, match=r"path \$ has no properties"):
-        render_constraining_output_schema(ForbidsExtra, _render)
-
-
-def test_nested_field_less_model_raises_naming_the_nested_path() -> None:
-    """The walker resolves ``$ref`` into ``$defs`` and reports the member path."""
-    with pytest.raises(TypeError, match=r"path \$\.inner has no properties"):
-        render_constraining_output_schema(NestsFieldLess, _render)
-
-
-def test_field_less_model_in_a_list_raises() -> None:
-    """A list member is descended through ``items``."""
-    with pytest.raises(TypeError, match=r"path \$\.xs has no properties"):
-        render_constraining_output_schema(ListsFieldLess, _render)
-
-
-def test_field_less_model_in_a_tuple_raises() -> None:
-    """A tuple member is descended through ``prefixItems``."""
-    with pytest.raises(TypeError, match=r"path \$\.t has no properties"):
-        render_constraining_output_schema(TuplesFieldLess, _render)
-
-
-def test_field_less_model_as_a_map_value_raises() -> None:
-    """A schema-valued ``additionalProperties`` is descended through."""
-    with pytest.raises(TypeError, match=r"path \$\.m has no properties"):
-        render_constraining_output_schema(MapsToFieldLess, _render)
-
-
-@pytest.mark.parametrize("model", [AnyOfsFieldLess, OneOfsFieldLess, AllOfsFieldLess])
-def test_field_less_model_under_a_branch_keyword_raises(
-    model: type[BaseModel],
-) -> None:
-    """Every branch keyword is descended through, not just the one a union emits."""
-    with pytest.raises(TypeError, match=r"path \$\.u has no properties"):
-        render_constraining_output_schema(model, _render)
-
-
-def test_map_member_is_accepted_under_a_normalizing_renderer() -> None:
-    """A renderer that empties a map member must not turn it into a rejection."""
-    # Fails if the emptiness check is ever moved back onto the renderer's output.
-    assert render_constraining_output_schema(TypedMap, _render_anthropic_style) == (
-        _render_anthropic_style(TypedMap)
-    )
+    assert render_output_schema(FieldLess, _render) == _render(FieldLess)
 
 
 def test_return_value_is_the_renderer_output_not_the_model_schema() -> None:
     """Callers receive the wire format they asked for, not the model's own schema."""
-    schema = render_provider_output_schema(Renderable, _render_strict)
+    schema = render_output_schema(Renderable, _render_strict)
 
     assert schema == _render_strict(Renderable)
     assert schema != _render(Renderable)
 
 
 def test_renderer_failure_raises_chained() -> None:
-    """A renderer that fails is reported against the model, with the cause kept."""
-    with pytest.raises(TypeError, match="Renderable") as exc_info:
-        render_provider_output_schema(Renderable, _render_failing)
+    """A renderer that fails is reported against the model, with the cause kept.
+
+    The wording separates that from a model no JSON Schema can express, which is a
+    different failure carrying a different remedy.
+    """
+    with pytest.raises(
+        TypeError, match="Renderable cannot be translated by the renderer in use"
+    ) as exc_info:
+        render_output_schema(Renderable, _render_failing)
 
     assert isinstance(exc_info.value.__cause__, ValueError)
-
-
-def test_typed_map_member_is_accepted() -> None:
-    """A ``dict[str, str]`` member omits ``properties``, which is not a defect."""
-    assert render_constraining_output_schema(TypedMap, _render) == _render(TypedMap)
-
-
-def test_free_form_map_member_is_accepted() -> None:
-    """A ``dict[str, Any]`` member is free-form by intent, not unconstrained."""
-    assert render_constraining_output_schema(FreeFormMap, _render) == _render(
-        FreeFormMap
-    )
-
-
-def test_typed_extras_model_is_accepted() -> None:
-    """An empty ``properties`` beside a schema-valued map still bounds every field."""
-    assert _render(TypedExtras)["additionalProperties"] == {"type": "string"}
-
-    assert render_constraining_output_schema(TypedExtras, _render) == _render(
-        TypedExtras
-    )
-
-
-def test_empty_schema_valued_additional_properties_is_accepted() -> None:
-    """``{}`` is a schema, and falsy in Python, so the test must be an identity."""
-    assert _render(OpenExtras)["additionalProperties"] == {}
-
-    assert render_constraining_output_schema(OpenExtras, _render) == _render(OpenExtras)
-
-
-def test_object_member_without_properties_is_accepted() -> None:
-    """An object that never declares ``properties`` is never the rejected shape."""
-    assert "properties" not in _render(ObjectTypedMember)["properties"]["m"]
-
-    assert render_constraining_output_schema(ObjectTypedMember, _render) == _render(
-        ObjectTypedMember
-    )
-
-
-def test_model_allowing_extra_fields_is_accepted() -> None:
-    """``extra="allow"`` renders empty properties beside a permissive map."""
-    assert render_constraining_output_schema(ExtraAllowed, _render) == _render(
-        ExtraAllowed
-    )
-
-
-def test_self_referential_model_is_accepted() -> None:
-    """A model referencing itself terminates instead of recursing forever."""
-    assert render_constraining_output_schema(Node, _render) == _render(Node)
-
-
-def test_renderable_model_returns_the_rendered_schema() -> None:
-    """A schema that constrains the response is returned as the renderer built it."""
-    assert render_provider_output_schema(Renderable, _render) == _render(Renderable)

--- a/python/flink_agents/api/agents/tests/test_output_schema_render.py
+++ b/python/flink_agents/api/agents/tests/test_output_schema_render.py
@@ -1,0 +1,295 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+from typing import Any, Callable, Dict
+
+import pytest
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic.errors import PydanticInvalidForJsonSchema
+
+from flink_agents.api.agents.types import render_output_schema
+
+
+def _render(model: type[BaseModel]) -> dict[str, Any]:
+    return model.model_json_schema()
+
+
+def _render_strict(model: type[BaseModel]) -> dict[str, Any]:
+    """Render the way the strict renderers do, closing every object."""
+    return _close_objects(model.model_json_schema())
+
+
+def _close_objects(node: Any) -> Any:
+    if isinstance(node, list):
+        return [_close_objects(item) for item in node]
+    if not isinstance(node, dict):
+        return node
+    closed = {key: _close_objects(value) for key, value in node.items()}
+    if closed.get("type") == "object" and "additionalProperties" not in closed:
+        closed["additionalProperties"] = False
+    return closed
+
+
+def _render_anthropic_style(model: type[BaseModel]) -> dict[str, Any]:
+    """Empty every map member's properties, as one vendor renderer normalizes them.
+
+    A local stand-in: ``api`` may not depend on an integration's SDK.
+    """
+    return {
+        "type": "object",
+        "properties": {
+            "m": {"type": "object", "properties": {}, "additionalProperties": False}
+        },
+        "additionalProperties": False,
+    }
+
+
+def _render_failing(model: type[BaseModel]) -> dict[str, Any]:
+    """Fail the way a vendor renderer does on a schema it cannot translate."""
+    msg = "unsupported by this provider"
+    raise ValueError(msg)
+
+
+class Unrenderable(BaseModel):
+    cb: Callable[[int], int]
+
+
+class NestsUnrenderable(BaseModel):
+    inner: Unrenderable
+
+
+class FieldLess(BaseModel):
+    pass
+
+
+class NestsFieldLess(BaseModel):
+    inner: FieldLess
+
+
+class ListsFieldLess(BaseModel):
+    xs: list[FieldLess]
+
+
+class TuplesFieldLess(BaseModel):
+    t: tuple[FieldLess, int]
+
+
+class MapsToFieldLess(BaseModel):
+    m: dict[str, FieldLess]
+
+
+_EMPTY_OBJECT = {"type": "object", "properties": {}}
+
+
+class AnyOfsFieldLess(BaseModel):
+    u: FieldLess | int
+
+
+class OneOfsFieldLess(BaseModel):
+    u: int = Field(json_schema_extra={"oneOf": [_EMPTY_OBJECT]})
+
+
+class AllOfsFieldLess(BaseModel):
+    u: int = Field(json_schema_extra={"allOf": [_EMPTY_OBJECT]})
+
+
+class TypedMap(BaseModel):
+    m: dict[str, str]
+
+
+class FreeFormMap(BaseModel):
+    m: dict[str, Any]
+
+
+class TypedExtras(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    __pydantic_extra__: Dict[str, str]
+
+
+class OpenExtras(BaseModel):
+    model_config = ConfigDict(
+        extra="allow", json_schema_extra={"additionalProperties": {}}
+    )
+
+
+class ObjectTypedMember(BaseModel):
+    m: int = Field(json_schema_extra={"type": "object"})
+
+
+class ForbidsExtra(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class ExtraAllowed(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class Node(BaseModel):
+    name: str
+    children: list["Node"] = []
+
+
+class Renderable(BaseModel):
+    x: int
+
+
+def test_unrenderable_member_raises_naming_the_model() -> None:
+    """A member the renderer cannot express fails with a clear, chained error."""
+    with pytest.raises(TypeError, match="Unrenderable") as exc_info:
+        render_output_schema(Unrenderable, _render)
+
+    assert "pass no output schema" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, PydanticInvalidForJsonSchema)
+
+
+def test_nested_unrenderable_member_raises() -> None:
+    """The failure of a nested member surfaces as the same clear error."""
+    with pytest.raises(TypeError, match="NestsUnrenderable"):
+        render_output_schema(NestsUnrenderable, _render)
+
+
+def test_renderer_returning_no_document_raises() -> None:
+    """A renderer yielding something other than a document fails as a TypeError."""
+    with pytest.raises(TypeError, match="rather than a JSON Schema document"):
+        render_output_schema(Renderable, lambda model: "{}")
+
+
+def test_field_less_model_raises_naming_the_root_path() -> None:
+    """A model with no fields renders to a schema that constrains nothing."""
+    with pytest.raises(TypeError, match=r"path \$ has no properties"):
+        render_output_schema(FieldLess, _render)
+
+
+def test_field_less_model_raises_under_a_strict_renderer() -> None:
+    """A closed object, which is what three of the render sites emit, still fires."""
+    assert _render_strict(FieldLess)["additionalProperties"] is False
+
+    with pytest.raises(TypeError, match=r"path \$ has no properties"):
+        render_output_schema(FieldLess, _render_strict)
+
+
+def test_field_less_model_forbidding_extra_fields_raises() -> None:
+    """``extra="forbid"`` closes the object with ``False``; it is still empty."""
+    assert _render(ForbidsExtra)["additionalProperties"] is False
+
+    with pytest.raises(TypeError, match=r"path \$ has no properties"):
+        render_output_schema(ForbidsExtra, _render)
+
+
+def test_nested_field_less_model_raises_naming_the_nested_path() -> None:
+    """The walker resolves ``$ref`` into ``$defs`` and reports the member path."""
+    with pytest.raises(TypeError, match=r"path \$\.inner has no properties"):
+        render_output_schema(NestsFieldLess, _render)
+
+
+def test_field_less_model_in_a_list_raises() -> None:
+    """A list member is descended through ``items``."""
+    with pytest.raises(TypeError, match=r"path \$\.xs has no properties"):
+        render_output_schema(ListsFieldLess, _render)
+
+
+def test_field_less_model_in_a_tuple_raises() -> None:
+    """A tuple member is descended through ``prefixItems``."""
+    with pytest.raises(TypeError, match=r"path \$\.t has no properties"):
+        render_output_schema(TuplesFieldLess, _render)
+
+
+def test_field_less_model_as_a_map_value_raises() -> None:
+    """A schema-valued ``additionalProperties`` is descended through."""
+    with pytest.raises(TypeError, match=r"path \$\.m has no properties"):
+        render_output_schema(MapsToFieldLess, _render)
+
+
+@pytest.mark.parametrize("model", [AnyOfsFieldLess, OneOfsFieldLess, AllOfsFieldLess])
+def test_field_less_model_under_a_branch_keyword_raises(
+    model: type[BaseModel],
+) -> None:
+    """Every branch keyword is descended through, not just the one a union emits."""
+    with pytest.raises(TypeError, match=r"path \$\.u has no properties"):
+        render_output_schema(model, _render)
+
+
+def test_map_member_is_accepted_under_a_normalizing_renderer() -> None:
+    """A renderer that empties a map member must not turn it into a rejection."""
+    # Fails if the emptiness check is ever moved back onto the renderer's output.
+    assert render_output_schema(TypedMap, _render_anthropic_style) == (
+        _render_anthropic_style(TypedMap)
+    )
+
+
+def test_return_value_is_the_renderer_output_not_the_model_schema() -> None:
+    """Callers receive the wire format they asked for, not the model's own schema."""
+    schema = render_output_schema(Renderable, _render_strict)
+
+    assert schema == _render_strict(Renderable)
+    assert schema != _render(Renderable)
+
+
+def test_renderer_failure_raises_chained() -> None:
+    """A renderer that fails is reported against the model, with the cause kept."""
+    with pytest.raises(TypeError, match="Renderable") as exc_info:
+        render_output_schema(Renderable, _render_failing)
+
+    assert isinstance(exc_info.value.__cause__, ValueError)
+
+
+def test_typed_map_member_is_accepted() -> None:
+    """A ``dict[str, str]`` member omits ``properties``, which is not a defect."""
+    assert render_output_schema(TypedMap, _render) == _render(TypedMap)
+
+
+def test_free_form_map_member_is_accepted() -> None:
+    """A ``dict[str, Any]`` member is free-form by intent, not unconstrained."""
+    assert render_output_schema(FreeFormMap, _render) == _render(FreeFormMap)
+
+
+def test_typed_extras_model_is_accepted() -> None:
+    """An empty ``properties`` beside a schema-valued map still bounds every field."""
+    assert _render(TypedExtras)["additionalProperties"] == {"type": "string"}
+
+    assert render_output_schema(TypedExtras, _render) == _render(TypedExtras)
+
+
+def test_empty_schema_valued_additional_properties_is_accepted() -> None:
+    """``{}`` is a schema, and falsy in Python, so the test must be an identity."""
+    assert _render(OpenExtras)["additionalProperties"] == {}
+
+    assert render_output_schema(OpenExtras, _render) == _render(OpenExtras)
+
+
+def test_object_member_without_properties_is_accepted() -> None:
+    """An object that never declares ``properties`` is never the rejected shape."""
+    assert "properties" not in _render(ObjectTypedMember)["properties"]["m"]
+
+    assert render_output_schema(ObjectTypedMember, _render) == _render(
+        ObjectTypedMember
+    )
+
+
+def test_model_allowing_extra_fields_is_accepted() -> None:
+    """``extra="allow"`` renders empty properties beside a permissive map."""
+    assert render_output_schema(ExtraAllowed, _render) == _render(ExtraAllowed)
+
+
+def test_self_referential_model_is_accepted() -> None:
+    """A model referencing itself terminates instead of recursing forever."""
+    assert render_output_schema(Node, _render) == _render(Node)
+
+
+def test_renderable_model_returns_the_rendered_schema() -> None:
+    """A schema that constrains the response is returned as the renderer built it."""
+    assert render_output_schema(Renderable, _render) == _render(Renderable)

--- a/python/flink_agents/api/agents/tests/test_react_agent.py
+++ b/python/flink_agents/api/agents/tests/test_react_agent.py
@@ -1,0 +1,113 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+from typing import Any, Callable
+
+import pytest
+from pydantic import BaseModel
+from pyflink.common.typeinfo import Types
+
+from flink_agents.api.agents.react_agent import (
+    _DEFAULT_SCHEMA_PROMPT,
+    ReActAgent,
+)
+from flink_agents.api.resource import ResourceDescriptor, ResourceType
+
+# Named rather than imported so building an agent needs no chat model on the path;
+# a descriptor records the class and resolves it only when the resource is created.
+_CHAT_MODEL_CLASS = (
+    "flink_agents.integrations.chat_models.ollama_chat_model.OllamaChatModelSetup"
+)
+
+
+class Person(BaseModel):
+    """A representative BaseModel output schema."""
+
+    name: str
+    age: int
+
+
+class Unrenderable(BaseModel):
+    """A schema carrying a member that no JSON Schema can express."""
+
+    cb: Callable[[int], int]
+
+
+class FieldLess(BaseModel):
+    """A schema declaring no fields, so it constrains nothing."""
+
+
+class Labelled(BaseModel):
+    """A schema whose only member is a free-form map, a legitimate constraint."""
+
+    labels: dict[str, str]
+
+
+def _agent(output_schema: Any) -> ReActAgent:
+    return ReActAgent(
+        chat_model=ResourceDescriptor(
+            clazz=_CHAT_MODEL_CLASS, connection="ollama_connection", model="qwen3:8b"
+        ),
+        output_schema=output_schema,
+    )
+
+
+def _schema_prompt(agent: ReActAgent) -> str:
+    """The prompt text the agent derived from the output schema."""
+    return agent._resources[ResourceType.PROMPT][_DEFAULT_SCHEMA_PROMPT].template
+
+
+def _expected_prompt(rendered: Any) -> str:
+    return f"The final response should be json format, and match the schema {rendered}."
+
+
+def test_unrenderable_output_schema_raises_naming_the_model() -> None:
+    """A schema that cannot be rendered fails at construction, not at the provider."""
+    with pytest.raises(TypeError, match="Unrenderable cannot be rendered"):
+        _agent(Unrenderable)
+
+
+def test_field_less_output_schema_raises_naming_the_model() -> None:
+    """A schema declaring no fields would instruct the model to match nothing."""
+    with pytest.raises(TypeError, match="FieldLess renders to a JSON Schema"):
+        _agent(FieldLess)
+
+
+def test_map_member_output_schema_is_accepted() -> None:
+    """A free-form map is a legitimate constraint and reaches the prompt intact."""
+    assert _schema_prompt(_agent(Labelled)) == _expected_prompt(
+        Labelled.model_json_schema()
+    )
+
+
+def test_renderable_output_schema_keeps_the_schema_prompt() -> None:
+    """An ordinary schema still yields exactly the prompt it did before."""
+    assert _schema_prompt(_agent(Person)) == _expected_prompt(
+        Person.model_json_schema()
+    )
+
+
+def test_row_type_info_output_schema_keeps_the_prompt_fallback() -> None:
+    """A RowTypeInfo has no JSON Schema render and keeps its own prompt text."""
+    row_type = Types.ROW_NAMED(["name"], [Types.STRING()])
+    assert _schema_prompt(_agent(row_type)) == _expected_prompt(row_type)
+
+
+def test_unsupported_output_schema_type_reports_the_type() -> None:
+    """A schema of neither supported kind is rejected before any render is attempted."""
+    with pytest.raises(TypeError, match="is not supported"):
+        _agent("not-a-schema")

--- a/python/flink_agents/api/agents/tests/test_react_agent.py
+++ b/python/flink_agents/api/agents/tests/test_react_agent.py
@@ -48,13 +48,7 @@ class Unrenderable(BaseModel):
 
 
 class FieldLess(BaseModel):
-    """A schema declaring no fields, so it constrains nothing."""
-
-
-class Labelled(BaseModel):
-    """A schema whose only member is a free-form map, a legitimate constraint."""
-
-    labels: dict[str, str]
+    """A schema declaring no fields."""
 
 
 def _agent(output_schema: Any) -> ReActAgent:
@@ -81,21 +75,15 @@ def test_unrenderable_output_schema_raises_naming_the_model() -> None:
         _agent(Unrenderable)
 
 
-def test_field_less_output_schema_raises_naming_the_model() -> None:
-    """A schema declaring no fields would instruct the model to match nothing."""
-    with pytest.raises(TypeError, match="FieldLess renders to a JSON Schema"):
-        _agent(FieldLess)
-
-
-def test_map_member_output_schema_is_accepted() -> None:
-    """A free-form map is a legitimate constraint and reaches the prompt intact."""
-    assert _schema_prompt(_agent(Labelled)) == _expected_prompt(
-        Labelled.model_json_schema()
+def test_field_less_output_schema_reaches_the_schema_prompt() -> None:
+    """A schema declaring no fields renders, and reaches the prompt as rendered."""
+    assert _schema_prompt(_agent(FieldLess)) == _expected_prompt(
+        FieldLess.model_json_schema()
     )
 
 
 def test_renderable_output_schema_keeps_the_schema_prompt() -> None:
-    """An ordinary schema still yields exactly the prompt it did before."""
+    """An ordinary schema yields the prompt built from its rendered JSON Schema."""
     assert _schema_prompt(_agent(Person)) == _expected_prompt(
         Person.model_json_schema()
     )
@@ -108,6 +96,6 @@ def test_row_type_info_output_schema_keeps_the_prompt_fallback() -> None:
 
 
 def test_unsupported_output_schema_type_reports_the_type() -> None:
-    """A schema of neither supported kind is rejected before any render is attempted."""
-    with pytest.raises(TypeError, match="is not supported"):
+    """A schema of neither supported kind is rejected, named by the type received."""
+    with pytest.raises(TypeError, match=r"<class 'str'> is not supported"):
         _agent("not-a-schema")

--- a/python/flink_agents/api/agents/types.py
+++ b/python/flink_agents/api/agents/types.py
@@ -67,25 +67,25 @@ class OutputSchema(BaseModel):
         return self
 
 
-def render_output_schema(
+def render_provider_output_schema(
     model: type[BaseModel], render: Callable[[type[BaseModel]], dict[str, Any]]
 ) -> dict[str, Any]:
-    """Render an output schema, refusing one that cannot constrain the response.
-
-    Whether a model expresses a constraint is a property of the model, not of a
-    provider's wire format, so the check runs against the model's own JSON Schema
-    and only the returned document comes from ``render``. That keeps the check
-    independent of how any SDK normalizes a schema: one renderer rewrites every
-    map-typed member into an empty object, which is indistinguishable from a model
-    that declares no fields at all.
+    """Render an output schema for a provider, reporting a render failure clearly.
 
     The renderer is supplied by the caller because each chat model translates a
     schema with its own vendor renderer, and this module may not depend on any of
-    them. Both renders can fail, and they fail for different reasons: the model's
-    own render rejects a model that has no JSON Schema at all, while a vendor
-    renderer additionally rejects models it will not accept, such as one carrying
-    an untyped member that renders to a document with no ``type``. Neither wrapper
-    is therefore removable.
+    them. The model's own render runs first so that a model no JSON Schema can
+    express is reported as exactly that: a vendor renderer renders the model
+    itself, so it would otherwise surface the same failure worded as a translation
+    failure. The vendor render is wrapped in turn because it rejects models the
+    model's own render accepts, such as one carrying an untyped member that renders
+    to a document with no ``type``.
+
+    A schema that renders but declares no fields is returned as rendered. Whether
+    such a document is usable is the receiving provider's to judge, and refusing it
+    here would fail a request that succeeds today. Callers whose deliverable is the
+    rendered document itself have no provider to defer to and use
+    ``render_constraining_output_schema`` instead.
 
     Args:
         model: The model class describing the shape the response must take.
@@ -95,10 +95,51 @@ def render_output_schema(
         The document ``render`` produced.
 
     Raises:
-        TypeError: If ``model`` has no JSON Schema, if it renders to one containing
-            an object that declares no properties and so constrains nothing, or if
-            ``render`` fails or returns something other than a document.
+        TypeError: If ``model`` has no JSON Schema, or if ``render`` fails or returns
+            something other than a document.
     """
+    return _render_output_schema(model, render, reject_unconstrained=False)
+
+
+def render_constraining_output_schema(
+    model: type[BaseModel], render: Callable[[type[BaseModel]], dict[str, Any]]
+) -> dict[str, Any]:
+    """Render an output schema, refusing one that cannot constrain the response.
+
+    For a caller that consumes the rendered document itself rather than sending it
+    to a provider, such as one pasting it into an instruction prompt. A document
+    describing an object with no fields instructs the model to match nothing, and
+    every response then satisfies it.
+
+    Whether a model expresses a constraint is a property of the model, not of a
+    provider's wire format, so the check runs against the model's own JSON Schema
+    and only the returned document comes from ``render``. That keeps the check
+    independent of how any SDK normalizes a schema: one renderer rewrites every
+    map-typed member into an empty object, which is indistinguishable from a model
+    that declares no fields at all.
+
+    Args:
+        model: The model class describing the shape the response must take.
+        render: Renders ``model`` in the wire format the caller expects.
+
+    Returns:
+        The document ``render`` produced.
+
+    Raises:
+        TypeError: Everything ``render_provider_output_schema`` raises, and
+            additionally if ``model`` renders to a JSON Schema containing an object
+            that declares no properties and so constrains nothing.
+    """
+    return _render_output_schema(model, render, reject_unconstrained=True)
+
+
+def _render_output_schema(
+    model: type[BaseModel],
+    render: Callable[[type[BaseModel]], dict[str, Any]],
+    *,
+    reject_unconstrained: bool,
+) -> dict[str, Any]:
+    """Back the two public renderers, which differ only in the emptiness check."""
     try:
         document = model.model_json_schema()
     except Exception as e:
@@ -110,10 +151,11 @@ def render_output_schema(
         )
         raise TypeError(msg) from e
 
-    defs = document.get("$defs")
-    _reject_empty_objects(
-        document, "$", defs if isinstance(defs, dict) else {}, set(), model
-    )
+    if reject_unconstrained:
+        defs = document.get("$defs")
+        _reject_empty_objects(
+            document, "$", defs if isinstance(defs, dict) else {}, set(), model
+        )
 
     try:
         schema = render(model)

--- a/python/flink_agents/api/agents/types.py
+++ b/python/flink_agents/api/agents/types.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 #################################################################################
 import importlib
-from typing import Any
+from typing import Any, Callable
 
 from pydantic import BaseModel, ConfigDict, model_serializer, model_validator
 from pyflink.common.typeinfo import BasicType, BasicTypeInfo, RowTypeInfo
@@ -65,3 +65,135 @@ class OutputSchema(BaseModel):
                 module = importlib.import_module(output_schema["module"])
                 self["output_schema"] = getattr(module, output_schema["class"])
         return self
+
+
+def render_output_schema(
+    model: type[BaseModel], render: Callable[[type[BaseModel]], dict[str, Any]]
+) -> dict[str, Any]:
+    """Render an output schema, refusing one that cannot constrain the response.
+
+    Whether a model expresses a constraint is a property of the model, not of a
+    provider's wire format, so the check runs against the model's own JSON Schema
+    and only the returned document comes from ``render``. That keeps the check
+    independent of how any SDK normalizes a schema: one renderer rewrites every
+    map-typed member into an empty object, which is indistinguishable from a model
+    that declares no fields at all.
+
+    The renderer is supplied by the caller because each chat model translates a
+    schema with its own vendor renderer, and this module may not depend on any of
+    them. Both renders can fail, and they fail for different reasons: the model's
+    own render rejects a model that has no JSON Schema at all, while a vendor
+    renderer additionally rejects models it will not accept, such as one carrying
+    an untyped member that renders to a document with no ``type``. Neither wrapper
+    is therefore removable.
+
+    Args:
+        model: The model class describing the shape the response must take.
+        render: Renders ``model`` in the wire format the chat model expects.
+
+    Returns:
+        The document ``render`` produced.
+
+    Raises:
+        TypeError: If ``model`` has no JSON Schema, if it renders to one containing
+            an object that declares no properties and so constrains nothing, or if
+            ``render`` fails or returns something other than a document.
+    """
+    try:
+        document = model.model_json_schema()
+    except Exception as e:
+        msg = (
+            f"Output schema {model.__module__}.{model.__qualname__} cannot be"
+            " rendered as a JSON Schema, so it cannot constrain the response. Use a"
+            " schema whose fields are all JSON-Schema-renderable, or pass no output"
+            f" schema. Rendering it reported: {e}"
+        )
+        raise TypeError(msg) from e
+
+    defs = document.get("$defs")
+    _reject_empty_objects(
+        document, "$", defs if isinstance(defs, dict) else {}, set(), model
+    )
+
+    try:
+        schema = render(model)
+    except Exception as e:
+        msg = (
+            f"Output schema {model.__module__}.{model.__qualname__} cannot be"
+            " translated for this chat model, so it cannot constrain the response."
+            " Use a schema whose fields are all JSON-Schema-renderable, or pass no"
+            f" output schema. The renderer reported: {e}"
+        )
+        raise TypeError(msg) from e
+    if not isinstance(schema, dict):
+        msg = (
+            f"Output schema {model.__module__}.{model.__qualname__} rendered to"
+            f" {type(schema).__name__} rather than a JSON Schema document, so it"
+            " cannot constrain the response. Supply a renderer that returns a JSON"
+            " Schema document, or pass no output schema."
+        )
+        raise TypeError(msg)
+    return schema
+
+
+def _reject_empty_objects(
+    node: Any,
+    path: str,
+    defs: dict[str, Any],
+    visited: set[int],
+    model: type[BaseModel],
+) -> None:
+    """Raise if any object below ``node`` declares an empty ``properties``.
+
+    ``properties`` present and empty is an object that admits every response and
+    rejects none. ``properties`` absent is a free-form map such as
+    ``dict[str, str]``, which is a legitimate constraint and is left alone.
+
+    An empty ``properties`` still constrains something when ``additionalProperties``
+    carries a schema, which bounds every extra member, or ``True``, which admits
+    them deliberately. Only an absent or ``False`` ``additionalProperties`` leaves
+    the object expressing nothing. The tests are identity comparisons because a
+    JSON Schema document may hold ``{}`` there, which is a legitimate schema and is
+    falsy in Python.
+
+    Descends through ``properties``, ``items``, ``prefixItems``, a schema-valued
+    ``additionalProperties``, the ``anyOf``/``oneOf``/``allOf`` branches, and any
+    ``$defs`` entry a ``$ref`` reaches.
+    """
+    if not isinstance(node, dict) or id(node) in visited:
+        return
+    visited.add(id(node))
+
+    ref = node.get("$ref")
+    if isinstance(ref, str):
+        prefix = "#/$defs/"
+        target = defs.get(ref[len(prefix) :]) if ref.startswith(prefix) else None
+        _reject_empty_objects(target, path, defs, visited, model)
+        return
+
+    properties = node.get("properties")
+    additional = node.get("additionalProperties")
+    if (
+        node.get("type") == "object"
+        and (additional is None or additional is False)
+        and isinstance(properties, dict)
+        and not properties
+    ):
+        msg = (
+            f"Output schema {model.__module__}.{model.__qualname__} renders to a"
+            " JSON Schema that cannot constrain the response: the object at path"
+            f" {path} has no properties. Use a schema whose objects each declare at"
+            " least one field, or pass no output schema."
+        )
+        raise TypeError(msg)
+
+    if isinstance(properties, dict):
+        for name, child in properties.items():
+            _reject_empty_objects(child, f"{path}.{name}", defs, visited, model)
+    _reject_empty_objects(node.get("items"), path, defs, visited, model)
+    _reject_empty_objects(node.get("additionalProperties"), path, defs, visited, model)
+    for keyword in ("prefixItems", "anyOf", "oneOf", "allOf"):
+        branches = node.get(keyword)
+        if isinstance(branches, list):
+            for branch in branches:
+                _reject_empty_objects(branch, path, defs, visited, model)

--- a/python/flink_agents/api/agents/types.py
+++ b/python/flink_agents/api/agents/types.py
@@ -67,56 +67,24 @@ class OutputSchema(BaseModel):
         return self
 
 
-def render_provider_output_schema(
+def render_output_schema(
     model: type[BaseModel], render: Callable[[type[BaseModel]], dict[str, Any]]
 ) -> dict[str, Any]:
-    """Render an output schema for a provider, reporting a render failure clearly.
+    """Render an output schema, reporting a render failure clearly.
 
-    The renderer is supplied by the caller because each chat model translates a
-    schema with its own vendor renderer, and this module may not depend on any of
-    them. The model's own render runs first so that a model no JSON Schema can
-    express is reported as exactly that: a vendor renderer renders the model
-    itself, so it would otherwise surface the same failure worded as a translation
-    failure. The vendor render is wrapped in turn because it rejects models the
-    model's own render accepts, such as one carrying an untyped member that renders
-    to a document with no ``type``.
+    The caller supplies ``render`` because callers differ in the wire format they
+    need, and this module cannot depend on the renderers that produce it.
 
-    A schema that renders but declares no fields is returned as rendered. Whether
-    such a document is usable is the receiving provider's to judge, and refusing it
-    here would fail a request that succeeds today. Callers whose deliverable is the
-    rendered document itself have no provider to defer to and use
-    ``render_constraining_output_schema`` instead.
+    The model's own render runs first so that a model no JSON Schema can express is
+    reported as exactly that. ``render`` renders the model itself, so without that
+    first attempt the same failure would surface worded as a translation failure.
+    The call to ``render`` is wrapped in turn because a renderer can reject a model
+    the model's own render accepts, such as one carrying an untyped member that
+    renders to a document with no ``type``.
 
-    Args:
-        model: The model class describing the shape the response must take.
-        render: Renders ``model`` in the wire format the chat model expects.
-
-    Returns:
-        The document ``render`` produced.
-
-    Raises:
-        TypeError: If ``model`` has no JSON Schema, or if ``render`` fails or returns
-            something other than a document.
-    """
-    return _render_output_schema(model, render, reject_unconstrained=False)
-
-
-def render_constraining_output_schema(
-    model: type[BaseModel], render: Callable[[type[BaseModel]], dict[str, Any]]
-) -> dict[str, Any]:
-    """Render an output schema, refusing one that cannot constrain the response.
-
-    For a caller that consumes the rendered document itself rather than sending it
-    to a provider, such as one pasting it into an instruction prompt. A document
-    describing an object with no fields instructs the model to match nothing, and
-    every response then satisfies it.
-
-    Whether a model expresses a constraint is a property of the model, not of a
-    provider's wire format, so the check runs against the model's own JSON Schema
-    and only the returned document comes from ``render``. That keeps the check
-    independent of how any SDK normalizes a schema: one renderer rewrites every
-    map-typed member into an empty object, which is indistinguishable from a model
-    that declares no fields at all.
+    Whatever ``render`` produces is returned as produced. A document that declares
+    no fields is not refused here: whether it is usable belongs to the caller that
+    consumes it, and refusing it would fail a request that succeeds today.
 
     Args:
         model: The model class describing the shape the response must take.
@@ -126,22 +94,12 @@ def render_constraining_output_schema(
         The document ``render`` produced.
 
     Raises:
-        TypeError: Everything ``render_provider_output_schema`` raises, and
-            additionally if ``model`` renders to a JSON Schema containing an object
-            that declares no properties and so constrains nothing.
+        TypeError: If ``model`` has no JSON Schema, or if ``render`` fails or returns
+            something other than a document.
     """
-    return _render_output_schema(model, render, reject_unconstrained=True)
-
-
-def _render_output_schema(
-    model: type[BaseModel],
-    render: Callable[[type[BaseModel]], dict[str, Any]],
-    *,
-    reject_unconstrained: bool,
-) -> dict[str, Any]:
-    """Back the two public renderers, which differ only in the emptiness check."""
     try:
-        document = model.model_json_schema()
+        # Run for its failure, not for its value.
+        model.model_json_schema()
     except Exception as e:
         msg = (
             f"Output schema {model.__module__}.{model.__qualname__} cannot be"
@@ -151,18 +109,12 @@ def _render_output_schema(
         )
         raise TypeError(msg) from e
 
-    if reject_unconstrained:
-        defs = document.get("$defs")
-        _reject_empty_objects(
-            document, "$", defs if isinstance(defs, dict) else {}, set(), model
-        )
-
     try:
         schema = render(model)
     except Exception as e:
         msg = (
             f"Output schema {model.__module__}.{model.__qualname__} cannot be"
-            " translated for this chat model, so it cannot constrain the response."
+            " translated by the renderer in use, so it cannot constrain the response."
             " Use a schema whose fields are all JSON-Schema-renderable, or pass no"
             f" output schema. The renderer reported: {e}"
         )
@@ -176,66 +128,3 @@ def _render_output_schema(
         )
         raise TypeError(msg)
     return schema
-
-
-def _reject_empty_objects(
-    node: Any,
-    path: str,
-    defs: dict[str, Any],
-    visited: set[int],
-    model: type[BaseModel],
-) -> None:
-    """Raise if any object below ``node`` declares an empty ``properties``.
-
-    ``properties`` present and empty is an object that admits every response and
-    rejects none. ``properties`` absent is a free-form map such as
-    ``dict[str, str]``, which is a legitimate constraint and is left alone.
-
-    An empty ``properties`` still constrains something when ``additionalProperties``
-    carries a schema, which bounds every extra member, or ``True``, which admits
-    them deliberately. Only an absent or ``False`` ``additionalProperties`` leaves
-    the object expressing nothing. The tests are identity comparisons because a
-    JSON Schema document may hold ``{}`` there, which is a legitimate schema and is
-    falsy in Python.
-
-    Descends through ``properties``, ``items``, ``prefixItems``, a schema-valued
-    ``additionalProperties``, the ``anyOf``/``oneOf``/``allOf`` branches, and any
-    ``$defs`` entry a ``$ref`` reaches.
-    """
-    if not isinstance(node, dict) or id(node) in visited:
-        return
-    visited.add(id(node))
-
-    ref = node.get("$ref")
-    if isinstance(ref, str):
-        prefix = "#/$defs/"
-        target = defs.get(ref[len(prefix) :]) if ref.startswith(prefix) else None
-        _reject_empty_objects(target, path, defs, visited, model)
-        return
-
-    properties = node.get("properties")
-    additional = node.get("additionalProperties")
-    if (
-        node.get("type") == "object"
-        and (additional is None or additional is False)
-        and isinstance(properties, dict)
-        and not properties
-    ):
-        msg = (
-            f"Output schema {model.__module__}.{model.__qualname__} renders to a"
-            " JSON Schema that cannot constrain the response: the object at path"
-            f" {path} has no properties. Use a schema whose objects each declare at"
-            " least one field, or pass no output schema."
-        )
-        raise TypeError(msg)
-
-    if isinstance(properties, dict):
-        for name, child in properties.items():
-            _reject_empty_objects(child, f"{path}.{name}", defs, visited, model)
-    _reject_empty_objects(node.get("items"), path, defs, visited, model)
-    _reject_empty_objects(node.get("additionalProperties"), path, defs, visited, model)
-    for keyword in ("prefixItems", "anyOf", "oneOf", "allOf"):
-        branches = node.get(keyword)
-        if isinstance(branches, list):
-            for branch in branches:
-                _reject_empty_objects(branch, path, defs, visited, model)

--- a/python/flink_agents/api/chat_models/chat_model.py
+++ b/python/flink_agents/api/chat_models/chat_model.py
@@ -244,10 +244,38 @@ class BaseChatModelConnection(Resource, ABC):
             unconstrained response. This is framework-level execution metadata, and
             every implementation must declare it as a named parameter rather than let
             it fall into ``**kwargs``: ``**kwargs`` is forwarded to the provider SDK,
-            so a schema landing there would reach the request body. Implementations
-            without a native structured-output translation reject a non-``None`` value
-            via ``_reject_unsupported_output_schema``, so a caller that wants the
-            prompt-engineering fallback must pass ``None``.
+            so a schema landing there would reach the request body.
+
+            An ``OutputSchema`` wraps either a ``BaseModel`` subclass or a
+            ``RowTypeInfo``. No implementation translates a ``RowTypeInfo`` natively,
+            and what follows differs by implementation: one that translates a
+            ``BaseModel`` natively skips the ``RowTypeInfo`` and leaves the request
+            unchanged, so the caller keeps the prompt-engineering fallback; one with
+            no native translation at all rejects it, as described below. The skip is a
+            deliberate, permanent fallback, not a translation still to be written.
+
+            A ``BaseModel`` subclass is refused with a ``TypeError`` naming the schema
+            class and chaining the underlying error as its cause, both when it has no
+            JSON Schema at all and when it has one that this provider's renderer will
+            not accept. The second outcome is per-provider: a model with an untyped
+            member renders under Pydantic, and one provider's renderer takes it while
+            another refuses it. Neither is raised unless the request was going to
+            carry a native schema, since an implementation renders only once it has
+            decided to send one — so an unrenderable schema reports nothing when the
+            effective model is not one the implementation calls natively capable, or
+            when some other condition has already ruled the native branch out.
+
+            A ``BaseModel`` subclass that renders but declares no fields is sent as
+            rendered, leaving the receiving provider to accept or refuse it. It is
+            refused only where the rendered document is itself the deliverable, as on
+            the ReAct prompt path, which pastes it into the instruction prompt.
+
+            An implementation with no native structured-output translation at all is a
+            separate case, not the ``RowTypeInfo`` skip above: it rejects *every*
+            non-``None`` schema, ``RowTypeInfo`` included, via
+            ``_reject_unsupported_output_schema``, because it could otherwise only
+            drop the schema silently. A caller that wants the prompt-engineering
+            fallback from such an implementation must pass ``None``.
         **kwargs : Any
             Additional parameters passed to the model service (e.g., temperature,
             max_tokens, etc.)

--- a/python/flink_agents/api/chat_models/chat_model.py
+++ b/python/flink_agents/api/chat_models/chat_model.py
@@ -266,9 +266,7 @@ class BaseChatModelConnection(Resource, ABC):
             when some other condition has already ruled the native branch out.
 
             A ``BaseModel`` subclass that renders but declares no fields is sent as
-            rendered, leaving the receiving provider to accept or refuse it. It is
-            refused only where the rendered document is itself the deliverable, as on
-            the ReAct prompt path, which pastes it into the instruction prompt.
+            rendered, leaving the receiving provider to accept or refuse it.
 
             An implementation with no native structured-output translation at all is a
             separate case, not the ``RowTypeInfo`` skip above: it rejects *every*

--- a/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
@@ -24,7 +24,7 @@ from anthropic.types import MessageParam, TextBlockParam, ToolParam
 from pydantic import BaseModel, Field, PrivateAttr
 from typing_extensions import override
 
-from flink_agents.api.agents.types import OutputSchema, render_provider_output_schema
+from flink_agents.api.agents.types import OutputSchema, render_output_schema
 from flink_agents.api.chat_message import ChatMessage, MessageRole
 from flink_agents.api.chat_models.chat_model import (
     BaseChatModelConnection,
@@ -224,7 +224,7 @@ def _native_output_config(output_schema: Any) -> Dict[str, Any] | None:
     return {
         "format": {
             "type": "json_schema",
-            "schema": render_provider_output_schema(model, transform_schema),
+            "schema": render_output_schema(model, transform_schema),
         }
     }
 

--- a/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
@@ -24,7 +24,7 @@ from anthropic.types import MessageParam, TextBlockParam, ToolParam
 from pydantic import BaseModel, Field, PrivateAttr
 from typing_extensions import override
 
-from flink_agents.api.agents.types import OutputSchema
+from flink_agents.api.agents.types import OutputSchema, render_output_schema
 from flink_agents.api.chat_message import ChatMessage, MessageRole
 from flink_agents.api.chat_models.chat_model import (
     BaseChatModelConnection,
@@ -207,6 +207,10 @@ def _native_output_config(output_schema: Any) -> Dict[str, Any] | None:
     Anthropic's format object carries only the schema and its type, so it shares no
     shape with the providers that nest the schema under a named, strict
     ``json_schema`` object and is built here rather than in a shared helper.
+
+    Raises ``TypeError`` if a ``BaseModel`` schema cannot be rendered, or renders to a
+    document that constrains nothing. Such a request would come back unconstrained and
+    be mistaken for a schema-conforming response.
     """
     if output_schema is None:
         return None
@@ -215,7 +219,12 @@ def _native_output_config(output_schema: Any) -> Dict[str, Any] | None:
     )
     if not (isinstance(model, type) and issubclass(model, BaseModel)):
         return None
-    return {"format": {"type": "json_schema", "schema": transform_schema(model)}}
+    return {
+        "format": {
+            "type": "json_schema",
+            "schema": render_output_schema(model, transform_schema),
+        }
+    }
 
 
 class AnthropicChatModelConnection(BaseChatModelConnection):
@@ -345,13 +354,19 @@ class AnthropicChatModelConnection(BaseChatModelConnection):
         if output_schema is not None and self.supports_native_structured_output(
             kwargs.get("model")
         ):
-            output_config = _native_output_config(output_schema)
             # An output_config already in kwargs is the caller being explicit about the
             # exact parameter this branch writes, so it is left alone and the schema
             # keeps the prompt-engineering fallback. Writing over it would drop the
             # caller's value with no error and no other trace.
-            if output_config is not None and "output_config" not in kwargs:
-                kwargs["output_config"] = output_config
+            #
+            # The schema is rendered inside that test rather than before it, because
+            # rendering rejects a schema that cannot constrain the response. Rendering
+            # one whose result this branch is about to discard would fail a request the
+            # caller had already steered away from the derived config.
+            if "output_config" not in kwargs:
+                output_config = _native_output_config(output_schema)
+                if output_config is not None:
+                    kwargs["output_config"] = output_config
 
         # JSON prefill appends a prefilled assistant "{" message to steer the model
         # into emitting a JSON document. It applies only when the request carries none

--- a/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
@@ -24,7 +24,7 @@ from anthropic.types import MessageParam, TextBlockParam, ToolParam
 from pydantic import BaseModel, Field, PrivateAttr
 from typing_extensions import override
 
-from flink_agents.api.agents.types import OutputSchema, render_output_schema
+from flink_agents.api.agents.types import OutputSchema, render_provider_output_schema
 from flink_agents.api.chat_message import ChatMessage, MessageRole
 from flink_agents.api.chat_models.chat_model import (
     BaseChatModelConnection,
@@ -208,9 +208,11 @@ def _native_output_config(output_schema: Any) -> Dict[str, Any] | None:
     shape with the providers that nest the schema under a named, strict
     ``json_schema`` object and is built here rather than in a shared helper.
 
-    Raises ``TypeError`` if a ``BaseModel`` schema cannot be rendered, or renders to a
-    document that constrains nothing. Such a request would come back unconstrained and
-    be mistaken for a schema-conforming response.
+    Raises ``TypeError`` if a ``BaseModel`` schema cannot be rendered, naming the
+    schema class rather than letting the renderer's own error, which names only its
+    internals, surface from a request the provider never sees. A schema that renders
+    but declares no fields is sent as it is, leaving the provider to accept or refuse
+    the document it receives.
     """
     if output_schema is None:
         return None
@@ -222,7 +224,7 @@ def _native_output_config(output_schema: Any) -> Dict[str, Any] | None:
     return {
         "format": {
             "type": "json_schema",
-            "schema": render_output_schema(model, transform_schema),
+            "schema": render_provider_output_schema(model, transform_schema),
         }
     }
 
@@ -360,9 +362,9 @@ class AnthropicChatModelConnection(BaseChatModelConnection):
             # caller's value with no error and no other trace.
             #
             # The schema is rendered inside that test rather than before it, because
-            # rendering rejects a schema that cannot constrain the response. Rendering
-            # one whose result this branch is about to discard would fail a request the
-            # caller had already steered away from the derived config.
+            # rendering raises on a schema it cannot express. Rendering one whose
+            # result this branch is about to discard would fail a request the caller
+            # had already steered away from the derived config.
             if "output_config" not in kwargs:
                 output_config = _native_output_config(output_schema)
                 if output_config is not None:

--- a/python/flink_agents/integrations/chat_models/anthropic/tests/test_anthropic_response_parsing.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/tests/test_anthropic_response_parsing.py
@@ -173,6 +173,18 @@ class _FieldLess(BaseModel):
     """A schema declaring no fields, so it constrains nothing."""
 
 
+class _NestsFieldLess(BaseModel):
+    """A field-less schema one level down, reached through a ``$ref``."""
+
+    inner: _FieldLess
+
+
+class _MapsToFieldLess(BaseModel):
+    """A field-less schema reached through a map's ``additionalProperties``."""
+
+    m: Dict[str, _FieldLess]
+
+
 class _Labelled(BaseModel):
     """A schema whose only member is a free-form map, a legitimate constraint."""
 
@@ -265,11 +277,18 @@ def test_unrenderable_schema_raises_naming_the_model() -> None:
         )
 
 
-def test_field_less_schema_raises_naming_the_model() -> None:
-    with pytest.raises(TypeError, match="_FieldLess renders to a JSON Schema"):
-        _request_kwargs(
-            model=_CAPABLE_MODEL, output_schema=OutputSchema(output_schema=_FieldLess)
-        )
+@pytest.mark.parametrize("schema", [_FieldLess, _NestsFieldLess, _MapsToFieldLess])
+def test_field_less_schema_is_accepted_and_sent_whole(schema) -> None:
+    # A schema declaring no fields renders, so the provider decides on it, not this
+    # connection. Fails if a check for a schema that renders but constrains nothing is
+    # ever added back here, which would refuse a request that works today. The nested
+    # cases are the ones a root-only check would still let through, so they pin the
+    # whole document rather than its top level.
+    output_config = _request_kwargs(
+        model=_CAPABLE_MODEL, output_schema=OutputSchema(output_schema=schema)
+    )["output_config"]
+
+    assert output_config["format"]["schema"] == transform_schema(schema)
 
 
 def test_map_member_schema_is_accepted_and_sent_whole() -> None:
@@ -320,7 +339,7 @@ def test_caller_output_config_wins_over_schema() -> None:
     assert sent == caller_config
 
 
-def test_caller_output_config_wins_over_a_schema_that_cannot_constrain() -> None:
+def test_caller_output_config_wins_over_a_schema_that_cannot_be_rendered() -> None:
     # The schema is rendered only when this branch will actually send the result. A
     # render placed before the caller's value is honoured would refuse a request the
     # caller had already steered away from the derived config, on the strength of a
@@ -329,7 +348,7 @@ def test_caller_output_config_wins_over_a_schema_that_cannot_constrain() -> None
 
     sent = _request_kwargs(
         model=_CAPABLE_MODEL,
-        output_schema=OutputSchema(output_schema=_FieldLess),
+        output_schema=OutputSchema(output_schema=_Unrenderable),
         output_config=caller_config,
     )["output_config"]
 

--- a/python/flink_agents/integrations/chat_models/anthropic/tests/test_anthropic_response_parsing.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/tests/test_anthropic_response_parsing.py
@@ -280,10 +280,9 @@ def test_unrenderable_schema_raises_naming_the_model() -> None:
 @pytest.mark.parametrize("schema", [_FieldLess, _NestsFieldLess, _MapsToFieldLess])
 def test_field_less_schema_is_accepted_and_sent_whole(schema) -> None:
     # A schema declaring no fields renders, so the provider decides on it, not this
-    # connection. Fails if a check for a schema that renders but constrains nothing is
-    # ever added back here, which would refuse a request that works today. The nested
-    # cases are the ones a root-only check would still let through, so they pin the
-    # whole document rather than its top level.
+    # connection. The document reaches the request exactly as rendered rather than
+    # being refused here. The nested cases carry the field-less model below the root,
+    # so the assertion covers the whole document rather than only its top level.
     output_config = _request_kwargs(
         model=_CAPABLE_MODEL, output_schema=OutputSchema(output_schema=schema)
     )["output_config"]
@@ -292,9 +291,9 @@ def test_field_less_schema_is_accepted_and_sent_whole(schema) -> None:
 
 
 def test_map_member_schema_is_accepted_and_sent_whole() -> None:
-    # This renderer rewrites a map member into an object with an empty properties,
-    # which is exactly the shape a field-less model produces. Checking the renderer's
-    # output rather than the model's would therefore reject every map-typed member.
+    # This renderer rewrites a map member into an object with an empty properties. The
+    # rewritten document is what reaches the request, so the member survives the
+    # normalization rather than being dropped or flattened.
     output_config = _request_kwargs(
         model=_CAPABLE_MODEL, output_schema=OutputSchema(output_schema=_Labelled)
     )["output_config"]

--- a/python/flink_agents/integrations/chat_models/anthropic/tests/test_anthropic_response_parsing.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/tests/test_anthropic_response_parsing.py
@@ -15,10 +15,11 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 #################################################################################
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 from unittest.mock import MagicMock
 
 import pytest
+from anthropic import transform_schema
 from anthropic.types import Message, TextBlock, ToolUseBlock, Usage
 from pydantic import BaseModel
 from pyflink.common.typeinfo import Types
@@ -162,6 +163,22 @@ class _Answer(BaseModel):
     verdict: str
 
 
+class _Unrenderable(BaseModel):
+    """A schema carrying a member that no JSON Schema can express."""
+
+    cb: Callable[[int], int]
+
+
+class _FieldLess(BaseModel):
+    """A schema declaring no fields, so it constrains nothing."""
+
+
+class _Labelled(BaseModel):
+    """A schema whose only member is a free-form map, a legitimate constraint."""
+
+    labels: Dict[str, str]
+
+
 # A model the provider documents native structured-output support for.
 #
 # Deliberately a 4.5-generation name, which is the only generation that is both
@@ -240,6 +257,33 @@ def test_native_output_config_applied_on_capable_model(model) -> None:
     assert set(output_config["format"]["schema"]["properties"]) == {"verdict"}
 
 
+def test_unrenderable_schema_raises_naming_the_model() -> None:
+    with pytest.raises(TypeError, match="_Unrenderable cannot be rendered"):
+        _request_kwargs(
+            model=_CAPABLE_MODEL,
+            output_schema=OutputSchema(output_schema=_Unrenderable),
+        )
+
+
+def test_field_less_schema_raises_naming_the_model() -> None:
+    with pytest.raises(TypeError, match="_FieldLess renders to a JSON Schema"):
+        _request_kwargs(
+            model=_CAPABLE_MODEL, output_schema=OutputSchema(output_schema=_FieldLess)
+        )
+
+
+def test_map_member_schema_is_accepted_and_sent_whole() -> None:
+    # This renderer rewrites a map member into an object with an empty properties,
+    # which is exactly the shape a field-less model produces. Checking the renderer's
+    # output rather than the model's would therefore reject every map-typed member.
+    output_config = _request_kwargs(
+        model=_CAPABLE_MODEL, output_schema=OutputSchema(output_schema=_Labelled)
+    )["output_config"]
+
+    assert output_config["format"]["schema"] == transform_schema(_Labelled)
+    assert output_config["format"]["schema"]["properties"]["labels"]["properties"] == {}
+
+
 def test_native_output_config_not_applied_on_incapable_model() -> None:
     assert "output_config" not in _request_kwargs(
         model=_INCAPABLE_MODEL, output_schema=OutputSchema(output_schema=_Answer)
@@ -270,6 +314,22 @@ def test_caller_output_config_wins_over_schema() -> None:
     sent = _request_kwargs(
         model=_CAPABLE_MODEL,
         output_schema=OutputSchema(output_schema=_Answer),
+        output_config=caller_config,
+    )["output_config"]
+
+    assert sent == caller_config
+
+
+def test_caller_output_config_wins_over_a_schema_that_cannot_constrain() -> None:
+    # The schema is rendered only when this branch will actually send the result. A
+    # render placed before the caller's value is honoured would refuse a request the
+    # caller had already steered away from the derived config, on the strength of a
+    # schema nothing was going to use.
+    caller_config = {"format": {"type": "json_schema", "schema": {"type": "object"}}}
+
+    sent = _request_kwargs(
+        model=_CAPABLE_MODEL,
+        output_schema=OutputSchema(output_schema=_FieldLess),
         output_config=caller_config,
     )["output_config"]
 

--- a/python/flink_agents/integrations/chat_models/azure/azure_openai_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/azure/azure_openai_chat_model.py
@@ -29,7 +29,7 @@ from openai.lib._pydantic import to_strict_json_schema
 from pydantic import BaseModel, Field, PrivateAttr
 from typing_extensions import override
 
-from flink_agents.api.agents.types import OutputSchema
+from flink_agents.api.agents.types import OutputSchema, render_output_schema
 from flink_agents.api.chat_message import ChatMessage
 from flink_agents.api.chat_models.chat_model import (
     BaseChatModelConnection,
@@ -93,12 +93,14 @@ _MIN_STRUCTURED_OUTPUT_API_VERSION = "2024-08-01"
 _API_VERSION_DATE_PREFIX = re.compile(r"^\d{4}-\d{2}-\d{2}", re.ASCII)
 
 
-def _native_response_format(output_schema: Any) -> Dict[str, Any] | None:
-    """Build the ``response_format`` for a native structured-output request.
+def _native_output_model(output_schema: Any) -> type[BaseModel] | None:
+    """The model a schema translates natively to, or ``None`` where none applies.
 
-    Returns ``None`` (leaving behavior unchanged) unless the schema is a ``BaseModel``
-    subclass. A ``RowTypeInfo`` schema is skipped so it keeps the prompt-engineering
-    fallback.
+    ``None`` covers both no schema at all and a ``RowTypeInfo``, which has no native
+    translation and keeps the prompt-engineering fallback.
+
+    Separate from the render below because the caller-conflict check needs to know
+    whether a schema will be sent, and under what name, before anything is rendered.
     """
     if output_schema is None:
         return None
@@ -107,11 +109,28 @@ def _native_response_format(output_schema: Any) -> Dict[str, Any] | None:
     )
     if not (isinstance(model, type) and issubclass(model, BaseModel)):
         return None
+    return model
+
+
+def _native_response_format(output_schema: Any) -> Dict[str, Any] | None:
+    """Build the ``response_format`` for a native structured-output request.
+
+    Returns ``None`` (leaving behavior unchanged) unless the schema is a ``BaseModel``
+    subclass. A ``RowTypeInfo`` schema is skipped so it keeps the prompt-engineering
+    fallback.
+
+    Raises ``TypeError`` if a ``BaseModel`` schema cannot be rendered, or renders to a
+    document that constrains nothing. Such a request would come back unconstrained and
+    be mistaken for a schema-conforming response.
+    """
+    model = _native_output_model(output_schema)
+    if model is None:
+        return None
     return {
         "type": "json_schema",
         "json_schema": {
             "name": model.__name__,
-            "schema": to_strict_json_schema(model),
+            "schema": render_output_schema(model, to_strict_json_schema),
             "strict": True,
         },
     }
@@ -302,22 +321,27 @@ class AzureOpenAIChatModelConnection(BaseChatModelConnection):
             and self.supports_native_structured_output(model_of_azure_deployment)
             and self._api_version_supports_structured_output()
         ):
+            native_model = _native_output_model(output_schema)
+            # Tested before the schema is rendered. A caller who supplies both a schema
+            # and a response_format has a conflict to resolve whatever the schema turns
+            # out to render to, and reporting a render failure instead would describe
+            # the wrong problem. The name is read off the model class, so this needs no
+            # rendered document.
+            caller_response_format = (
+                "response_format" in kwargs or "response_format" in additional_kwargs
+            )
+            if native_model is not None and caller_response_format:
+                msg = (
+                    f"The {native_model.__name__} output schema "
+                    f"is sent as response_format on deployment "
+                    f"'{azure_deployment}', so response_format must not also be "
+                    f"passed as a kwarg or in additional_kwargs. Remove that "
+                    f"value, or omit output_schema to set response_format "
+                    f"directly."
+                )
+                raise ValueError(msg)
             response_format = _native_response_format(output_schema)
             if response_format is not None:
-                caller_response_format = (
-                    "response_format" in kwargs
-                    or "response_format" in additional_kwargs
-                )
-                if caller_response_format:
-                    msg = (
-                        f"The {response_format['json_schema']['name']} output schema "
-                        f"is sent as response_format on deployment "
-                        f"'{azure_deployment}', so response_format must not also be "
-                        f"passed as a kwarg or in additional_kwargs. Remove that "
-                        f"value, or omit output_schema to set response_format "
-                        f"directly."
-                    )
-                    raise ValueError(msg)
                 kwargs["response_format"] = response_format
 
         response = self.client.chat.completions.create(

--- a/python/flink_agents/integrations/chat_models/azure/azure_openai_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/azure/azure_openai_chat_model.py
@@ -29,7 +29,7 @@ from openai.lib._pydantic import to_strict_json_schema
 from pydantic import BaseModel, Field, PrivateAttr
 from typing_extensions import override
 
-from flink_agents.api.agents.types import OutputSchema, render_output_schema
+from flink_agents.api.agents.types import OutputSchema, render_provider_output_schema
 from flink_agents.api.chat_message import ChatMessage
 from flink_agents.api.chat_models.chat_model import (
     BaseChatModelConnection,
@@ -119,9 +119,11 @@ def _native_response_format(output_schema: Any) -> Dict[str, Any] | None:
     subclass. A ``RowTypeInfo`` schema is skipped so it keeps the prompt-engineering
     fallback.
 
-    Raises ``TypeError`` if a ``BaseModel`` schema cannot be rendered, or renders to a
-    document that constrains nothing. Such a request would come back unconstrained and
-    be mistaken for a schema-conforming response.
+    Raises ``TypeError`` if a ``BaseModel`` schema cannot be rendered, naming the
+    schema class rather than letting the renderer's own error, which names only its
+    internals, surface from a request the provider never sees. A schema that renders
+    but declares no fields is sent as it is, leaving the provider to accept or refuse
+    the document it receives.
     """
     model = _native_output_model(output_schema)
     if model is None:
@@ -130,7 +132,7 @@ def _native_response_format(output_schema: Any) -> Dict[str, Any] | None:
         "type": "json_schema",
         "json_schema": {
             "name": model.__name__,
-            "schema": render_output_schema(model, to_strict_json_schema),
+            "schema": render_provider_output_schema(model, to_strict_json_schema),
             "strict": True,
         },
     }

--- a/python/flink_agents/integrations/chat_models/azure/azure_openai_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/azure/azure_openai_chat_model.py
@@ -29,7 +29,7 @@ from openai.lib._pydantic import to_strict_json_schema
 from pydantic import BaseModel, Field, PrivateAttr
 from typing_extensions import override
 
-from flink_agents.api.agents.types import OutputSchema, render_provider_output_schema
+from flink_agents.api.agents.types import OutputSchema, render_output_schema
 from flink_agents.api.chat_message import ChatMessage
 from flink_agents.api.chat_models.chat_model import (
     BaseChatModelConnection,
@@ -132,7 +132,7 @@ def _native_response_format(output_schema: Any) -> Dict[str, Any] | None:
         "type": "json_schema",
         "json_schema": {
             "name": model.__name__,
-            "schema": render_provider_output_schema(model, to_strict_json_schema),
+            "schema": render_output_schema(model, to_strict_json_schema),
             "strict": True,
         },
     }

--- a/python/flink_agents/integrations/chat_models/azure/tests/test_azure_openai_native_structured_output.py
+++ b/python/flink_agents/integrations/chat_models/azure/tests/test_azure_openai_native_structured_output.py
@@ -15,10 +15,11 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 #################################################################################
-from typing import Any
+from typing import Any, Callable
 from unittest.mock import MagicMock
 
 import pytest
+from openai.lib._pydantic import to_strict_json_schema
 from pydantic import BaseModel
 from pyflink.common.typeinfo import Types
 
@@ -46,6 +47,22 @@ class Person(BaseModel):
 
     name: str
     age: int
+
+
+class Unrenderable(BaseModel):
+    """A schema carrying a member that no JSON Schema can express."""
+
+    cb: Callable[[int], int]
+
+
+class FieldLess(BaseModel):
+    """A schema declaring no fields, so it constrains nothing."""
+
+
+class Labelled(BaseModel):
+    """A schema whose only member is a free-form map, a legitimate constraint."""
+
+    labels: dict[str, str]
 
 
 ROW_TYPE = Types.ROW_NAMED(["name"], [Types.STRING()])
@@ -322,6 +339,23 @@ def test_caller_response_format_conflicts_with_native_schema(
     assert "Person" in str(excinfo.value)
 
 
+def test_caller_response_format_conflict_precedes_the_schema_render() -> None:
+    """A schema that cannot be rendered still reports the conflict, not the render.
+
+    The conflict stands whatever the schema would have rendered to, and it names the
+    two inputs the caller has to choose between. Rendering first would report a
+    different problem, on a value this branch was never going to send.
+    """
+    with pytest.raises(ValueError, match="Unrenderable") as excinfo:
+        _chat_with_caller_response_format(
+            _connection(),
+            model_of_azure_deployment="gpt-4o-mini",
+            in_additional_kwargs=False,
+            schema=Unrenderable,
+        )
+    assert "response_format must not also be passed" in str(excinfo.value)
+
+
 @pytest.mark.parametrize("in_additional_kwargs", [True, False])
 @pytest.mark.parametrize(
     ("api_version", "model_of_azure_deployment", "schema"),
@@ -430,3 +464,32 @@ def test_capability_predicate_reads_no_instance_state() -> None:
         AzureOpenAIChatModelConnection
     )
     assert uninitialized.supports_native_structured_output("gpt-5") is True
+
+
+def _chat_with_schema(conn: AzureOpenAIChatModelConnection, schema: Any) -> None:
+    conn.chat(
+        [ChatMessage(role=MessageRole.USER, content="hi")],
+        model=DEPLOYMENT,
+        model_of_azure_deployment="gpt-4o-mini",
+        output_schema=OutputSchema(output_schema=schema),
+    )
+
+
+def test_unrenderable_schema_raises_naming_the_model() -> None:
+    """A schema that cannot be rendered fails here rather than at the provider."""
+    with pytest.raises(TypeError, match="Unrenderable cannot be rendered"):
+        _chat_with_schema(_connection(), Unrenderable)
+
+
+def test_field_less_schema_raises_naming_the_model() -> None:
+    """A schema declaring no fields would leave the response unconstrained."""
+    with pytest.raises(TypeError, match="FieldLess renders to a JSON Schema"):
+        _chat_with_schema(_connection(), FieldLess)
+
+
+def test_map_member_schema_is_accepted_and_sent_whole() -> None:
+    """A free-form map is a legitimate constraint and reaches the request intact."""
+    conn = _connection()
+    _chat_with_schema(conn, Labelled)
+    response_format = _create_call_kwargs(conn)["response_format"]
+    assert response_format["json_schema"]["schema"] == to_strict_json_schema(Labelled)

--- a/python/flink_agents/integrations/chat_models/azure/tests/test_azure_openai_native_structured_output.py
+++ b/python/flink_agents/integrations/chat_models/azure/tests/test_azure_openai_native_structured_output.py
@@ -497,10 +497,9 @@ def test_unrenderable_schema_raises_naming_the_model() -> None:
 def test_field_less_schema_is_accepted_and_sent_whole(schema: type[BaseModel]) -> None:
     """A schema declaring no fields renders, so the provider decides on it, not us.
 
-    Fails if a check for a schema that renders but constrains nothing is ever added
-    back here: the provider accepts these documents, and refusing one would fail a
-    request that works today. The nested cases are the ones a root-only check would
-    still let through, so they pin the whole document rather than its top level.
+    The document reaches the request exactly as rendered rather than being refused
+    here. The nested cases carry the field-less model below the root, so the
+    assertion covers the whole document rather than only its top level.
     """
     conn = _connection()
     _chat_with_schema(conn, schema)

--- a/python/flink_agents/integrations/chat_models/azure/tests/test_azure_openai_native_structured_output.py
+++ b/python/flink_agents/integrations/chat_models/azure/tests/test_azure_openai_native_structured_output.py
@@ -59,6 +59,18 @@ class FieldLess(BaseModel):
     """A schema declaring no fields, so it constrains nothing."""
 
 
+class NestsFieldLess(BaseModel):
+    """A field-less schema one level down, reached through a ``$ref``."""
+
+    inner: FieldLess
+
+
+class MapsToFieldLess(BaseModel):
+    """A field-less schema reached through a map's ``additionalProperties``."""
+
+    m: dict[str, FieldLess]
+
+
 class Labelled(BaseModel):
     """A schema whose only member is a free-form map, a legitimate constraint."""
 
@@ -481,10 +493,19 @@ def test_unrenderable_schema_raises_naming_the_model() -> None:
         _chat_with_schema(_connection(), Unrenderable)
 
 
-def test_field_less_schema_raises_naming_the_model() -> None:
-    """A schema declaring no fields would leave the response unconstrained."""
-    with pytest.raises(TypeError, match="FieldLess renders to a JSON Schema"):
-        _chat_with_schema(_connection(), FieldLess)
+@pytest.mark.parametrize("schema", [FieldLess, NestsFieldLess, MapsToFieldLess])
+def test_field_less_schema_is_accepted_and_sent_whole(schema: type[BaseModel]) -> None:
+    """A schema declaring no fields renders, so the provider decides on it, not us.
+
+    Fails if a check for a schema that renders but constrains nothing is ever added
+    back here: the provider accepts these documents, and refusing one would fail a
+    request that works today. The nested cases are the ones a root-only check would
+    still let through, so they pin the whole document rather than its top level.
+    """
+    conn = _connection()
+    _chat_with_schema(conn, schema)
+    response_format = _create_call_kwargs(conn)["response_format"]
+    assert response_format["json_schema"]["schema"] == to_strict_json_schema(schema)
 
 
 def test_map_member_schema_is_accepted_and_sent_whole() -> None:

--- a/python/flink_agents/integrations/chat_models/openai/openai_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/openai/openai_chat_model.py
@@ -28,7 +28,7 @@ from openai.lib._pydantic import to_strict_json_schema
 from pydantic import BaseModel, Field, PrivateAttr
 from typing_extensions import override
 
-from flink_agents.api.agents.types import OutputSchema, render_output_schema
+from flink_agents.api.agents.types import OutputSchema, render_provider_output_schema
 from flink_agents.api.chat_message import ChatMessage
 from flink_agents.api.chat_models.chat_model import (
     BaseChatModelConnection,
@@ -89,9 +89,11 @@ def _native_response_format(output_schema: Any) -> Dict[str, Any] | None:
     subclass. A ``RowTypeInfo`` schema is skipped so it keeps the prompt-engineering
     fallback.
 
-    Raises ``TypeError`` if a ``BaseModel`` schema cannot be rendered, or renders to a
-    document that constrains nothing. Such a request would come back unconstrained and
-    be mistaken for a schema-conforming response.
+    Raises ``TypeError`` if a ``BaseModel`` schema cannot be rendered, naming the
+    schema class rather than letting the renderer's own error, which names only its
+    internals, surface from a request the provider never sees. A schema that renders
+    but declares no fields is sent as it is, leaving the provider to accept or refuse
+    the document it receives.
     """
     if output_schema is None:
         return None
@@ -104,7 +106,7 @@ def _native_response_format(output_schema: Any) -> Dict[str, Any] | None:
         "type": "json_schema",
         "json_schema": {
             "name": model.__name__,
-            "schema": render_output_schema(model, to_strict_json_schema),
+            "schema": render_provider_output_schema(model, to_strict_json_schema),
             "strict": True,
         },
     }

--- a/python/flink_agents/integrations/chat_models/openai/openai_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/openai/openai_chat_model.py
@@ -28,7 +28,7 @@ from openai.lib._pydantic import to_strict_json_schema
 from pydantic import BaseModel, Field, PrivateAttr
 from typing_extensions import override
 
-from flink_agents.api.agents.types import OutputSchema
+from flink_agents.api.agents.types import OutputSchema, render_output_schema
 from flink_agents.api.chat_message import ChatMessage
 from flink_agents.api.chat_models.chat_model import (
     BaseChatModelConnection,
@@ -88,6 +88,10 @@ def _native_response_format(output_schema: Any) -> Dict[str, Any] | None:
     Returns ``None`` (leaving behavior unchanged) unless the schema is a ``BaseModel``
     subclass. A ``RowTypeInfo`` schema is skipped so it keeps the prompt-engineering
     fallback.
+
+    Raises ``TypeError`` if a ``BaseModel`` schema cannot be rendered, or renders to a
+    document that constrains nothing. Such a request would come back unconstrained and
+    be mistaken for a schema-conforming response.
     """
     if output_schema is None:
         return None
@@ -100,7 +104,7 @@ def _native_response_format(output_schema: Any) -> Dict[str, Any] | None:
         "type": "json_schema",
         "json_schema": {
             "name": model.__name__,
-            "schema": to_strict_json_schema(model),
+            "schema": render_output_schema(model, to_strict_json_schema),
             "strict": True,
         },
     }

--- a/python/flink_agents/integrations/chat_models/openai/openai_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/openai/openai_chat_model.py
@@ -28,7 +28,7 @@ from openai.lib._pydantic import to_strict_json_schema
 from pydantic import BaseModel, Field, PrivateAttr
 from typing_extensions import override
 
-from flink_agents.api.agents.types import OutputSchema, render_provider_output_schema
+from flink_agents.api.agents.types import OutputSchema, render_output_schema
 from flink_agents.api.chat_message import ChatMessage
 from flink_agents.api.chat_models.chat_model import (
     BaseChatModelConnection,
@@ -106,7 +106,7 @@ def _native_response_format(output_schema: Any) -> Dict[str, Any] | None:
         "type": "json_schema",
         "json_schema": {
             "name": model.__name__,
-            "schema": render_provider_output_schema(model, to_strict_json_schema),
+            "schema": render_output_schema(model, to_strict_json_schema),
             "strict": True,
         },
     }

--- a/python/flink_agents/integrations/chat_models/openai/tests/test_openai_native_structured_output.py
+++ b/python/flink_agents/integrations/chat_models/openai/tests/test_openai_native_structured_output.py
@@ -15,10 +15,11 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 #################################################################################
-from typing import Any
+from typing import Any, Callable
 from unittest.mock import MagicMock
 
 import pytest
+from openai.lib._pydantic import to_strict_json_schema
 from pydantic import BaseModel
 from pyflink.common.typeinfo import Types
 
@@ -36,6 +37,22 @@ class Person(BaseModel):
 
     name: str
     age: int
+
+
+class Unrenderable(BaseModel):
+    """A schema carrying a member that no JSON Schema can express."""
+
+    cb: Callable[[int], int]
+
+
+class FieldLess(BaseModel):
+    """A schema declaring no fields, so it constrains nothing."""
+
+
+class Labelled(BaseModel):
+    """A schema whose only member is a free-form map, a legitimate constraint."""
+
+    labels: dict[str, str]
 
 
 def _connection() -> OpenAIChatModelConnection:
@@ -203,3 +220,31 @@ def test_capability_predicate_accepts_capable_models(model: str) -> None:
 def test_capability_predicate_rejects_incapable_models(model: str | None) -> None:
     """The predicate rejects modality variants, incapable, unknown, and empty models."""
     assert _connection().supports_native_structured_output(model) is False
+
+
+def _chat_with_schema(conn: OpenAIChatModelConnection, schema: Any) -> None:
+    conn.chat(
+        [ChatMessage(role=MessageRole.USER, content="hi")],
+        model="gpt-4o",
+        output_schema=OutputSchema(output_schema=schema),
+    )
+
+
+def test_unrenderable_schema_raises_naming_the_model() -> None:
+    """A schema that cannot be rendered fails here rather than at the provider."""
+    with pytest.raises(TypeError, match="Unrenderable cannot be rendered"):
+        _chat_with_schema(_connection(), Unrenderable)
+
+
+def test_field_less_schema_raises_naming_the_model() -> None:
+    """A schema declaring no fields would leave the response unconstrained."""
+    with pytest.raises(TypeError, match="FieldLess renders to a JSON Schema"):
+        _chat_with_schema(_connection(), FieldLess)
+
+
+def test_map_member_schema_is_accepted_and_sent_whole() -> None:
+    """A free-form map is a legitimate constraint and reaches the request intact."""
+    conn = _connection()
+    _chat_with_schema(conn, Labelled)
+    response_format = _create_call_kwargs(conn)["response_format"]
+    assert response_format["json_schema"]["schema"] == to_strict_json_schema(Labelled)

--- a/python/flink_agents/integrations/chat_models/openai/tests/test_openai_native_structured_output.py
+++ b/python/flink_agents/integrations/chat_models/openai/tests/test_openai_native_structured_output.py
@@ -252,10 +252,9 @@ def test_unrenderable_schema_raises_naming_the_model() -> None:
 def test_field_less_schema_is_accepted_and_sent_whole(schema: type[BaseModel]) -> None:
     """A schema declaring no fields renders, so the provider decides on it, not us.
 
-    Fails if a check for a schema that renders but constrains nothing is ever added
-    back here: the provider accepts these documents, and refusing one would fail a
-    request that works today. The nested cases are the ones a root-only check would
-    still let through, so they pin the whole document rather than its top level.
+    The document reaches the request exactly as rendered rather than being refused
+    here. The nested cases carry the field-less model below the root, so the
+    assertion covers the whole document rather than only its top level.
     """
     conn = _connection()
     _chat_with_schema(conn, schema)

--- a/python/flink_agents/integrations/chat_models/openai/tests/test_openai_native_structured_output.py
+++ b/python/flink_agents/integrations/chat_models/openai/tests/test_openai_native_structured_output.py
@@ -49,6 +49,18 @@ class FieldLess(BaseModel):
     """A schema declaring no fields, so it constrains nothing."""
 
 
+class NestsFieldLess(BaseModel):
+    """A field-less schema one level down, reached through a ``$ref``."""
+
+    inner: FieldLess
+
+
+class MapsToFieldLess(BaseModel):
+    """A field-less schema reached through a map's ``additionalProperties``."""
+
+    m: dict[str, FieldLess]
+
+
 class Labelled(BaseModel):
     """A schema whose only member is a free-form map, a legitimate constraint."""
 
@@ -236,10 +248,19 @@ def test_unrenderable_schema_raises_naming_the_model() -> None:
         _chat_with_schema(_connection(), Unrenderable)
 
 
-def test_field_less_schema_raises_naming_the_model() -> None:
-    """A schema declaring no fields would leave the response unconstrained."""
-    with pytest.raises(TypeError, match="FieldLess renders to a JSON Schema"):
-        _chat_with_schema(_connection(), FieldLess)
+@pytest.mark.parametrize("schema", [FieldLess, NestsFieldLess, MapsToFieldLess])
+def test_field_less_schema_is_accepted_and_sent_whole(schema: type[BaseModel]) -> None:
+    """A schema declaring no fields renders, so the provider decides on it, not us.
+
+    Fails if a check for a schema that renders but constrains nothing is ever added
+    back here: the provider accepts these documents, and refusing one would fail a
+    request that works today. The nested cases are the ones a root-only check would
+    still let through, so they pin the whole document rather than its top level.
+    """
+    conn = _connection()
+    _chat_with_schema(conn, schema)
+    response_format = _create_call_kwargs(conn)["response_format"]
+    assert response_format["json_schema"]["schema"] == to_strict_json_schema(schema)
 
 
 def test_map_member_schema_is_accepted_and_sent_whole() -> None:


### PR DESCRIPTION
Linked issue: #985

### Purpose of change

An output schema that cannot be rendered as JSON Schema fails opaquely. Python leaks a raw `PydanticInvalidForJsonSchema` naming a pydantic-internal type, never the caller's model. Java throws past a catch clause too narrow to see it.

Per the decision on the issue, such a schema is now refused with a clear, cause-chained error naming the schema. `RowTypeInfo` stays a fallback and is documented as one on the public `chat` contract, which previously said nothing about how a connection treats each kind of schema.

A schema that renders but declares no fields is returned as rendered, in both languages. Whether such a document is usable belongs to whatever consumes it.

**Observable changes:**

| Where | Change |
|---|---|
| Python, all 4 sites | unrenderable schema raises `TypeError`, cause chained |
| Java ReAct | catch widened to what Jackson actually throws; rethrown as `IllegalArgumentException`, cause chained |
| Java ReAct | a self-referential POJO overflows the stack inside Jackson. That is an `Error`, so it escaped the catch entirely. Now reported as a schema that refers back to itself |
| Java ReAct | an unsupported output schema type now names the type received, matching the Python message |
| Anthropic (py) | a model pydantic renders but Anthropic refuses now raises `TypeError`, not `ValueError`. Only site where the new type is not a subtype of the old |
| Anthropic (py) | no render at all when the caller supplies `output_config`, so a discarded schema can no longer fail the call |
| Azure (py) | the caller `response_format` conflict is reported before the render |

**The Java connections are deliberately untouched.** Validating them with Jackson would refuse schemas the providers accept: a `@JsonTypeInfo` member renders empty under Jackson while the SDK ships a full `anyOf` union, and Jackson throws on field-less, colliding-property and self-referential POJOs that the SDKs send today. Validating the SDK's own schema is no better, since it renders a map member and an unrenderable member identically. Probed with 15 hostile classes, the SDKs never failed to render, so there is no failure there to report.

That leaves one asymmetry, imposed by the libraries rather than chosen: pydantic raises where the Java SDKs do not.

Not in scope: no change to `RowTypeInfo` handling, no new dependency, no payload change for a schema that renders, and `output_schema` still is not threaded from the runtime to a connection in either language.

### Tests

`ReActAgentTest` and `test_react_agent.py` are the first unit coverage of `ReActAgent` in either language.

Per site: an unrenderable schema raises with the cause chained, a `dict`/`Map` member is accepted and still sent whole, and a normal schema produces the payload it produced before.

Two assertions are load-bearing:

- The self-referential test asserts the chained cause, not only that something was thrown. Removing the catch clause fails it with a raw `StackOverflowError`, which is the regression it exists to catch.
- The Python self-reference test asserts a top-level `$ref`. A model that merely nests another model has `$defs` but no top-level `$ref`, so the weaker guards pass on a non-cyclic model and would miss a regression.

Both languages pin that an unsupported output schema type names the type it received, so neither message can silently stop reporting it.

Verified. Java: `mvn clean test -pl api` 380 passed, openai 104, anthropic 61, zero failures, `spotless:check` clean. Python: `pytest flink_agents --ignore=flink_agents/e2e_tests -m "not integration"` 940 passed, 13 skipped. `check-license.sh` clean. The e2e failures in this worktree are pre-existing, from jars never built here.

`tools/lint.sh` could not run locally (its Python step needs an editable install this pip is too old to perform). `ruff check`, which is what that step runs, is clean on every changed file.

### API

Yes. One helper in `flink_agents.api.agents.types`: `render_output_schema`, used by the three chat model connections and by the ReAct prompt path. It renders through a callable the caller supplies, and reports a render failure clearly.

No Java helper is added. `OutputSchema.java` is unchanged.

No existing signature changes. Exception types change as listed above, and two error messages change wording: the Java unsupported-type message now names the type, and the Python translation failure no longer describes its caller as a chat model, since the prompt path is also a caller.

### Documentation

- [x] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes

Generated-by: Claude Code v2.1.53 (claude-opus-5[1m])
