### PR TITLE
[hotfix][runtime] Raise Kafka admin future timeout from 100ms to 30s

### DIFF
--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStore.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStore.java
@@ -74,7 +74,9 @@ public class KafkaActionStateStore implements ActionStateStore {
 
     private static final Duration CONSUMER_POLL_TIMEOUT = Duration.ofMillis(1000);
     private static final Logger LOG = LoggerFactory.getLogger(KafkaActionStateStore.class);
-    private static final Long DEFAULT_FUTURE_GET_TIMEOUT_MS = 100L;
+    // A cold AdminClient's first metadata round-trip routinely exceeds 100ms even against a
+    // local broker; 100ms made store initialization fail nondeterministically at startup.
+    private static final Long DEFAULT_FUTURE_GET_TIMEOUT_MS = 30_000L;
 
     private final AgentConfiguration agentConfiguration;
 


### PR DESCRIPTION
Linked issue: N/A (hotfix)

### Purpose of change

`KafkaActionStateStore` gives its `AdminClient` futures 100ms (`DEFAULT_FUTURE_GET_TIMEOUT_MS`). A cold AdminClient's first `listTopics` metadata round-trip routinely exceeds 100ms even against a broker on localhost, so store initialization fails nondeterministically at job startup. This raises the timeout to 30s — an initialization-time bound, not a per-record cost.

### How it was found

Recovery experiments against the Kafka action-state store: jobs failed to start intermittently with future-timeout exceptions from topic setup, disappearing on retry once broker metadata was warm.

### Tests

- `mvn test -pl runtime -am -Dtest='*ActionState*'` — 127 tests, 0 failures (includes `KafkaActionStateStoreTest`), on current main.

### API

No public API changes.

### Documentation

- [ ] `doc-needed`
- [x] `doc-not-needed`
- [ ] `doc-included`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

Generated-by: Claude Code (Claude Fable 5)
