### PR TITLE
[hotfix][python] Pin googleapis common protos below 1.72.1

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -58,6 +58,9 @@ dependencies = [
     "anthropic>=0.77.0",
     "ibm-watsonx-ai>=1.3.42,<1.6.0;python_version<'3.11'",
     "ibm-watsonx-ai>=1.6.0,<2;python_version>='3.11'",
+    # googleapis-common-protos 1.75.1+ requires protobuf 6.33.5+, which is
+    # incompatible with the protobuf runtimes selected by supported PyFlink releases.
+    "googleapis-common-protos<1.72.1",
     "chromadb==1.0.21",
     "mem0ai>=0.1.43,<2.0.0",
     "onnxruntime<1.24.1;python_version<'3.11'",


### PR DESCRIPTION
Linked issue: N/A (hotfix)

### Purpose of change

Fresh Python dependency resolution can install `googleapis-common-protos` 1.75.1 or newer, whose generated protobufs require protobuf 6.33.5 or newer. Installing a supported PyFlink release afterwards can downgrade the protobuf runtime to 4.23.4 or 5.29.6, causing pytest collection and user imports through Chroma/OpenTelemetry to fail with a protobuf gencode/runtime `VersionError`.

Constrain `googleapis-common-protos` below 1.72.1 so normal package resolution selects the verified 1.72.0 release, which remains compatible with the protobuf runtimes selected by supported PyFlink versions.

### Tests

- `tools/ut.sh -p` — 930 passed, 13 skipped, 165 deselected.
- Verified `googleapis-common-protos<1.72.1` resolves to 1.72.0 and imports `google.rpc.error_details_pb2` with protobuf 4.23.4 and 5.29.6.
- Verified the original `chromadb -> OpenTelemetry -> google.rpc` import chain after installing PyFlink 2.3.0.

### API

No public API changes. This only constrains a Python package dependency.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

Generated-by: Codex (GPT-5)
