### PR TITLE
[release-0.3][hotfix][runtime][java] Reject raw bytes from PyFlink inputs

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -56,6 +56,9 @@ dependencies = [
     "dashscope~=1.24.2",
     "openai>=1.66.3",
     "anthropic>=0.64.0",
+    # googleapis-common-protos 1.75.1+ requires protobuf 6.33.5+, which is
+    # incompatible with the protobuf runtimes selected by supported PyFlink releases.
+    "googleapis-common-protos<1.72.1",
     "chromadb==1.0.21",
     "mem0ai>=0.1.43,<2.0.0",
     "onnxruntime<1.24.1;python_version<'3.11'",

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/CompileUtils.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/CompileUtils.java
@@ -24,17 +24,32 @@ import org.apache.flink.agents.plan.AgentPlan;
 import org.apache.flink.agents.runtime.operator.ActionExecutionOperatorFactory;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.KeyedStream;
+import org.apache.flink.streaming.api.typeinfo.python.PickledByteArrayTypeInfo;
 import org.apache.flink.types.Row;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /** A utility class that bridges Flink DataStream/SQL with the Flink Agents agent. */
 public class CompileUtils {
+
+    private static final int PYTHON_VALUE_FIELD_INDEX = 1;
 
     // ============================ invoke by python ====================================
     public static DataStream<byte[]> connectToAgent(
             KeyedStream<Row, Row> inputDataStream, String agentPlanJson)
             throws JsonProcessingException {
+        TypeInformation<?> inputType = inputDataStream.getType();
+        checkArgument(
+                isPickledPythonFieldType(inputType, PYTHON_VALUE_FIELD_INDEX),
+                "Flink Agents only supports PyFlink input values serialized with "
+                        + "PickledByteArrayTypeInfo. Convert raw byte-array inputs with a Python "
+                        + "operator using the default pickle output type before connecting them "
+                        + "to Flink Agents, but got %s",
+                inputType);
+
         // deserialize agent plan json.
         AgentPlan agentPlan = new ObjectMapper().readValue(agentPlanJson, AgentPlan.class);
         return connectToAgent(inputDataStream, agentPlan, TypeInformation.of(byte[].class), false);
@@ -81,5 +96,23 @@ public class CompileUtils {
                                 outTypeInformation,
                                 new ActionExecutionOperatorFactory(agentPlan, inputIsJava))
                         .setParallelism(keyedInputStream.getParallelism());
+    }
+
+    /** Returns whether a PyFlink Row field uses its default pickle representation. */
+    static boolean isPickledPythonFieldType(TypeInformation<?> typeInformation, int fieldIndex) {
+        checkArgument(fieldIndex >= 0, "Field index must not be negative, but got %s", fieldIndex);
+        checkArgument(
+                typeInformation instanceof RowTypeInfo,
+                "Expected PyFlink type to be a RowTypeInfo, but got %s",
+                typeInformation);
+        RowTypeInfo rowType = (RowTypeInfo) typeInformation;
+        int expectedArity = fieldIndex + 1;
+        checkArgument(
+                rowType.getArity() == expectedArity,
+                "Expected PyFlink type to contain %s fields, but got arity %s",
+                expectedArity,
+                rowType.getArity());
+        TypeInformation<?> fieldType = rowType.getTypeAt(fieldIndex);
+        return fieldType instanceof PickledByteArrayTypeInfo;
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/CompileUtilsTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/CompileUtilsTest.java
@@ -17,22 +17,29 @@
  */
 package org.apache.flink.agents.runtime;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.flink.agents.plan.AgentPlan;
 import org.apache.flink.agents.runtime.operator.ActionExecutionOperatorTest;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.KeyedStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.typeinfo.python.PickledByteArrayTypeInfo;
+import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link CompileUtils}. */
 public class CompileUtilsTest {
@@ -94,6 +101,73 @@ public class CompileUtilsTest {
         resultList.sort(Long::compareTo);
 
         checkResult(resultList);
+    }
+
+    @Test
+    void detectsPickledAndNonPickledPythonValueTypes() {
+        assertThat(
+                        CompileUtils.isPickledPythonFieldType(
+                                Types.ROW(
+                                        PickledByteArrayTypeInfo.PICKLED_BYTE_ARRAY_TYPE_INFO,
+                                        PickledByteArrayTypeInfo.PICKLED_BYTE_ARRAY_TYPE_INFO),
+                                1))
+                .isTrue();
+        assertThat(
+                        CompileUtils.isPickledPythonFieldType(
+                                Types.ROW(
+                                        PickledByteArrayTypeInfo.PICKLED_BYTE_ARRAY_TYPE_INFO,
+                                        Types.PRIMITIVE_ARRAY(Types.BYTE)),
+                                1))
+                .isFalse();
+        assertThat(
+                        CompileUtils.isPickledPythonFieldType(
+                                Types.ROW(
+                                        PickledByteArrayTypeInfo.PICKLED_BYTE_ARRAY_TYPE_INFO,
+                                        Types.STRING),
+                                1))
+                .isFalse();
+    }
+
+    @Test
+    void rejectsRawByteArrayPythonInputBeforeDeserializingTheAgentPlan() {
+        KeyedStream<Row, Row> inputDataStream =
+                createPythonInputStream(Types.PRIMITIVE_ARRAY(Types.BYTE));
+
+        assertThatThrownBy(() -> CompileUtils.connectToAgent(inputDataStream, "not-json"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("only supports PyFlink input values")
+                .hasMessageContaining("raw byte-array");
+    }
+
+    @Test
+    void acceptsPickledPythonInputBeforeDeserializingTheAgentPlan() {
+        KeyedStream<Row, Row> inputDataStream =
+                createPythonInputStream(PickledByteArrayTypeInfo.PICKLED_BYTE_ARRAY_TYPE_INFO);
+
+        assertThatThrownBy(() -> CompileUtils.connectToAgent(inputDataStream, "not-json"))
+                .isInstanceOf(JsonProcessingException.class);
+    }
+
+    @Test
+    void rejectsMalformedPythonInputType() {
+        assertThatThrownBy(
+                        () ->
+                                CompileUtils.isPickledPythonFieldType(
+                                        Types.ROW(
+                                                PickledByteArrayTypeInfo
+                                                        .PICKLED_BYTE_ARRAY_TYPE_INFO),
+                                        1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("contain 2 fields");
+    }
+
+    private static KeyedStream<Row, Row> createPythonInputStream(TypeInformation<?> valueType) {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        TypeInformation<Row> inputType =
+                Types.ROW(PickledByteArrayTypeInfo.PICKLED_BYTE_ARRAY_TYPE_INFO, valueType);
+        Row input = Row.of(new byte[0], new byte[0]);
+        return env.fromData(Collections.singletonList(input), inputType)
+                .keyBy(value -> Row.of(value.getField(0)));
     }
 
     private static List<Long> getTestSequence() {


### PR DESCRIPTION
Linked issue: N/A (hotfix)

### Purpose of change

Backport #1075 to `release-0.3`.

The PyFlink bridge deserializes input values using the default pickle representation, but this release line did not validate the incoming value `TypeInformation`. Reject explicit/raw value types before deserializing the agent plan while preserving normal `PickledByteArrayTypeInfo` inputs.

The main security-fix commit cannot be cherry-picked directly because `release-0.3` predates the Python key-serialization changes used by #1075. This backport keeps the release operator/factory interfaces unchanged and applies only the value-type guard.

Also backport #1052 (`e694079d`) to keep `googleapis-common-protos` compatible with the protobuf runtimes selected by supported PyFlink releases. Without this constraint, fresh dependency resolution installs generated Google protos requiring protobuf 6.33.5+, while PyFlink selects protobuf 5.29.6.

### Tests

- `mvn --batch-mode --no-transfer-progress -pl runtime -am test`
- API: 268 tests passed, 9 skipped
- Plan: 156 tests passed, 1 skipped
- Runtime: 403 tests passed
- `CompileUtilsTest`: 6 tests passed
- `tools/ut.sh -p -f 2.2`: 571 passed, 11 skipped, 122 deselected
- Spotless and `git diff --check` passed

### API

No public API changes.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`

Generated-by: OpenAI Codex 0.144.5 (GPT-5)
