### PR TITLE
[integrations][java][python] Update stale Anthropic default model to claude-sonnet-4-5

### DIFF
--- a/docs/content/docs/development/chat_models.md
+++ b/docs/content/docs/development/chat_models.md
@@ -287,7 +287,7 @@ Anthropic provides cloud-based chat models featuring the Claude family, known fo
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `connection` | str | Required | Reference to connection method name |
-| `model` | str | `"claude-sonnet-4-20250514"` | Name of the chat model to use |
+| `model` | str | `"claude-sonnet-4-5"` | Name of the chat model to use |
 | `prompt` | Prompt \| str | None | Prompt template or reference to prompt resource |
 | `tools` | List[str] | None | List of tool names available to the model |
 | `max_tokens` | int | `1024` | Maximum number of tokens to generate |
@@ -302,7 +302,7 @@ Anthropic provides cloud-based chat models featuring the Claude family, known fo
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `connection` | String | Required | Reference to connection method name |
-| `model` | String | `"claude-sonnet-4-20250514"` | Name of the chat model to use |
+| `model` | String | `"claude-sonnet-4-5"` | Name of the chat model to use |
 | `prompt` | Prompt \| String | None | Prompt template or reference to prompt resource |
 | `tools` | List<String> | None | List of tool names available to the model |
 | `max_tokens` | long | `1024` | Maximum number of tokens to generate |
@@ -339,7 +339,7 @@ class MyAgent(Agent):
         return ResourceDescriptor(
             clazz=ResourceName.ChatModel.ANTHROPIC_SETUP,
             connection="anthropic_connection",
-            model="claude-sonnet-4-20250514",
+            model="claude-sonnet-4-5",
             max_tokens=2048,
             temperature=0.7
         )
@@ -364,7 +364,7 @@ public class MyAgent extends Agent {
     public static ResourceDescriptor anthropicChatModel() {
         return ResourceDescriptor.Builder.newBuilder(ResourceName.ChatModel.ANTHROPIC_SETUP)
                 .addInitialArgument("connection", "anthropicConnection")
-                .addInitialArgument("model", "claude-sonnet-4-20250514")
+                .addInitialArgument("model", "claude-sonnet-4-5")
                 .addInitialArgument("temperature", 0.7d)
                 .addInitialArgument("max_tokens", 2048)
                 .build();
@@ -382,10 +382,7 @@ public class MyAgent extends Agent {
 Visit the [Anthropic Models documentation](https://docs.anthropic.com/en/docs/about-claude/models) for the complete and up-to-date list of available chat models.
 
 Some popular options include:
-- **Claude Sonnet 4.5** (claude-sonnet-4-5-20250929)
-- **Claude Sonnet 4** (claude-sonnet-4-20250514)
-- **Claude Sonnet 3.7** (claude-3-7-sonnet-20250219)
-- **Claude Opus 4.1** (claude-opus-4-1-20250805)
+- **Claude Sonnet 4.5** (claude-sonnet-4-5)
 
 {{< hint warning >}}
 Model availability and specifications may change. Always check the official Anthropic documentation for the latest information before implementing in production.

--- a/integrations/chat-models/anthropic/src/main/java/org/apache/flink/agents/integrations/chatmodels/anthropic/AnthropicChatModelSetup.java
+++ b/integrations/chat-models/anthropic/src/main/java/org/apache/flink/agents/integrations/chatmodels/anthropic/AnthropicChatModelSetup.java
@@ -37,7 +37,7 @@ import java.util.Optional;
  *
  * <ul>
  *   <li><b>connection</b> (required): Name of the AnthropicChatModelConnection resource
- *   <li><b>model</b> (optional): Model name (default: claude-sonnet-4-20250514)
+ *   <li><b>model</b> (optional): Model name (default: claude-sonnet-4-5)
  *   <li><b>temperature</b> (optional): Sampling temperature 0.0-1.0 (default: 0.1)
  *   <li><b>max_tokens</b> (optional): Maximum tokens in response (default: 1024)
  *   <li><b>json_prefill</b> (optional): When true, prefills assistant response with "{" to enforce
@@ -60,7 +60,7 @@ import java.util.Optional;
  *   public static ResourceDesc anthropic() {
  *     return ResourceDescriptor.Builder.newBuilder(AnthropicChatModelSetup.class.getName())
  *             .addInitialArgument("connection", "myAnthropicConnection")
- *             .addInitialArgument("model", "claude-sonnet-4-20250514")
+ *             .addInitialArgument("model", "claude-sonnet-4-5")
  *             .addInitialArgument("temperature", 0.3d)
  *             .addInitialArgument("max_tokens", 2048)
  *             .addInitialArgument("strict_tools", true)
@@ -75,7 +75,7 @@ import java.util.Optional;
  */
 public class AnthropicChatModelSetup extends BaseChatModelSetup {
 
-    private static final String DEFAULT_MODEL = "claude-sonnet-4-20250514";
+    private static final String DEFAULT_MODEL = "claude-sonnet-4-5";
     private static final double DEFAULT_TEMPERATURE = 0.1d;
     private static final long DEFAULT_MAX_TOKENS = 1024L;
     private static final boolean DEFAULT_JSON_PREFILL = false;

--- a/integrations/chat-models/anthropic/src/test/java/org/apache/flink/agents/integrations/chatmodels/anthropic/AnthropicChatModelSetupTest.java
+++ b/integrations/chat-models/anthropic/src/test/java/org/apache/flink/agents/integrations/chatmodels/anthropic/AnthropicChatModelSetupTest.java
@@ -43,7 +43,7 @@ class AnthropicChatModelSetupTest {
         Map<String, Object> params =
                 new AnthropicChatModelSetup(base().build(), NOOP).getParameters();
 
-        assertThat(params).containsEntry("model", "claude-sonnet-4-20250514");
+        assertThat(params).containsEntry("model", "claude-sonnet-4-5");
         assertThat(params).containsEntry("temperature", 0.1d);
         assertThat(params).containsEntry("max_tokens", 1024L);
         assertThat(params).containsEntry("strict_tools", false);

--- a/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
+++ b/python/flink_agents/integrations/chat_models/anthropic/anthropic_chat_model.py
@@ -450,7 +450,7 @@ class AnthropicChatModelConnection(BaseChatModelConnection):
                 self._client = None
 
 
-DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-20250514"
+DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-5"
 DEFAULT_MAX_TOKENS = 1024
 DEFAULT_TEMPERATURE = 0.1
 DEFAULT_JSON_PREFILL = False
@@ -464,7 +464,7 @@ class AnthropicChatModelSetup(BaseChatModelSetup):
     connection : str
         Name of the referenced connection. (Inherited from BaseChatModelSetup)
     model : str
-        Specifies the Anthropic model to use. Defaults to claude-sonnet-4-20250514
+        Specifies the Anthropic model to use. Defaults to ``DEFAULT_ANTHROPIC_MODEL``
         when omitted via ``__init__``. (Inherited from BaseChatModelSetup)
     prompt : Optional[Union[Prompt, str]
         Prompt template or string for the model. (Inherited from BaseChatModelSetup)


### PR DESCRIPTION
Linked issue: #1038

### Purpose of change

The Anthropic chat model integration defaulted to the deprecated `claude-sonnet-4-20250514` snapshot in both language runtimes, restated across Javadoc, a Python docstring, and the docs parameter tables/examples. A caller who took the default silently got a deprecated model and would hit a hard failure once it retires.

- Java: `AnthropicChatModelSetup.DEFAULT_MODEL`, plus its Javadoc parameter entry and usage example.
- Python: `DEFAULT_ANTHROPIC_MODEL`, and its docstring now names the constant instead of restating the literal (matching the OpenAI and Tongyi integrations, which is why those two never drifted).
- Docs: `AnthropicChatModelSetup` parameter tables and usage examples for both languages, and pruned the "Available Models" list down to the current default — it previously recommended `claude-3-7-sonnet` and `claude-opus-4-1`, both already past retirement.

Anthropic was also the only chat model integration using a dated snapshot as its default; every other one (OpenAI, Gemini, Tongyi) defaults to an undated alias, which is why only this one went stale unnoticed.

Left untouched, deliberately:
- The Bedrock integration's own model-ID default — `us.anthropic.claude-sonnet-4-20250514-v1:0` is Bedrock's own model catalog naming, not the Anthropic API snapshot this issue is about.
- The `AnthropicChatModelConnectionTest` fixtures that use the old snapshot name as an example of a model *not* capable of native structured output — those intentionally exercise the "not currently capable" recognition path rather than pin a default.

### Tests

- Updated `AnthropicChatModelSetupTest.testGetParametersDefaults` to assert the new default (was pinning the old one) — 2/2 pass.
- Full `AnthropicChatModelConnectionTest` suite (58 tests) still passes unchanged, confirming the deliberately-untouched fixtures weren't affected.
- Python: full `anthropic` integration test suite (64 passed, 2 skipped) still passes, including `test_anthropic_chat_model.py`'s check against the `DEFAULT_ANTHROPIC_MODEL` constant.
- `spotless:check` (Java) and `ruff check` + `ruff format --check` (Python) both clean.

### API

No public API shape change — only the default value of an existing optional parameter.

### Documentation

- [x] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes

Generated-by: AI coding assistant

This fix follows from my own diagnosis of the bug. I used AI tooling for exploration and testing, directing it toward the change I had in mind.
