### PR TITLE
[java][python][integrations][anthropic] Stop sending temperature on models that reject it

### DIFF
--- a/integrations/chat-models/anthropic/src/main/java/org/apache/flink/agents/integrations/chatmodels/anthropic/AnthropicChatModelConnection.java
+++ b/integrations/chat-models/anthropic/src/main/java/org/apache/flink/agents/integrations/chatmodels/anthropic/AnthropicChatModelConnection.java
@@ -223,6 +223,45 @@ public class AnthropicChatModelConnection extends BaseChatModelConnection {
         return !PREFILL_UNSUPPORTED_MODELS.contains(effectiveModel);
     }
 
+    // Models Anthropic documents as rejecting a non-default sampling parameter such as
+    // temperature. Source of truth:
+    // https://platform.claude.com/docs/en/build-with-claude/working-with-messages
+    //
+    // Sampling rejection starts at the 4.7 generation and also covers Claude Mythos 5, Claude
+    // Fable 5 and Claude Sonnet 5; a request that carries temperature for one of them is answered
+    // with a 400 rather than a completion. Claude 4.6-generation models still accept it, which is
+    // why this boundary sits one generation later than PREFILL_UNSUPPORTED_MODELS above and cannot
+    // reuse it: Claude 4.6 rejects a prefill while still accepting a temperature. Names carry no
+    // date and are pinned, so the name is itself the snapshot and is matched exactly, and a name
+    // outside the list is treated as accepting the parameter.
+    private static final Set<String> SAMPLING_UNSUPPORTED_MODELS =
+            Set.of(
+                    "claude-opus-4-7",
+                    "claude-opus-4-8",
+                    "claude-opus-5",
+                    "claude-sonnet-5",
+                    "claude-fable-5",
+                    "claude-mythos-5",
+                    "claude-mythos-preview");
+
+    /**
+     * Whether {@code effectiveModel} accepts a non-default sampling parameter such as {@code
+     * temperature}.
+     *
+     * <p>See the list above for the source of truth and for why it is one generation narrower than
+     * {@link #PREFILL_UNSUPPORTED_MODELS}. An unrecognized name reports {@code true}, matching the
+     * documented rule that sampling parameters are the long-standing behaviour and only the listed
+     * names withdraw support.
+     */
+    static boolean supportsSampling(String effectiveModel) {
+        // Load-bearing: the list is an immutable Set, whose contains(null) throws rather than
+        // reporting absence.
+        if (effectiveModel == null) {
+            return true;
+        }
+        return !SAMPLING_UNSUPPORTED_MODELS.contains(effectiveModel);
+    }
+
     /**
      * Derives the native {@code output_config} for a POJO class through the SDK's typed
      * structured-output builder.
@@ -365,8 +404,11 @@ public class AnthropicChatModelConnection extends BaseChatModelConnection {
             builder.maxTokens(((Number) maxTokens).longValue());
         }
 
+        // Only forwarded when the model accepts it: Claude 4.7 and later reject a request that
+        // carries temperature with a 400 rather than a completion, so an unsupported model omits
+        // the parameter instead of sending it.
         Object temperature = modelParams.remove("temperature");
-        if (temperature instanceof Number) {
+        if (temperature instanceof Number && supportsSampling(modelName)) {
             builder.temperature(((Number) temperature).doubleValue());
         }
 

--- a/integrations/chat-models/anthropic/src/test/java/org/apache/flink/agents/integrations/chatmodels/anthropic/AnthropicChatModelConnectionTest.java
+++ b/integrations/chat-models/anthropic/src/test/java/org/apache/flink/agents/integrations/chatmodels/anthropic/AnthropicChatModelConnectionTest.java
@@ -590,6 +590,89 @@ class AnthropicChatModelConnectionTest {
         assertPrefillDecisionForModel("claude-sonnet-4-5", true);
     }
 
+    // ---------------------------------------------------------------------------------------
+    // Sampling (temperature)
+    // ---------------------------------------------------------------------------------------
+
+    private static Map<String, Object> paramsWithModelAndTemperature(String model, double temp) {
+        Map<String, Object> params = params(null);
+        params.put("model", model);
+        params.put("temperature", temp);
+        return params;
+    }
+
+    /**
+     * The models the provider documents as rejecting a non-default sampling parameter, in the order
+     * the connection lists them.
+     */
+    private static Stream<String> samplingUnsupportedModels() {
+        return Stream.of(
+                "claude-opus-4-7",
+                "claude-opus-4-8",
+                "claude-opus-5",
+                "claude-sonnet-5",
+                "claude-fable-5",
+                "claude-mythos-5",
+                "claude-mythos-preview");
+    }
+
+    /**
+     * Names that accept a sampling parameter. {@code claude-opus-4-6} and {@code claude-sonnet-4-6}
+     * are the load-bearing ones: they reject a prefill but still accept temperature, which is why
+     * this boundary cannot reuse {@link #prefillUnsupportedModels}.
+     */
+    private static Stream<String> samplingSupportedModels() {
+        return Stream.of(
+                "claude-opus-4-6",
+                "claude-sonnet-4-6",
+                "claude-sonnet-4-20250514",
+                "claude-3-5-sonnet-latest",
+                "");
+    }
+
+    @ParameterizedTest
+    @MethodSource("samplingUnsupportedModels")
+    @DisplayName("every model documented as rejecting sampling reports unsupported")
+    void testSamplingUnsupportedModelsReportUnsupported(String model) {
+        assertThat(AnthropicChatModelConnection.supportsSampling(model)).isFalse();
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @MethodSource("samplingSupportedModels")
+    @DisplayName("a model outside that list reports sampling supported")
+    void testSamplingSupportedModelsReportSupported(String model) {
+        assertThat(AnthropicChatModelConnection.supportsSampling(model)).isTrue();
+    }
+
+    @Test
+    @DisplayName("temperature is omitted on a model that rejects sampling")
+    void testTemperatureOmittedOnUnsupportedModel() {
+        AnthropicChatModelConnection.BuiltRequest built =
+                connection()
+                        .buildRequest(
+                                userMessage(),
+                                List.of(),
+                                paramsWithModelAndTemperature("claude-opus-4-7", 0.1),
+                                null);
+
+        assertThat(built.params.temperature()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("temperature is sent on a model that accepts sampling")
+    void testTemperatureSentOnSupportedModel() {
+        AnthropicChatModelConnection.BuiltRequest built =
+                connection()
+                        .buildRequest(
+                                userMessage(),
+                                List.of(),
+                                paramsWithModelAndTemperature("claude-sonnet-4-20250514", 0.3),
+                                null);
+
+        assertThat(built.params.temperature()).hasValue(0.3);
+    }
+
     /** Minimal tool stub; only its presence in the tools list matters. */
     private static class StubTool extends Tool {
         StubTool() {

--- a/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
@@ -197,6 +197,42 @@ def _supports_json_prefill(effective_model: str | None) -> bool:
     return effective_model not in _PREFILL_UNSUPPORTED_MODELS
 
 
+# Models Anthropic documents as rejecting a non-default sampling parameter such as
+# temperature. Source of truth:
+# https://platform.claude.com/docs/en/build-with-claude/working-with-messages
+#
+# Sampling rejection starts at the 4.7 generation and also covers Claude Mythos 5,
+# Claude Fable 5 and Claude Sonnet 5; a request that carries temperature for one of
+# them is answered with a 400 rather than a completion. Claude 4.6-generation models
+# still accept it, which is why this boundary sits one generation later than
+# _PREFILL_UNSUPPORTED_MODELS above and cannot reuse it: Claude 4.6 rejects a prefill
+# while still accepting a temperature. Names carry no date and are pinned, so the name
+# is itself the snapshot and is matched exactly, and a name outside the list is treated
+# as accepting the parameter.
+_SAMPLING_UNSUPPORTED_MODELS = frozenset(
+    {
+        "claude-opus-4-7",
+        "claude-opus-4-8",
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-fable-5",
+        "claude-mythos-5",
+        "claude-mythos-preview",
+    }
+)
+
+
+def _supports_sampling(effective_model: str | None) -> bool:
+    """Whether ``effective_model`` accepts a non-default sampling parameter.
+
+    See the module-level list above for the source of truth and for why it is one
+    generation narrower than ``_PREFILL_UNSUPPORTED_MODELS``. An unrecognized name
+    reports ``True``, matching the documented rule that sampling parameters are the
+    long-standing behaviour and only the listed names withdraw support.
+    """
+    return effective_model not in _SAMPLING_UNSUPPORTED_MODELS
+
+
 def _native_output_config(output_schema: Any) -> Dict[str, Any] | None:
     """Build the Anthropic ``output_config`` for a native structured-output request.
 
@@ -335,6 +371,12 @@ class AnthropicChatModelConnection(BaseChatModelConnection):
         # Removed from kwargs unconditionally: it is a framework parameter, and leaving
         # it in place would reach messages.create as an unknown request field.
         json_prefill = kwargs.pop("json_prefill", False)
+
+        # Only forwarded when the model accepts it: Claude 4.7 and later reject a
+        # request that carries temperature with a 400 rather than a completion, so an
+        # unsupported model omits the parameter instead of sending it.
+        if "temperature" in kwargs and not _supports_sampling(kwargs.get("model")):
+            kwargs.pop("temperature")
 
         # TODO(#912): the requested strategy is not visible here, so this check
         # cannot tell an explicit NATIVE request apart from one that merely

--- a/python/flink_agents/integrations/chat_models/anthropic/tests/test_anthropic_response_parsing.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/tests/test_anthropic_response_parsing.py
@@ -30,6 +30,7 @@ from flink_agents.integrations.chat_models.anthropic.anthropic_chat_model import
     AnthropicChatModelConnection,
     AnthropicChatModelSetup,
     _supports_json_prefill,
+    _supports_sampling,
 )
 
 
@@ -498,6 +499,60 @@ def test_prefill_predicate_rejects_unsupported_models(model) -> None:
 @pytest.mark.parametrize("model", _PREFILL_SUPPORTED)
 def test_prefill_predicate_accepts_every_other_model(model) -> None:
     assert _supports_json_prefill(model) is True
+
+
+# ---------------------------------------------------------------------------------
+# Sampling (temperature)
+# ---------------------------------------------------------------------------------
+
+# The models the provider documents as rejecting a non-default sampling parameter, in
+# the order the connection lists them.
+_SAMPLING_UNSUPPORTED = [
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-opus-5",
+    "claude-sonnet-5",
+    "claude-fable-5",
+    "claude-mythos-5",
+    "claude-mythos-preview",
+]
+
+# Names that accept a sampling parameter. claude-opus-4-6 and claude-sonnet-4-6 are the
+# load-bearing ones: they reject a prefill but still accept temperature, which is why
+# this boundary cannot reuse _PREFILL_UNSUPPORTED.
+_SAMPLING_SUPPORTED = [
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-sonnet-4-20250514",
+    "claude-3-5-sonnet-latest",
+    "",
+    None,
+]
+
+
+def test_temperature_omitted_on_unsupported_model() -> None:
+    assert "temperature" not in _request_kwargs(
+        model="claude-opus-4-7", temperature=0.1
+    )
+
+
+def test_temperature_sent_on_supported_model() -> None:
+    assert (
+        _request_kwargs(model="claude-sonnet-4-20250514", temperature=0.3)[
+            "temperature"
+        ]
+        == 0.3
+    )
+
+
+@pytest.mark.parametrize("model", _SAMPLING_UNSUPPORTED)
+def test_sampling_predicate_rejects_unsupported_models(model) -> None:
+    assert _supports_sampling(model) is False
+
+
+@pytest.mark.parametrize("model", _SAMPLING_SUPPORTED)
+def test_sampling_predicate_accepts_every_other_model(model) -> None:
+    assert _supports_sampling(model) is True
 
 
 # ---------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #1036.

The Anthropic integration gives `temperature` a default of `0.1` and puts it on every request unconditionally, in both the Java and Python connections. Claude 4.7-generation models and later (`claude-opus-4-7`, `claude-opus-4-8`, `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`, `claude-mythos-5`, `claude-mythos-preview`) reject a non-default sampling parameter with an HTTP 400, so selecting one of those models turned every chat call into a provider error instead of a completion.

Claude 4.6-generation models (`claude-opus-4-6`, `claude-sonnet-4-6`) still accept `temperature`, so this boundary sits one generation narrower than the existing `PREFILL_UNSUPPORTED_MODELS` list and can't reuse it (the same reasoning already documented on that list applies here in reverse).

## Changes

- **Java** (`AnthropicChatModelConnection.java`): added a `SAMPLING_UNSUPPORTED_MODELS` allowlist and a `supportsSampling(String)` predicate, mirroring the existing `supportsJsonPrefill` gate. `buildRequest` now only forwards `temperature` onto the request builder when the effective model accepts it.
- **Python** (`anthropic_chat_model.py`): added the matching `_SAMPLING_UNSUPPORTED_MODELS` / `_supports_sampling` and popped `temperature` from `kwargs` before calling `messages.create` when the model doesn't accept it.
- Per the issue, `top_p` and `top_k` are out of scope — those only reach the request when a caller explicitly passes them via `additional_kwargs`/`kwargs`, not as a default the integration injects.

The fix omits the parameter rather than changing its value, since Anthropic's own default (or omitting the parameter) is accepted on every model.

## Test plan

- Added Java tests to `AnthropicChatModelConnectionTest`: parametrized coverage of every model in the new unsupported list reporting unsupported, every other model (including the 4.6-generation boundary models) reporting supported, and two `buildRequest` tests asserting `temperature` is present/absent on the built request.
- Added Python tests to `test_anthropic_response_parsing.py`: parametrized predicate coverage plus two request-level tests asserting `temperature` is omitted/forwarded in the kwargs sent to `messages.create`.
- Verified RED→GREEN: with the test files in place and only the source fix reverted (`git stash` on the source-only diff), the Java tests fail to compile against the missing `supportsSampling` symbol and the Python test module fails to import `_supports_sampling` — confirming the tests exercise the new behavior rather than passing vacuously. Restored the fix and reran: all new tests pass.
- `mvn -pl integrations/chat-models/anthropic -am test` — full module suite green, no regressions.
- `pytest flink_agents/integrations/chat_models/anthropic/tests/test_anthropic_response_parsing.py` — 77 passed.
- `ruff check` / `ruff format --check` on the touched Python files — clean.
- `spotless:apply` run on the touched Java test file to match AOSP formatting.

Generated-by: AI coding assistant
