### PR TITLE
[runtime][python] Release per-action Pemja objects

### DIFF
--- a/python/flink_agents/plan/function.py
+++ b/python/flink_agents/plan/function.py
@@ -414,28 +414,21 @@ _ASYNCIO_ERROR_MESSAGE = (
 )
 
 
-def call_python_awaitable(awaitable: Any) -> Tuple[bool, Any]:
-    """Invokes the next step of a Python coroutine or generator and returns whether
-    it is done, along with the yielded or returned value.
+def call_python_awaitable(awaitable: Any) -> bool:
+    """Invoke the next step of a Python coroutine or generator.
 
     Args:
         awaitable: A Python coroutine or generator object that can be driven
         by the send() method.
 
     Returns:
-        Tuple[bool, Any]:
-            - The first element is a boolean flag indicating whether the awaitable
-            has finished:
-                * False: The awaitable has more values to yield.
-                * True: The awaitable has completed.
-            - The second element is either:
-                * The value yielded by the awaitable (when not exhausted), or
-                * The return value of the awaitable (when it has finished).
+        True if the awaitable has completed, otherwise False. Yielded and returned
+        values are discarded because Actions communicate through emitted Events.
     """
     try:
-        result = awaitable.send(None)
-    except StopIteration as e:
-        return True, e.value if hasattr(e, "value") else None
+        awaitable.send(None)
+    except StopIteration:
+        return True
     except RuntimeError as e:
         err_msg = str(e)
         if (
@@ -448,4 +441,4 @@ def call_python_awaitable(awaitable: Any) -> Tuple[bool, Any]:
         logger.exception("Error in awaitable execution")
         raise
     else:
-        return False, result
+        return False

--- a/python/flink_agents/plan/tests/test_function.py
+++ b/python/flink_agents/plan/tests/test_function.py
@@ -29,6 +29,7 @@ from flink_agents.plan.function import (
     JavaFunction,
     PythonFunction,
     _is_function_cacheable,
+    call_python_awaitable,
     call_python_function,
     clear_python_function_cache,
     get_python_function_cache_keys,
@@ -224,6 +225,16 @@ def test_call_python_function_basic() -> None:
         "flink_agents.plan.tests.test_function", "function_for_caching", (5,)
     )
     assert result == 10
+
+
+def test_call_python_awaitable_returns_only_completion_state() -> None:
+    def awaitable_with_values() -> Generator[Any, None, Any]:
+        yield object()
+        return object()
+
+    awaitable = awaitable_with_values()
+    assert call_python_awaitable(awaitable) is False
+    assert call_python_awaitable(awaitable) is True
 
 
 def test_call_python_function_caching() -> None:

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutor.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutor.java
@@ -119,9 +119,9 @@ public class PythonActionExecutor {
     /**
      * Execute the Python function, which may return a Python coroutine (awaitable) that needs to be
      * processed in the future. Due to an issue in Pemja regarding incorrect object reference
-     * counting, this may lead to garbage collection of the object. To prevent this, we use the set
-     * and get methods to manually increment the object's reference count, then return the name of
-     * the Python awaitable variable.
+     * counting, this may lead to garbage collection of the object. To prevent this, we store the
+     * awaitable in the interpreter globals, then return the name of that variable. The temporary
+     * Java wrapper can be closed after the interpreter takes ownership of its own reference.
      *
      * @return The name of the Python awaitable variable. It may be null if the Python function does
      *     not return a coroutine.
@@ -131,10 +131,10 @@ public class PythonActionExecutor {
         function.setInterpreter(interpreter);
 
         String eventJson = new ObjectMapper().writeValueAsString(event);
-        Object pythonEventObject = interpreter.invoke(CONVERT_JSON_TO_PYTHON_EVENT, eventJson);
-
-        try {
-            Object calledResult = function.call(pythonEventObject, pythonRunnerContext);
+        try (PyObject pythonEventObject =
+                        (PyObject) interpreter.invoke(CONVERT_JSON_TO_PYTHON_EVENT, eventJson);
+                PyObject calledResult =
+                        (PyObject) function.call(pythonEventObject, pythonRunnerContext)) {
             if (calledResult == null) {
                 return null;
             } else {
@@ -189,16 +189,21 @@ public class PythonActionExecutor {
      *     interpreter's context
      * @return true if the awaitable has completed; false otherwise
      */
-    public boolean callPythonAwaitable(String pythonAwaitableRef) {
+    public boolean callPythonAwaitable(String pythonAwaitableRef) throws Exception {
         // Calling awaitable.send(None) in Python returns a tuple of (finished, output).
-        Object pythonAwaitable = interpreter.get(pythonAwaitableRef);
-        checkState(
-                pythonAwaitable != null,
-                "Python awaitable '%s' not found in interpreter. ",
-                pythonAwaitableRef);
-        Object invokeResult = interpreter.invoke(CALL_PYTHON_AWAITABLE, pythonAwaitable);
-        checkState(invokeResult.getClass().isArray() && ((Object[]) invokeResult).length == 2);
-        return (boolean) ((Object[]) invokeResult)[0];
+        try (PyObject pythonAwaitable = (PyObject) interpreter.get(pythonAwaitableRef)) {
+            checkState(
+                    pythonAwaitable != null,
+                    "Python awaitable '%s' not found in interpreter.",
+                    pythonAwaitableRef);
+            Object invokeResult = interpreter.invoke(CALL_PYTHON_AWAITABLE, pythonAwaitable);
+            checkState(invokeResult.getClass().isArray() && ((Object[]) invokeResult).length == 2);
+            boolean finished = (boolean) ((Object[]) invokeResult)[0];
+            if (finished) {
+                interpreter.exec("del " + pythonAwaitableRef);
+            }
+            return finished;
+        }
     }
 
     public void close() throws Exception {

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutor.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutor.java
@@ -190,15 +190,15 @@ public class PythonActionExecutor {
      * @return true if the awaitable has completed; false otherwise
      */
     public boolean callPythonAwaitable(String pythonAwaitableRef) throws Exception {
-        // Calling awaitable.send(None) in Python returns a tuple of (finished, output).
+        // Python discards yielded/returned values because Actions communicate through Events.
         try (PyObject pythonAwaitable = (PyObject) interpreter.get(pythonAwaitableRef)) {
             checkState(
                     pythonAwaitable != null,
                     "Python awaitable '%s' not found in interpreter.",
                     pythonAwaitableRef);
             Object invokeResult = interpreter.invoke(CALL_PYTHON_AWAITABLE, pythonAwaitable);
-            checkState(invokeResult.getClass().isArray() && ((Object[]) invokeResult).length == 2);
-            boolean finished = (boolean) ((Object[]) invokeResult)[0];
+            checkState(invokeResult instanceof Boolean);
+            boolean finished = (boolean) invokeResult;
             if (finished) {
                 interpreter.exec("del " + pythonAwaitableRef);
             }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutorTest.java
@@ -192,8 +192,7 @@ class PythonActionExecutorTest {
         PyObject pythonAwaitable = mock(PyObject.class);
         String pythonAwaitableRef = "python_awaitable_1";
         when(interpreter.get(pythonAwaitableRef)).thenReturn(pythonAwaitable);
-        when(interpreter.invoke(CALL_PYTHON_AWAITABLE, pythonAwaitable))
-                .thenReturn(new Object[] {false, null});
+        when(interpreter.invoke(CALL_PYTHON_AWAITABLE, pythonAwaitable)).thenReturn(false);
 
         assertThat(executor.callPythonAwaitable(pythonAwaitableRef)).isFalse();
 
@@ -208,8 +207,7 @@ class PythonActionExecutorTest {
         PyObject pythonAwaitable = mock(PyObject.class);
         String pythonAwaitableRef = "python_awaitable_1";
         when(interpreter.get(pythonAwaitableRef)).thenReturn(pythonAwaitable);
-        when(interpreter.invoke(CALL_PYTHON_AWAITABLE, pythonAwaitable))
-                .thenReturn(new Object[] {true, null});
+        when(interpreter.invoke(CALL_PYTHON_AWAITABLE, pythonAwaitable)).thenReturn(true);
 
         assertThat(executor.callPythonAwaitable(pythonAwaitableRef)).isTrue();
 

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutorTest.java
@@ -17,17 +17,33 @@
  */
 package org.apache.flink.agents.runtime.python.utils;
 
+import org.apache.flink.agents.api.InputEvent;
+import org.apache.flink.agents.plan.PythonFunction;
+import org.apache.flink.agents.runtime.python.context.PythonRunnerContextImpl;
 import org.apache.flink.types.Row;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import pemja.core.PythonInterpreter;
+import pemja.core.object.PyObject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class PythonActionExecutorTest {
+
+    private static final String CONVERT_JSON_TO_PYTHON_EVENT =
+            "python_java_utils.convert_json_to_python_event";
+    private static final String CALL_PYTHON_AWAITABLE = "function.call_python_awaitable";
 
     @Test
     void resolvesPickledPythonKeyTextFromPyFlinkKeyRow() throws Exception {
@@ -87,8 +103,145 @@ class PythonActionExecutorTest {
                 .hasMessage("bad pickle");
     }
 
+    @Test
+    void closesPythonEventAfterSynchronousAction() throws Exception {
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        PythonRunnerContextImpl runnerContext = mock(PythonRunnerContextImpl.class);
+        PythonActionExecutor executor = newExecutor(interpreter, runnerContext);
+        PythonFunction function = mock(PythonFunction.class);
+        PyObject pythonEvent = mock(PyObject.class);
+        when(interpreter.invoke(same(CONVERT_JSON_TO_PYTHON_EVENT), anyString()))
+                .thenReturn(pythonEvent);
+        when(function.call(same(pythonEvent), isNull())).thenReturn(null);
+
+        assertThat(executor.executePythonFunction(function, new InputEvent(1L))).isNull();
+
+        verify(function).setInterpreter(interpreter);
+        verify(pythonEvent).close();
+    }
+
+    @Test
+    void closesTemporaryWrappersAfterStoringAwaitable() throws Exception {
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        PythonRunnerContextImpl runnerContext = mock(PythonRunnerContextImpl.class);
+        PythonActionExecutor executor = newExecutor(interpreter, runnerContext);
+        PythonFunction function = mock(PythonFunction.class);
+        PyObject pythonEvent = mock(PyObject.class);
+        PyObject pythonAwaitable = mock(PyObject.class);
+        when(interpreter.invoke(same(CONVERT_JSON_TO_PYTHON_EVENT), anyString()))
+                .thenReturn(pythonEvent);
+        when(function.call(same(pythonEvent), isNull())).thenReturn(pythonAwaitable);
+
+        String pythonAwaitableRef = executor.executePythonFunction(function, new InputEvent(1L));
+
+        ArgumentCaptor<String> refCaptor = ArgumentCaptor.forClass(String.class);
+        verify(interpreter).set(refCaptor.capture(), same(pythonAwaitable));
+        assertThat(pythonAwaitableRef)
+                .isEqualTo(refCaptor.getValue())
+                .startsWith("python_awaitable_");
+        InOrder closeOrder = inOrder(interpreter, pythonAwaitable, pythonEvent);
+        closeOrder.verify(interpreter).set(pythonAwaitableRef, pythonAwaitable);
+        closeOrder.verify(pythonAwaitable).close();
+        closeOrder.verify(pythonEvent).close();
+    }
+
+    @Test
+    void closesPythonEventWhenActionFails() throws Exception {
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        PythonRunnerContextImpl runnerContext = mock(PythonRunnerContextImpl.class);
+        PythonActionExecutor executor = newExecutor(interpreter, runnerContext);
+        PythonFunction function = mock(PythonFunction.class);
+        PyObject pythonEvent = mock(PyObject.class);
+        RuntimeException failure = new RuntimeException("action failed");
+        when(interpreter.invoke(same(CONVERT_JSON_TO_PYTHON_EVENT), anyString()))
+                .thenReturn(pythonEvent);
+        when(function.call(same(pythonEvent), isNull())).thenThrow(failure);
+
+        assertThatThrownBy(() -> executor.executePythonFunction(function, new InputEvent(1L)))
+                .isInstanceOf(PythonActionExecutor.PythonActionExecutionException.class)
+                .hasCause(failure);
+        verify(pythonEvent).close();
+        verify(runnerContext).drainEvents(null);
+    }
+
+    @Test
+    void closesAwaitableAndEventWhenStoringAwaitableFails() throws Exception {
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        PythonRunnerContextImpl runnerContext = mock(PythonRunnerContextImpl.class);
+        PythonActionExecutor executor = newExecutor(interpreter, runnerContext);
+        PythonFunction function = mock(PythonFunction.class);
+        PyObject pythonEvent = mock(PyObject.class);
+        PyObject pythonAwaitable = mock(PyObject.class);
+        RuntimeException failure = new RuntimeException("set failed");
+        when(interpreter.invoke(same(CONVERT_JSON_TO_PYTHON_EVENT), anyString()))
+                .thenReturn(pythonEvent);
+        when(function.call(same(pythonEvent), isNull())).thenReturn(pythonAwaitable);
+        doThrow(failure).when(interpreter).set(anyString(), same(pythonAwaitable));
+
+        assertThatThrownBy(() -> executor.executePythonFunction(function, new InputEvent(1L)))
+                .isInstanceOf(PythonActionExecutor.PythonActionExecutionException.class)
+                .hasCause(failure);
+        verify(pythonAwaitable).close();
+        verify(pythonEvent).close();
+    }
+
+    @Test
+    void closesRetrievedAwaitableWhileItIsPending() throws Exception {
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        PythonActionExecutor executor = newExecutor(interpreter);
+        PyObject pythonAwaitable = mock(PyObject.class);
+        String pythonAwaitableRef = "python_awaitable_1";
+        when(interpreter.get(pythonAwaitableRef)).thenReturn(pythonAwaitable);
+        when(interpreter.invoke(CALL_PYTHON_AWAITABLE, pythonAwaitable))
+                .thenReturn(new Object[] {false, null});
+
+        assertThat(executor.callPythonAwaitable(pythonAwaitableRef)).isFalse();
+
+        verify(pythonAwaitable).close();
+        verify(interpreter, never()).exec(anyString());
+    }
+
+    @Test
+    void deletesCompletedAwaitableAndClosesRetrievedWrapper() throws Exception {
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        PythonActionExecutor executor = newExecutor(interpreter);
+        PyObject pythonAwaitable = mock(PyObject.class);
+        String pythonAwaitableRef = "python_awaitable_1";
+        when(interpreter.get(pythonAwaitableRef)).thenReturn(pythonAwaitable);
+        when(interpreter.invoke(CALL_PYTHON_AWAITABLE, pythonAwaitable))
+                .thenReturn(new Object[] {true, null});
+
+        assertThat(executor.callPythonAwaitable(pythonAwaitableRef)).isTrue();
+
+        InOrder closeOrder = inOrder(interpreter, pythonAwaitable);
+        closeOrder.verify(interpreter).invoke(CALL_PYTHON_AWAITABLE, pythonAwaitable);
+        closeOrder.verify(interpreter).exec("del " + pythonAwaitableRef);
+        closeOrder.verify(pythonAwaitable).close();
+    }
+
+    @Test
+    void closesRetrievedAwaitableWhenPollingFails() throws Exception {
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        PythonActionExecutor executor = newExecutor(interpreter);
+        PyObject pythonAwaitable = mock(PyObject.class);
+        String pythonAwaitableRef = "python_awaitable_1";
+        RuntimeException failure = new RuntimeException("poll failed");
+        when(interpreter.get(pythonAwaitableRef)).thenReturn(pythonAwaitable);
+        when(interpreter.invoke(CALL_PYTHON_AWAITABLE, pythonAwaitable)).thenThrow(failure);
+
+        assertThatThrownBy(() -> executor.callPythonAwaitable(pythonAwaitableRef))
+                .isSameAs(failure);
+        verify(pythonAwaitable).close();
+        verify(interpreter, never()).exec(anyString());
+    }
+
     private static PythonActionExecutor newExecutor(PythonInterpreter interpreter)
             throws Exception {
-        return new PythonActionExecutor(interpreter, null, null, null, "test-job");
+        return newExecutor(interpreter, null);
+    }
+
+    private static PythonActionExecutor newExecutor(
+            PythonInterpreter interpreter, PythonRunnerContextImpl runnerContext) throws Exception {
+        return new PythonActionExecutor(interpreter, null, null, runnerContext, "test-job");
     }
 }


### PR DESCRIPTION
Linked issue: #1048

### Purpose of change

`PythonActionExecutor` repeatedly creates Java-side Pemja `PyObject` handles while a Python Action is running. Those handles own native Python references and were previously dropped without calling `close()`.

This change:

- closes the temporary Python Event and coroutine wrappers after each Action invocation;
- keeps a pending coroutine alive through the independent interpreter-global reference established by `interpreter.set(...)`;
- closes the temporary wrapper returned by each `interpreter.get(...)` poll;
- deletes the interpreter-global coroutine reference after the coroutine completes;
- returns only the awaitable completion state from Python instead of materializing ignored yielded/returned values across JNI.

The last point avoids a recursive ownership problem: an Action output may contain arbitrary nested Python objects, while Java never consumes the output. Actions communicate with the runtime through emitted Events, so the narrow boundary is a boolean completion state.

This is complementary to #944: that PR handles executor-lifetime objects during attempt cleanup, while this PR handles objects created repeatedly during the lifetime of an open executor.

### Tests

- `PythonActionExecutorTest`: 11 passed, covering synchronous completion, async storage, Action failure, `set` failure, pending/completed polling, and polling failure.
- `test_function.py`: 27 passed, including yielded and returned values being reduced to completion state.
- `./tools/lint.sh -c`: passed for Python lint and all Java Spotless modules.
- Local Flink A/B: 12 fresh single-slot jobs covering six ownership boundaries in fixed/leak variants, 100 records with a 1 MiB payload each. Every fixed variant ended with zero tracked live objects and zero retained payload. Each leak variant retained exactly 100 affected objects or globals; payload-bearing variants retained 100 MiB. Full details are in #1048.

### API

No user-facing API changes. `PythonActionExecutor` and `call_python_awaitable` are internal runtime bridge helpers. The helper now returns `bool` rather than `(bool, output)` because the output was not consumed. `PyObject.close()` failures continue through the existing `ActionTask.invoke(...) throws Exception` path.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

Generated-by: Codex (GPT-5)
