### PR TITLE
[e2e][java] Temporarily disable Mem0 cross-language test

### DIFF
--- a/e2e-test/flink-agents-end-to-end-tests-resource-cross-language/src/test/java/org/apache/flink/agents/resource/test/Mem0LongTermMemoryTest.java
+++ b/e2e-test/flink-agents-end-to-end-tests-resource-cross-language/src/test/java/org/apache/flink/agents/resource/test/Mem0LongTermMemoryTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.util.CloseableIterator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -60,6 +61,7 @@ import static org.apache.flink.agents.resource.test.Mem0LongTermMemoryAgent.OLLA
  *       MILVUS_URI} env var
  * </ul>
  */
+@Disabled("Disabled until #1087 is resolved")
 public class Mem0LongTermMemoryTest {
 
     private final boolean embeddingReady;


### PR DESCRIPTION
Linked issue: #1087

### Purpose of change

Temporarily disable `Mem0LongTermMemoryTest` because concurrent access to the shared embedded `PythonInterpreter` can terminate the Surefire JVM and currently makes the cross-language CI job fail for unrelated changes.

The test is disabled at the class level so JUnit skips it before constructing the test instance or probing Ollama, OpenAI, Elasticsearch, or Milvus. It should be re-enabled after #1087 is resolved.

### Tests

- `mvn --batch-mode --no-transfer-progress -Dspotless.skip=true -Dtest=Mem0LongTermMemoryTest -pl e2e-test/flink-agents-end-to-end-tests-resource-cross-language test`
  - `Tests run: 1, Failures: 0, Errors: 0, Skipped: 1`
- `mvn --batch-mode --no-transfer-progress -Dspotless.skip=false -pl e2e-test/flink-agents-end-to-end-tests-resource-cross-language spotless:check`

### API

No public API changes.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

Generated-by: Codex 0.144.5 (GPT-5)
