### PR TITLE
[hotfix][python][test] Fix OpenAI E2E model configuration

### DIFF
--- a/python/flink_agents/e2e_tests/e2e_tests_integration/agent_skills_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/agent_skills_test.py
@@ -74,7 +74,7 @@ class SkillTestAgent(Agent):
             clazz=ResourceName.ChatModel.OPENAI_COMPLETIONS_CONNECTION,
             api_key=API_KEY,
             api_base_url=BASE_URL,
-            request_timeout=300,
+            timeout=300,
         )
 
     @chat_model_setup
@@ -267,7 +267,7 @@ def test_react_agent_with_skills(tmp_path: Path) -> None:
                 clazz=ResourceName.ChatModel.OPENAI_COMPLETIONS_CONNECTION,
                 api_key=API_KEY,
                 api_base_url=BASE_URL,
-                request_timeout=300,
+                timeout=300,
             ),
         ).add_resource(
             "my_skill",

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/long_term_memory_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/long_term_memory_test.py
@@ -148,7 +148,7 @@ class LongTermMemoryAgent(Agent):
             clazz=ResourceName.ChatModel.OPENAI_COMPLETIONS_CONNECTION,
             api_key=API_KEY,
             api_base_url=BASE_URL,
-            request_timeout=300,
+            timeout=300,
         )
 
     @chat_model_setup
@@ -159,8 +159,6 @@ class LongTermMemoryAgent(Agent):
             clazz=ResourceName.ChatModel.OPENAI_COMPLETIONS_SETUP,
             connection="openai_connection",
             model=MODEL,
-            extract_reasoning=True,
-            think=False,
         )
 
     @embedding_model_connection


### PR DESCRIPTION
Linked issue: N/A (hotfix follow-up to #1051)

### Purpose of change

The strict unknown-argument validation introduced by #1051 exposed invalid OpenAI chat model arguments in Python E2E descriptors. The affected tests passed `request_timeout` to `OpenAIChatModelConnection` and passed `extract_reasoning` and `think` to `OpenAIChatModelSetup`, causing the Python IT job on `main` to fail with Pydantic validation errors.

This change uses the supported `timeout` connection field and removes setup arguments that were previously ignored and are not part of the OpenAI setup contract.

Failed CI job: https://github.com/apache/flink-agents/actions/runs/33037847152/job/98404469756

### Tests

- `PYTHONPATH=$(python3 -c "import sysconfig; print(sysconfig.get_paths()[\"purelib\"])") uv run --no-sync pytest flink_agents/api/chat_models/tests/test_chat_model_base.py flink_agents/integrations/chat_models/openai/tests/test_openai_chat_model.py`
  - 30 passed, 2 skipped
- `uv run --no-sync ruff check --no-fix flink_agents/e2e_tests/e2e_tests_integration/agent_skills_test.py flink_agents/e2e_tests/e2e_tests_integration/long_term_memory_test.py`
- `git diff --check`

The external-service E2E tests were not run locally because they require `ACTION_API_KEY`; the linked CI job exercises them with the repository secret.

### API

No public API changes. This only aligns Python E2E resource descriptors with the existing OpenAI chat model configuration contract.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

Generated-by: OpenAI Codex Desktop 26.803.41515 (GPT-5.6 Sol)