### PR TITLE
[ci][integrations] Consolidate vector store tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,33 +245,6 @@ jobs:
           LOG_LEVEL: INFO
         run: tools/ut.sh -j -e -f ${{ matrix.flink-version }}
 
-  elasticsearch_tests:
-    name: Elasticsearch vector-store tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-      - name: Install flink-agents Java
-        run: bash tools/build.sh -j
-      - name: Start Elasticsearch
-        run: |
-          docker compose -f tools/docker/elasticsearch/docker-compose.yml down -v
-          docker compose -f tools/docker/elasticsearch/docker-compose.yml up -d
-          timeout 180 bash -c 'until curl -fsS http://localhost:9200/_cluster/health; do sleep 5; done'
-      - name: Run Elasticsearch tests
-        env:
-          ES_HOST: http://localhost:9200
-        run: |
-          mvn -B --no-transfer-progress -pl integrations/vector-stores/elasticsearch -am -Dspotless.skip=true -Drat.skip=true -Dtest=ElasticsearchVectorStoreTest -Dsurefire.failIfNoSpecifiedTests=false test
-      - name: Stop Elasticsearch
-        if: always()
-        run: docker compose -f tools/docker/elasticsearch/docker-compose.yml down -v
-
   cross_language_tests:
     name: cross-language [${{ matrix.os }}] [python-${{ matrix.python-version}}] [java-${{ matrix.java-version}}]
     runs-on: ${{ matrix.os }}
@@ -319,11 +292,21 @@ jobs:
           docker compose -f tools/docker/elasticsearch/docker-compose.yml down -v
           docker compose -f tools/docker/elasticsearch/docker-compose.yml up -d
           timeout 180 bash -c 'until curl -fsS http://localhost:9200/_cluster/health; do sleep 5; done'
+      - name: Run Elasticsearch vector-store tests
+        env:
+          ES_HOST: http://localhost:9200
+        run: |
+          mvn -B --no-transfer-progress -pl integrations/vector-stores/elasticsearch -am -Dspotless.skip=true -Drat.skip=true -Dtest=ElasticsearchVectorStoreTest -Dsurefire.failIfNoSpecifiedTests=false test
       - name: Start Milvus
         run: |
           docker compose -f tools/docker/milvus/docker-compose.yml down -v
           docker compose -f tools/docker/milvus/docker-compose.yml up -d
           timeout 180 bash -c 'until curl -fsS http://localhost:9091/healthz; do sleep 5; done'
+      - name: Run Milvus vector-store tests
+        env:
+          MILVUS_URI: http://localhost:19530
+        run: |
+          mvn -B --no-transfer-progress -pl integrations/vector-stores/milvus -am -Dspotless.skip=true -Drat.skip=true -Dtest=MilvusVectorStoreTest -Dsurefire.failIfNoSpecifiedTests=false test
       - name: Run e2e tests
         env:
           LOG_LEVEL: INFO


### PR DESCRIPTION
Linked issue: N/A

### Purpose of change

The `cross_language_tests` job already starts Elasticsearch and Milvus for its
end-to-end coverage. The standalone `elasticsearch_tests` job duplicated the
checkout, Java setup, build, and Elasticsearch lifecycle.

This change:

- runs `ElasticsearchVectorStoreTest` after Elasticsearch becomes ready in the
  existing cross-language job;
- runs `MilvusVectorStoreTest` after Milvus becomes ready in the same job; and
- removes the standalone Elasticsearch job and its duplicate setup.

### Tests

- `ElasticsearchVectorStoreTest`: 6 tests passed against Elasticsearch 8.19.0,
  with no failures, errors, or skips.
- `MilvusVectorStoreTest`: 12 tests passed against Milvus 2.6.15, with no
  failures, errors, or skips.
- Both Docker Compose files pass `docker compose config --quiet`.
- The workflow passes YAML parsing, job-structure assertions, and
  `git diff --check`.

### API

No public API changes.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

Generated-by: OpenAI Codex 0.144.5 (GPT-5)
