### PR TITLE
[runtime] Preserve typed Flink key identity in action state

### DIFF
--- a/docs/content/docs/operations/configuration.md
+++ b/docs/content/docs/operations/configuration.md
@@ -179,7 +179,7 @@ Here are the configuration options for Kafka-based Action State Store.
 | Key                                 | Default                  | Type    | Description                                                                 |
 |-------------------------------------|--------------------------|---------|-----------------------------------------------------------------------------|
 | `kafkaBootstrapServers`             | "localhost:9092"         | String  | The config parameter specifies the Kafka bootstrap server.                  |
-| `kafkaActionStateTopic`             | (none)                   | String  | The config parameter specifies the Kafka topic for action state.            |
+| `kafkaActionStateTopic`             | (none)                   | String  | The Kafka topic for action state. Dedicate it to one logical Flink Agents operator, shared by that operator's subtasks. |
 | `kafkaActionStateTopicNumPartitions`| 64                       | Integer | The config parameter specifies the number of partitions for the Kafka action state topic. |
 | `kafkaActionStateTopicReplicationFactor` | 1                     | Integer | The config parameter specifies the replication factor for the Kafka action state topic. |
 
@@ -191,7 +191,7 @@ Here are the configuration options for Fluss-based Action State Store.
 |------------------------------|------------------|---------|------------------------------------------------------------------------------------------|
 | `flussBootstrapServers`      | "localhost:9123" | String  | The Fluss bootstrap servers address.                                                     |
 | `flussActionStateDatabase`   | "flink_agents"   | String  | The Fluss database name for storing action state.                                        |
-| `flussActionStateTable`      | (none)           | String  | The Fluss table name for storing action state.                                           |
+| `flussActionStateTable`      | (none)           | String  | The Fluss table for action state. Dedicate it to one logical Flink Agents operator, shared by that operator's subtasks. |
 | `flussActionStateTableBuckets` | 64             | Integer | The number of buckets for the Fluss action state table.                                  |
 | `flussSecurityProtocol`      | "PLAINTEXT"      | String  | The authentication protocol for Fluss client. Valid values: `PLAINTEXT` (default, no authentication), `SASL` (SASL/PLAIN authentication). |
 | `flussSaslMechanism`         | "PLAIN"          | String  | The SASL mechanism for Fluss authentication.                                             |

--- a/docs/content/docs/operations/deployment.md
+++ b/docs/content/docs/operations/deployment.md
@@ -102,6 +102,16 @@ The same persisted action state is also used by fine-grained durable execution.
 **Note**: Currently, Kafka and Fluss are supported as the external action state store.
 {{< /hint >}}
 
+{{< hint warning >}}
+The current versioned action-state key format is not compatible with records written in the earlier unversioned format. When upgrading a job that still has unversioned action-state records in its recovery range, use a fresh Kafka topic or Fluss table and start without an older checkpoint or savepoint. Recovery rejects the old format instead of guessing which typed Flink key it represents.
+
+Versioned action-state keys include a fingerprint of the operator key serializer. Restoring existing action state requires the same key type and byte-for-byte-equivalent serializer snapshot configuration. Changing the key serializer or its configuration requires a fresh action-state topic or table and a start without an older checkpoint or savepoint; recovery rejects a mismatched serializer fingerprint.
+
+Dedicate each Kafka topic or Fluss table to one logical Flink Agents operator, shared by that operator's subtasks. Action-state keys do not contain a job or operator namespace, so sharing a backend between logical operators can allow otherwise identical records to collide.
+{{< /hint >}}
+
+The business-key component stored in the backend is a SHA-256 digest rather than the serialized key itself. This keeps record keys bounded and avoids embedding raw key bytes, but it is not encryption; protect the action-state backend with appropriate access controls.
+
 See [Action State Store Configuration]({{< ref "docs/operations/configuration#action-state-store" >}}) for configuration options.
 
 {{< hint info >}}

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateKeyEncoder.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateKeyEncoder.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.actionstate;
+
+import org.apache.flink.agents.api.Event;
+import org.apache.flink.agents.plan.actions.Action;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.function.IntPredicate;
+
+/**
+ * Encodes and validates versioned action-state keys using an operator's keyed-state serializer.
+ *
+ * <p>The serializer snapshot fingerprint is part of every encoded key. Recovery therefore fails
+ * closed if a restored operator uses a different serializer configuration, even when Flink regards
+ * the new serializer as schema-compatible.
+ */
+@Internal
+public final class ActionStateKeyEncoder {
+
+    private final int maxParallelism;
+    private final TypeSerializer<Object> keySerializer;
+    private final String serializerFingerprint;
+
+    public ActionStateKeyEncoder(int maxParallelism, TypeSerializer<?> keySerializer) {
+        Preconditions.checkArgument(
+                maxParallelism > 0,
+                "maxParallelism must be positive but was %s; it must match the operator's maximum parallelism.",
+                maxParallelism);
+        this.maxParallelism = maxParallelism;
+        this.keySerializer = duplicateKeySerializer(keySerializer);
+        this.serializerFingerprint =
+                ActionStateUtil.generateSerializerFingerprint(this.keySerializer);
+    }
+
+    public String generateKey(Object key, long seqNum, Action action, Event event)
+            throws IOException {
+        return ActionStateUtil.generateKey(
+                key, seqNum, action, event, maxParallelism, keySerializer, serializerFingerprint);
+    }
+
+    public String generateBusinessKeyIdentity(Object key) {
+        return ActionStateUtil.generateBusinessKeyIdentity(key, keySerializer);
+    }
+
+    public boolean isKeyRetained(@Nullable IntPredicate ownershipFilter, String stateKey) {
+        return ActionStateUtil.isKeyRetained(
+                ownershipFilter, stateKey, maxParallelism, serializerFingerprint);
+    }
+
+    @VisibleForTesting
+    String getSerializerFingerprint() {
+        return serializerFingerprint;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static TypeSerializer<Object> duplicateKeySerializer(TypeSerializer<?> keySerializer) {
+        return (TypeSerializer<Object>)
+                Preconditions.checkNotNull(keySerializer, "keySerializer cannot be null")
+                        .duplicate();
+    }
+}

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateKeyPartitioner.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateKeyPartitioner.java
@@ -17,12 +17,15 @@
  */
 package org.apache.flink.agents.runtime.actionstate;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.util.MathUtils;
 import org.apache.kafka.clients.producer.Partitioner;
 import org.apache.kafka.common.Cluster;
 
 import java.util.Map;
 
+/** Partitions versioned action-state records by their encoded business-key identity. */
+@Internal
 public class ActionStateKeyPartitioner implements Partitioner {
 
     @Override
@@ -41,15 +44,15 @@ public class ActionStateKeyPartitioner implements Partitioner {
             throw new IllegalArgumentException("Key must be a String");
         }
 
-        String businessKey = ActionStateUtil.businessKeyOf((String) key);
-        if (businessKey == null) {
+        String businessKeyIdentity = ActionStateUtil.businessKeyIdentityOf((String) key);
+        if (businessKeyIdentity == null) {
             throw new IllegalArgumentException("Key format is invalid");
         }
-        if (businessKey.isEmpty()) {
-            throw new IllegalArgumentException("Business key part of the key cannot be empty");
+        if (businessKeyIdentity.isEmpty()) {
+            throw new IllegalArgumentException("Business key identity cannot be empty");
         }
 
-        return MathUtils.murmurHash(businessKey.hashCode()) % numPartitions;
+        return MathUtils.murmurHash(businessKeyIdentity.hashCode()) % numPartitions;
     }
 
     @Override

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateUtil.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateUtil.java
@@ -222,8 +222,11 @@ public class ActionStateUtil {
     }
 
     private static String generateUUIDForAction(Action action) throws IOException {
+        // Action.hashCode() folds in JavaFunction's Class[] parameterTypes, and Class.hashCode()
+        // is the per-JVM identity hash — so the hash-derived UUID changes on every process
+        // restart and recovery lookups can never hit. Derive from the plan-unique action name,
+        // which is stable across restarts.
         return String.valueOf(
-                UUID.nameUUIDFromBytes(
-                        String.valueOf(action.hashCode()).getBytes(StandardCharsets.UTF_8)));
+                UUID.nameUUIDFromBytes(action.getName().getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateUtil.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateUtil.java
@@ -22,25 +22,29 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.plan.actions.Action;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshotSerializationUtil;
+import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.util.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 
 /** Utility class for action state related operations. */
-public class ActionStateUtil {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ActionStateUtil.class);
+@Internal
+public final class ActionStateUtil {
 
     private static final JsonMapper MAPPER =
             JsonMapper.builder()
@@ -48,31 +52,39 @@ public class ActionStateUtil {
                     .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
                     .build();
     private static final String KEY_SEPARATOR = "_";
+    private static final String KEY_FORMAT_VERSION = "v2";
+    private static final String KEY_GROUP_PREFIX = KEY_FORMAT_VERSION + ":";
 
-    // Composite key layout: keyGroup_seqNum_eventUUID_actionUUID_businessKey.
+    // Composite key layout:
+    // v2:keyGroup_seqNum_eventUUID_actionUUID_serializerFingerprint_businessKeyDigest.
     //
-    // Every fixed field before the business key (key-group, seq-num, and the two UUIDs) is
-    // guaranteed to be free of KEY_SEPARATOR, and the business key — the only caller-supplied,
-    // variable-length field — is placed LAST. Parsing therefore splits with a fixed limit so the
-    // final segment keeps the business key intact even when it contains the separator, e.g.
-    // "tenant_user". No escaping is required and the segment count is always exact.
+    // The final segment contains a SHA-256 digest of the bytes produced by Flink's key serializer.
+    // This preserves the typed identity used by keyed state instead of collapsing distinct keys
+    // through Object.toString(), while keeping durable keys bounded in size and avoiding embedding
+    // serialized business-key data directly.
     private static final int KEY_GROUP_SEGMENT = 0;
     private static final int SEQ_NUM_SEGMENT = 1;
     private static final int EVENT_UUID_SEGMENT = 2;
     private static final int ACTION_UUID_SEGMENT = 3;
-    private static final int BUSINESS_KEY_SEGMENT = 4;
-    static final int KEY_SEGMENT_COUNT = 5;
+    private static final int SERIALIZER_FINGERPRINT_SEGMENT = 4;
+    private static final int BUSINESS_KEY_IDENTITY_SEGMENT = 5;
+    static final int KEY_SEGMENT_COUNT = 6;
 
-    public static String generateKey(
-            @Nonnull Object key,
+    static <K> String generateKey(
+            @Nonnull K key,
             long seqNum,
             @Nonnull Action action,
             @Nonnull Event event,
-            int maxParallelism)
+            int maxParallelism,
+            @Nonnull TypeSerializer<K> keySerializer,
+            String serializerFingerprint)
             throws IOException {
         Preconditions.checkNotNull(key, "key cannot be null.");
         Preconditions.checkNotNull(action, "action cannot be null.");
         Preconditions.checkNotNull(event, "event cannot be null.");
+        Preconditions.checkNotNull(keySerializer, "keySerializer cannot be null.");
+        Preconditions.checkNotNull(serializerFingerprint, "serializerFingerprint cannot be null.");
+        Preconditions.checkArgument(seqNum >= 0, "seqNum must be nonnegative but was %s.", seqNum);
         Preconditions.checkArgument(
                 maxParallelism > 0,
                 "maxParallelism must be positive but was %s; the store's maxParallelism must be"
@@ -81,16 +93,46 @@ public class ActionStateUtil {
         int keyGroup = KeyGroupRangeAssignment.assignToKeyGroup(key, maxParallelism);
         return String.join(
                 KEY_SEPARATOR,
-                String.valueOf(keyGroup),
+                KEY_GROUP_PREFIX + keyGroup,
                 String.valueOf(seqNum),
                 generateUUIDForEvent(event),
                 generateUUIDForAction(action),
-                key.toString());
+                serializerFingerprint,
+                generateBusinessKeyIdentity(key, keySerializer));
+    }
+
+    /** Returns a stable digest of a Flink key's serialized, type-preserving representation. */
+    public static <K> String generateBusinessKeyIdentity(
+            @Nonnull K key, @Nonnull TypeSerializer<K> keySerializer) {
+        Preconditions.checkNotNull(key, "key cannot be null.");
+        Preconditions.checkNotNull(keySerializer, "keySerializer cannot be null.");
+        DataOutputSerializer output = new DataOutputSerializer(64);
+        try {
+            keySerializer.serialize(key, output);
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                    "Failed to serialize the Flink key for durable action state", e);
+        }
+        return sha256Base64(output.getCopyOfBuffer());
+    }
+
+    static String generateSerializerFingerprint(TypeSerializer<?> keySerializer) {
+        Preconditions.checkNotNull(keySerializer, "keySerializer cannot be null.");
+        DataOutputSerializer output = new DataOutputSerializer(128);
+        try {
+            TypeSerializerSnapshotSerializationUtil.writeSerializerSnapshot(
+                    output, keySerializer.snapshotConfiguration());
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                    "Failed to fingerprint the Flink key serializer for durable action state", e);
+        }
+        return sha256Base64(output.getCopyOfBuffer());
     }
 
     /**
      * Parses a composite state key into its semantic fields, in the order {@code [keyGroup, seqNum,
-     * eventUUID, actionUUID, businessKey]}. Throws when {@code key} is not in the current format.
+     * eventUUID, actionUUID, serializerFingerprint, businessKeyIdentity]}. Throws when {@code key}
+     * is not in the current format.
      */
     public static List<String> parseKey(String key) {
         Preconditions.checkNotNull(key, "key cannot be null.");
@@ -101,7 +143,8 @@ public class ActionStateUtil {
                 parts[SEQ_NUM_SEGMENT],
                 parts[EVENT_UUID_SEGMENT],
                 parts[ACTION_UUID_SEGMENT],
-                parts[BUSINESS_KEY_SEGMENT]);
+                parts[SERIALIZER_FINGERPRINT_SEGMENT],
+                parts[BUSINESS_KEY_IDENTITY_SEGMENT]);
     }
 
     /**
@@ -118,91 +161,96 @@ public class ActionStateUtil {
 
     /**
      * Returns {@code true} when {@code stateKey} is in the current format and its business-key
-     * segment equals {@code businessKey}. The business key occupies its own trailing segment, so
-     * the comparison is exact and cannot collide with another record's numeric segments.
+     * identity segment equals {@code businessKeyIdentity}. The identity occupies its own trailing
+     * segment, so the comparison is exact and cannot collide with another record's numeric
+     * segments.
      */
-    public static boolean matchesBusinessKey(String stateKey, Object businessKey) {
+    public static boolean matchesBusinessKeyIdentity(String stateKey, String businessKeyIdentity) {
         String[] parts = splitValidatedKey(stateKey);
-        return parts != null && parts[BUSINESS_KEY_SEGMENT].equals(businessKey.toString());
+        return parts != null && parts[BUSINESS_KEY_IDENTITY_SEGMENT].equals(businessKeyIdentity);
     }
 
-    /** Like {@link #matchesBusinessKey} with an additional exact sequence-number segment match. */
-    public static boolean matchesBusinessKeyAndSeqNum(
-            String stateKey, Object businessKey, long seqNum) {
+    /** Like {@link #matchesBusinessKeyIdentity} with an exact sequence-number segment match. */
+    public static boolean matchesBusinessKeyIdentityAndSeqNum(
+            String stateKey, String businessKeyIdentity, long seqNum) {
         String[] parts = splitValidatedKey(stateKey);
         return parts != null
-                && parts[BUSINESS_KEY_SEGMENT].equals(businessKey.toString())
+                && parts[BUSINESS_KEY_IDENTITY_SEGMENT].equals(businessKeyIdentity)
                 && parts[SEQ_NUM_SEGMENT].equals(String.valueOf(seqNum));
     }
 
     /**
-     * Like {@link #matchesBusinessKey} with an additional predicate over the parsed sequence-number
-     * segment. Returns {@code false} for keys that cannot be attributed (not the current format or
-     * an unparsable sequence number): never prune what cannot be attributed.
+     * Like {@link #matchesBusinessKeyIdentity} with an additional predicate over the parsed
+     * sequence-number segment. Returns {@code false} for keys that cannot be attributed (not the
+     * current format or an unparsable sequence number): never prune what cannot be attributed.
      */
-    public static boolean matchesBusinessKeyWithSeqNum(
-            String stateKey, Object businessKey, LongPredicate seqNumFilter) {
+    public static boolean matchesBusinessKeyIdentityWithSeqNum(
+            String stateKey, String businessKeyIdentity, LongPredicate seqNumFilter) {
         String[] parts = splitValidatedKey(stateKey);
-        if (parts == null || !parts[BUSINESS_KEY_SEGMENT].equals(businessKey.toString())) {
+        if (parts == null || !parts[BUSINESS_KEY_IDENTITY_SEGMENT].equals(businessKeyIdentity)) {
             return false;
         }
         try {
             return seqNumFilter.test(Long.parseLong(parts[SEQ_NUM_SEGMENT]));
         } catch (NumberFormatException e) {
-            LOG.warn("Failed to parse sequence number from state key: {}", stateKey);
             return false;
         }
     }
 
     /**
      * Returns {@code true} if the composite {@code stateKey}'s key-group is accepted by the given
-     * ownership filter. A {@code null} filter retains every key (the default for in-memory and test
-     * backends).
+     * ownership filter. A {@code null} filter retains every valid key (the default for in-memory
+     * and test backends).
      *
-     * <p>A key that does not have the expected segment count — or whose key-group segment cannot be
-     * parsed — is dropped rather than retained: it cannot be attributed to a key-group, so keeping
-     * it in every subtask would leak orphan state. This is safe because the project does not
-     * preserve pre-format durable state.
+     * <p>Recovery fails for an unsupported format or invalid key field instead of silently reusing
+     * or discarding durable state that cannot be attributed safely.
      */
-    public static boolean isKeyRetained(@Nullable IntPredicate ownershipFilter, String stateKey) {
-        if (ownershipFilter == null) {
-            return true;
-        }
+    static boolean isKeyRetained(
+            @Nullable IntPredicate ownershipFilter,
+            String stateKey,
+            int maxParallelism,
+            String expectedSerializerFingerprint) {
+        Preconditions.checkArgument(maxParallelism > 0, "maxParallelism must be positive.");
+        Preconditions.checkNotNull(
+                expectedSerializerFingerprint, "expectedSerializerFingerprint cannot be null.");
         String[] parts = splitValidatedKey(stateKey);
         if (parts == null) {
-            LOG.warn(
-                    "Dropping state key with unrecognized format during ownership filtering: {}",
-                    stateKey);
-            return false;
+            if (stateKey != null && stateKey.startsWith(KEY_FORMAT_VERSION + ":")) {
+                throw new IllegalStateException(
+                        "Malformed v2 action-state key during recovery: " + stateKey);
+            }
+            throw new IllegalStateException(
+                    "Unsupported action-state key format during recovery. The durable state was "
+                            + "written by an incompatible version; use a new action-state topic or "
+                            + "table when starting without an old checkpoint or savepoint. Key: "
+                            + stateKey);
         }
-        try {
-            return ownershipFilter.test(Integer.parseInt(parts[KEY_GROUP_SEGMENT]));
-        } catch (NumberFormatException e) {
-            LOG.warn(
-                    "Dropping state key with unparsable key-group during ownership filtering: {}",
-                    stateKey,
-                    e);
-            return false;
+        int keyGroup = parseCanonicalKeyGroup(parts[KEY_GROUP_SEGMENT], stateKey);
+        if (keyGroup < 0 || keyGroup >= maxParallelism) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Action-state key-group %s is outside the configured range [0, %s). Key: %s",
+                            keyGroup, maxParallelism, stateKey));
         }
+        validateRecoveryFields(parts, expectedSerializerFingerprint, stateKey);
+        return ownershipFilter == null || ownershipFilter.test(keyGroup);
     }
 
     /**
-     * Returns the business-key segment of {@code stateKey}, or {@code null} when {@code stateKey}
-     * is not in the current format. The returned value preserves separators inside the business
-     * key.
+     * Returns the business-key identity segment of {@code stateKey}, or {@code null} when {@code
+     * stateKey} is not in the current format.
      */
     @Nullable
-    public static String businessKeyOf(String stateKey) {
+    public static String businessKeyIdentityOf(String stateKey) {
         Preconditions.checkNotNull(stateKey, "stateKey cannot be null.");
         String[] parts = splitValidatedKey(stateKey);
-        return parts == null ? null : parts[BUSINESS_KEY_SEGMENT];
+        return parts == null ? null : parts[BUSINESS_KEY_IDENTITY_SEGMENT];
     }
 
     /**
      * Splits and validates a composite state key. Returns its {@link #KEY_SEGMENT_COUNT} segments
      * when {@code key} has the expected segment count, or {@code null} otherwise. The split is
-     * bounded so the trailing business-key segment is returned intact even when it contains {@link
-     * #KEY_SEPARATOR}.
+     * bounded so the trailing business-key identity segment is returned intact.
      */
     @Nullable
     private static String[] splitValidatedKey(String key) {
@@ -210,10 +258,106 @@ public class ActionStateUtil {
             return null;
         }
         String[] parts = key.split(KEY_SEPARATOR, KEY_SEGMENT_COUNT);
-        if (parts.length != KEY_SEGMENT_COUNT) {
+        if (parts.length != KEY_SEGMENT_COUNT
+                || !parts[KEY_GROUP_SEGMENT].startsWith(KEY_GROUP_PREFIX)) {
             return null;
         }
+        parts[KEY_GROUP_SEGMENT] = parts[KEY_GROUP_SEGMENT].substring(KEY_GROUP_PREFIX.length());
         return parts;
+    }
+
+    private static int parseCanonicalKeyGroup(String encodedKeyGroup, String stateKey) {
+        try {
+            int keyGroup = Integer.parseInt(encodedKeyGroup);
+            if (!Integer.toString(keyGroup).equals(encodedKeyGroup)) {
+                throw new NumberFormatException("noncanonical integer");
+            }
+            return keyGroup;
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException(
+                    "Invalid key-group '"
+                            + encodedKeyGroup
+                            + "' in action-state key during recovery: "
+                            + stateKey,
+                    e);
+        }
+    }
+
+    private static void validateRecoveryFields(
+            String[] parts, String expectedSerializerFingerprint, String stateKey) {
+        validateSequenceNumber(parts[SEQ_NUM_SEGMENT], stateKey);
+        validateUuid("event UUID", parts[EVENT_UUID_SEGMENT], stateKey);
+        validateUuid("action UUID", parts[ACTION_UUID_SEGMENT], stateKey);
+        validateDigest(
+                parts[SERIALIZER_FINGERPRINT_SEGMENT],
+                "serializer fingerprint",
+                expectedSerializerFingerprint,
+                stateKey);
+        validateDigest(
+                parts[BUSINESS_KEY_IDENTITY_SEGMENT], "business-key identity", null, stateKey);
+    }
+
+    private static void validateSequenceNumber(String encodedSequenceNumber, String stateKey) {
+        try {
+            long sequenceNumber = Long.parseLong(encodedSequenceNumber);
+            if (sequenceNumber < 0
+                    || !Long.toString(sequenceNumber).equals(encodedSequenceNumber)) {
+                throw new NumberFormatException("negative or noncanonical long");
+            }
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException(
+                    "Invalid sequence number '"
+                            + encodedSequenceNumber
+                            + "' in action-state key during recovery: "
+                            + stateKey,
+                    e);
+        }
+    }
+
+    private static void validateUuid(String fieldName, String encodedUuid, String stateKey) {
+        try {
+            UUID uuid = UUID.fromString(encodedUuid);
+            if (!uuid.toString().equals(encodedUuid)) {
+                throw new IllegalArgumentException("noncanonical UUID");
+            }
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException(
+                    "Invalid "
+                            + fieldName
+                            + " '"
+                            + encodedUuid
+                            + "' in action-state key during recovery: "
+                            + stateKey,
+                    e);
+        }
+    }
+
+    private static void validateDigest(
+            String encodedDigest,
+            String fieldName,
+            @Nullable String expectedDigest,
+            String stateKey) {
+        try {
+            byte[] digest = Base64.getDecoder().decode(encodedDigest);
+            if (digest.length != 32
+                    || !Base64.getEncoder().encodeToString(digest).equals(encodedDigest)) {
+                throw new IllegalArgumentException("not a canonical SHA-256 digest");
+            }
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException(
+                    "Invalid "
+                            + fieldName
+                            + " '"
+                            + encodedDigest
+                            + "' in action-state key during recovery: "
+                            + stateKey,
+                    e);
+        }
+        if (expectedDigest != null && !expectedDigest.equals(encodedDigest)) {
+            throw new IllegalStateException(
+                    "Action-state key serializer fingerprint does not match the operator key serializer. Key: "
+                            + stateKey);
+        }
     }
 
     private static String generateUUIDForEvent(Event event) throws IOException {
@@ -229,4 +373,15 @@ public class ActionStateUtil {
         return String.valueOf(
                 UUID.nameUUIDFromBytes(action.getName().getBytes(StandardCharsets.UTF_8)));
     }
+
+    private static String sha256Base64(byte[] bytes) {
+        try {
+            return Base64.getEncoder()
+                    .encodeToString(MessageDigest.getInstance("SHA-256").digest(bytes));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+
+    private ActionStateUtil() {}
 }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStore.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStore.java
@@ -20,6 +20,7 @@ package org.apache.flink.agents.runtime.actionstate;
 import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.plan.AgentConfiguration;
 import org.apache.flink.agents.plan.actions.Action;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
@@ -63,7 +64,6 @@ import static org.apache.flink.agents.api.configuration.AgentConfigOptions.FLUSS
 import static org.apache.flink.agents.api.configuration.AgentConfigOptions.FLUSS_SASL_PASSWORD;
 import static org.apache.flink.agents.api.configuration.AgentConfigOptions.FLUSS_SASL_USERNAME;
 import static org.apache.flink.agents.api.configuration.AgentConfigOptions.FLUSS_SECURITY_PROTOCOL;
-import static org.apache.flink.agents.runtime.actionstate.ActionStateUtil.generateKey;
 import static org.apache.fluss.config.ConfigOptions.BOOTSTRAP_SERVERS;
 import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_JAAS_CONFIG;
 import static org.apache.fluss.config.ConfigOptions.CLIENT_SASL_JAAS_PASSWORD;
@@ -76,6 +76,7 @@ import static org.apache.fluss.config.ConfigOptions.CLIENT_SECURITY_PROTOCOL;
  * All state is maintained in an in-memory map for fast lookups, with the Fluss log table providing
  * durability and recovery support.
  */
+@Internal
 public class FlussActionStateStore implements ActionStateStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(FlussActionStateStore.class);
@@ -88,6 +89,7 @@ public class FlussActionStateStore implements ActionStateStore {
     // Column names in the Fluss table schema
     private static final String COL_NAME_STATE_KEY = "state_key";
     private static final String COL_NAME_STATE_PAYLOAD = "state_payload";
+    // The historical column name is retained; values are business-key identity digests.
     private static final String COL_NAME_AGENT_KEY = "agent_key";
 
     // Column indices in the Fluss table schema
@@ -110,8 +112,7 @@ public class FlussActionStateStore implements ActionStateStore {
     // in-memory cache during rebuildState; null means retain all keys (default).
     private IntPredicate ownershipFilter;
 
-    // The operator's maximum parallelism, used to compute key-groups consistently with Flink.
-    private final int maxParallelism;
+    private final ActionStateKeyEncoder keyEncoder;
 
     @VisibleForTesting
     FlussActionStateStore(
@@ -119,7 +120,7 @@ public class FlussActionStateStore implements ActionStateStore {
             Connection connection,
             Table table,
             AppendWriter writer,
-            int maxParallelism) {
+            ActionStateKeyEncoder keyEncoder) {
         this.agentConfiguration = null;
         this.databaseName = null;
         this.tableName = null;
@@ -128,16 +129,18 @@ public class FlussActionStateStore implements ActionStateStore {
         this.connection = connection;
         this.table = table;
         this.writer = writer;
-        this.maxParallelism = maxParallelism;
+        this.keyEncoder = Preconditions.checkNotNull(keyEncoder, "keyEncoder cannot be null");
     }
 
-    public FlussActionStateStore(AgentConfiguration agentConfiguration, int maxParallelism) {
-        Preconditions.checkArgument(
-                maxParallelism > 0,
-                "maxParallelism must be positive but was %s; it must be set to the operator's max"
-                        + " parallelism so key-groups match Flink's key-group assignment.",
-                maxParallelism);
-        this.maxParallelism = maxParallelism;
+    /**
+     * Creates a Fluss-backed store using the operator's action-state key encoder.
+     *
+     * @param agentConfiguration the Fluss action-state configuration.
+     * @param keyEncoder the encoder configured from the operator's keyed-state serializer.
+     */
+    public FlussActionStateStore(
+            AgentConfiguration agentConfiguration, ActionStateKeyEncoder keyEncoder) {
+        this.keyEncoder = Preconditions.checkNotNull(keyEncoder, "keyEncoder cannot be null");
         this.agentConfiguration = agentConfiguration;
         this.databaseName = agentConfiguration.get(FLUSS_ACTION_STATE_DATABASE);
         this.tableName =
@@ -209,14 +212,15 @@ public class FlussActionStateStore implements ActionStateStore {
     @Override
     public void put(Object key, long seqNum, Action action, Event event, ActionState state)
             throws Exception {
-        String stateKey = generateKey(key, seqNum, action, event, maxParallelism);
+        String stateKey = keyEncoder.generateKey(key, seqNum, action, event);
+        String businessKeyIdentity = ActionStateUtil.businessKeyIdentityOf(stateKey);
         byte[] payload = ActionStateSerde.serialize(state);
 
         GenericRow row =
                 GenericRow.of(
                         BinaryString.fromString(stateKey),
                         payload,
-                        BinaryString.fromString(key.toString()));
+                        BinaryString.fromString(businessKeyIdentity));
 
         // Synchronous write ensures the record is durable before returning.
         // TODO: Optimize throughput via batching + flush() once Fluss supports it
@@ -231,12 +235,13 @@ public class FlussActionStateStore implements ActionStateStore {
 
     @Override
     public ActionState get(Object key, long seqNum, Action action, Event event) throws Exception {
-        String stateKey = generateKey(key, seqNum, action, event, maxParallelism);
+        String stateKey = keyEncoder.generateKey(key, seqNum, action, event);
+        String businessKeyIdentity = ActionStateUtil.businessKeyIdentityOf(stateKey);
 
-        boolean hasDivergence = checkDivergence(key, seqNum);
+        boolean hasDivergence = checkDivergence(businessKeyIdentity, seqNum);
 
         if (!actionStates.containsKey(stateKey) || hasDivergence) {
-            removeStateEntries(key, stateSeqNum -> stateSeqNum > seqNum);
+            removeStateEntries(businessKeyIdentity, stateSeqNum -> stateSeqNum > seqNum);
         }
 
         ActionState state = actionStates.get(stateKey);
@@ -244,24 +249,27 @@ public class FlussActionStateStore implements ActionStateStore {
         return state;
     }
 
-    private boolean checkDivergence(Object key, long seqNum) {
+    private boolean checkDivergence(String businessKeyIdentity, long seqNum) {
         return actionStates.keySet().stream()
-                        .filter(k -> ActionStateUtil.matchesBusinessKeyAndSeqNum(k, key, seqNum))
+                        .filter(
+                                k ->
+                                        ActionStateUtil.matchesBusinessKeyIdentityAndSeqNum(
+                                                k, businessKeyIdentity, seqNum))
                         .count()
                 > 1;
     }
 
     /**
-     * Removes cached state entries whose business-key segment equals {@code key} and whose parsed
-     * sequence number satisfies {@code seqNumFilter}.
+     * Removes cached state entries whose business-key identity equals {@code businessKeyIdentity}
+     * and whose parsed sequence number satisfies {@code seqNumFilter}.
      */
-    private void removeStateEntries(Object key, LongPredicate seqNumFilter) {
+    private void removeStateEntries(String businessKeyIdentity, LongPredicate seqNumFilter) {
         actionStates
                 .keySet()
                 .removeIf(
                         cachedKey ->
-                                ActionStateUtil.matchesBusinessKeyWithSeqNum(
-                                        cachedKey, key, seqNumFilter));
+                                ActionStateUtil.matchesBusinessKeyIdentityWithSeqNum(
+                                        cachedKey, businessKeyIdentity, seqNumFilter));
     }
 
     /**
@@ -444,7 +452,7 @@ public class FlussActionStateStore implements ActionStateStore {
             }
             InternalRow row = record.getRow();
             String stateKey = row.getString(COL_STATE_KEY).toString();
-            if (!ActionStateUtil.isKeyRetained(ownershipFilter, stateKey)) {
+            if (!keyEncoder.isKeyRetained(ownershipFilter, stateKey)) {
                 continue;
             }
             byte[] payload = row.getBytes(COL_STATE_PAYLOAD);
@@ -497,7 +505,8 @@ public class FlussActionStateStore implements ActionStateStore {
     @Override
     public void pruneState(Object key, long seqNum) {
         LOG.debug("Pruning in-memory state for key: {} up to seqNum: {}", key, seqNum);
-        removeStateEntries(key, stateSeqNum -> stateSeqNum <= seqNum);
+        removeStateEntries(
+                keyEncoder.generateBusinessKeyIdentity(key), stateSeqNum -> stateSeqNum <= seqNum);
     }
 
     @Override

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStore.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStore.java
@@ -20,6 +20,7 @@ package org.apache.flink.agents.runtime.actionstate;
 import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.plan.AgentConfiguration;
 import org.apache.flink.agents.plan.actions.Action;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
@@ -56,7 +57,6 @@ import static org.apache.flink.agents.api.configuration.AgentConfigOptions.KAFKA
 import static org.apache.flink.agents.api.configuration.AgentConfigOptions.KAFKA_ACTION_STATE_TOPIC_NUM_PARTITIONS;
 import static org.apache.flink.agents.api.configuration.AgentConfigOptions.KAFKA_ACTION_STATE_TOPIC_REPLICATION_FACTOR;
 import static org.apache.flink.agents.api.configuration.AgentConfigOptions.KAFKA_BOOTSTRAP_SERVERS;
-import static org.apache.flink.agents.runtime.actionstate.ActionStateUtil.generateKey;
 import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.CLIENT_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
@@ -70,6 +70,7 @@ import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_
  * This class provides methods to put, get, and retrieve all action states associated with a given
  * key and action.
  */
+@Internal
 public class KafkaActionStateStore implements ActionStateStore {
 
     private static final Duration CONSUMER_POLL_TIMEOUT = Duration.ofMillis(1000);
@@ -96,8 +97,7 @@ public class KafkaActionStateStore implements ActionStateStore {
     // in-memory cache during rebuildState; null means retain all keys (default).
     private IntPredicate ownershipFilter;
 
-    // The operator's maximum parallelism, used to compute key-groups consistently with Flink.
-    private final int maxParallelism;
+    private final ActionStateKeyEncoder keyEncoder;
 
     @VisibleForTesting
     KafkaActionStateStore(
@@ -106,24 +106,25 @@ public class KafkaActionStateStore implements ActionStateStore {
             Producer<String, ActionState> producer,
             Consumer<String, ActionState> consumer,
             String topic,
-            int maxParallelism) {
+            ActionStateKeyEncoder keyEncoder) {
         this.actionStates = actionStates;
         this.producer = producer;
         this.consumer = consumer;
         this.topic = topic;
         this.latestKeySeqNum = new HashMap<>();
         this.agentConfiguration = agentConfiguration;
-        this.maxParallelism = maxParallelism;
+        this.keyEncoder = Preconditions.checkNotNull(keyEncoder, "keyEncoder cannot be null");
     }
 
-    /** Constructs a new KafkaActionStateStore with custom Kafka configuration. */
-    public KafkaActionStateStore(AgentConfiguration agentConfiguration, int maxParallelism) {
-        Preconditions.checkArgument(
-                maxParallelism > 0,
-                "maxParallelism must be positive but was %s; it must be set to the operator's max"
-                        + " parallelism so key-groups match Flink's key-group assignment.",
-                maxParallelism);
-        this.maxParallelism = maxParallelism;
+    /**
+     * Creates a Kafka-backed store using the operator's action-state key encoder.
+     *
+     * @param agentConfiguration the Kafka action-state configuration.
+     * @param keyEncoder the encoder configured from the operator's keyed-state serializer.
+     */
+    public KafkaActionStateStore(
+            AgentConfiguration agentConfiguration, ActionStateKeyEncoder keyEncoder) {
+        this.keyEncoder = Preconditions.checkNotNull(keyEncoder, "keyEncoder cannot be null");
         this.actionStates = new HashMap<>();
         this.latestKeySeqNum = new HashMap<>();
         this.agentConfiguration = agentConfiguration;
@@ -148,7 +149,7 @@ public class KafkaActionStateStore implements ActionStateStore {
             return;
         }
 
-        String stateKey = generateKey(key, seqNum, action, event, maxParallelism);
+        String stateKey = keyEncoder.generateKey(key, seqNum, action, event);
         try {
             ProducerRecord<String, ActionState> kafkaRecord =
                     new ProducerRecord<>(topic, stateKey, state);
@@ -166,7 +167,8 @@ public class KafkaActionStateStore implements ActionStateStore {
 
     @Override
     public ActionState get(Object key, long seqNum, Action action, Event event) throws Exception {
-        String stateKey = generateKey(key, seqNum, action, event, maxParallelism);
+        String stateKey = keyEncoder.generateKey(key, seqNum, action, event);
+        String businessKeyIdentity = ActionStateUtil.businessKeyIdentityOf(stateKey);
 
         LOG.debug(
                 "Looking up action state: key={}, seqNum={}, stateKey={}, cachedStates={}",
@@ -175,7 +177,7 @@ public class KafkaActionStateStore implements ActionStateStore {
                 stateKey,
                 actionStates.keySet());
 
-        boolean hasDivergence = checkDivergence(key, seqNum);
+        boolean hasDivergence = checkDivergence(businessKeyIdentity, seqNum);
 
         if (!actionStates.containsKey(stateKey) || hasDivergence) {
             // Clean up this key's states with sequence number greater than the requested seqNum.
@@ -183,8 +185,10 @@ public class KafkaActionStateStore implements ActionStateStore {
                     .keySet()
                     .removeIf(
                             cachedKey ->
-                                    ActionStateUtil.matchesBusinessKeyWithSeqNum(
-                                            cachedKey, key, stateSeqNum -> stateSeqNum > seqNum));
+                                    ActionStateUtil.matchesBusinessKeyIdentityWithSeqNum(
+                                            cachedKey,
+                                            businessKeyIdentity,
+                                            stateSeqNum -> stateSeqNum > seqNum));
         }
 
         ActionState result = actionStates.get(stateKey);
@@ -197,9 +201,12 @@ public class KafkaActionStateStore implements ActionStateStore {
         return result;
     }
 
-    private boolean checkDivergence(Object key, long seqNum) {
+    private boolean checkDivergence(String businessKeyIdentity, long seqNum) {
         return actionStates.keySet().stream()
-                        .filter(k -> ActionStateUtil.matchesBusinessKeyAndSeqNum(k, key, seqNum))
+                        .filter(
+                                k ->
+                                        ActionStateUtil.matchesBusinessKeyIdentityAndSeqNum(
+                                                k, businessKeyIdentity, seqNum))
                         .count()
                 > 1;
     }
@@ -257,17 +264,10 @@ public class KafkaActionStateStore implements ActionStateStore {
                 }
 
                 for (ConsumerRecord<String, ActionState> record : records) {
-                    try {
-                        if (!ActionStateUtil.isKeyRetained(ownershipFilter, record.key())) {
-                            continue;
-                        }
-                        actionStates.put(record.key(), record.value());
-                    } catch (Exception e) {
-                        LOG.warn(
-                                "Failed to deserialize action state record: {}",
-                                record.value().toString(),
-                                e);
+                    if (!keyEncoder.isKeyRetained(ownershipFilter, record.key())) {
+                        continue;
                     }
+                    actionStates.put(record.key(), record.value());
                 }
 
                 // Commit offsets manually
@@ -287,6 +287,7 @@ public class KafkaActionStateStore implements ActionStateStore {
     @Override
     public void pruneState(Object key, long seqNum) {
         LOG.debug("Pruning state for key: {} up to sequence number: {}", key, seqNum);
+        String businessKeyIdentity = keyEncoder.generateBusinessKeyIdentity(key);
 
         // Remove states from in-memory cache for this key up to the specified sequence
         // number
@@ -294,8 +295,10 @@ public class KafkaActionStateStore implements ActionStateStore {
                 .keySet()
                 .removeIf(
                         cachedKey ->
-                                ActionStateUtil.matchesBusinessKeyWithSeqNum(
-                                        cachedKey, key, stateSeqNum -> stateSeqNum <= seqNum));
+                                ActionStateUtil.matchesBusinessKeyIdentityWithSeqNum(
+                                        cachedKey,
+                                        businessKeyIdentity,
+                                        stateSeqNum -> stateSeqNum <= seqNum));
 
         LOG.debug("Pruned state for key: {} up to sequence number: {}", key, seqNum);
     }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -44,6 +44,7 @@ import org.apache.flink.agents.runtime.trace.ExecutionEventLogger;
 import org.apache.flink.agents.runtime.utils.EventUtil;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
@@ -195,7 +196,8 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         eventRouter.open(builtInMetrics);
 
         int maxParallelism = getRuntimeContext().getTaskInfo().getMaxNumberOfParallelSubtasks();
-        durableExecManager.maybeInitActionStateStore(agentPlan.getConfig(), maxParallelism);
+        durableExecManager.maybeInitActionStateStore(
+                agentPlan.getConfig(), maxParallelism, getActionStateKeySerializer());
         durableExecManager.initRecoveryMarkerState(getOperatorStateBackend());
         durableExecManager.initializeKeyedStates(getRuntimeContext());
 
@@ -630,7 +632,8 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         super.initializeState(context);
 
         int maxParallelism = getRuntimeContext().getTaskInfo().getMaxNumberOfParallelSubtasks();
-        durableExecManager.maybeInitActionStateStore(agentPlan.getConfig(), maxParallelism);
+        durableExecManager.maybeInitActionStateStore(
+                agentPlan.getConfig(), maxParallelism, getActionStateKeySerializer());
 
         stateManager = new OperatorStateManager();
 
@@ -662,6 +665,10 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
                     StateUtils.getSingleValueFromState(
                             context, "identifier_state", String.class, initialJobIdentifier);
         }
+    }
+
+    private TypeSerializer<?> getActionStateKeySerializer() {
+        return getKeyedStateBackend().getKeySerializer();
     }
 
     @Override

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/DurableExecutionManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/DurableExecutionManager.java
@@ -22,6 +22,7 @@ import org.apache.flink.agents.api.context.MemoryUpdate;
 import org.apache.flink.agents.plan.AgentConfiguration;
 import org.apache.flink.agents.plan.actions.Action;
 import org.apache.flink.agents.runtime.actionstate.ActionState;
+import org.apache.flink.agents.runtime.actionstate.ActionStateKeyEncoder;
 import org.apache.flink.agents.runtime.actionstate.ActionStateStore;
 import org.apache.flink.agents.runtime.actionstate.FlussActionStateStore;
 import org.apache.flink.agents.runtime.actionstate.KafkaActionStateStore;
@@ -34,6 +35,7 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.VoidNamespace;
@@ -64,14 +66,15 @@ import static org.apache.flink.agents.runtime.actionstate.ActionStateStore.Backe
  * durable execution is enabled.
  *
  * <p>Lifecycle: instantiated in the operator constructor. {@link
- * #maybeInitActionStateStore(AgentConfiguration, int)} runs from BOTH the operator's {@code
- * initializeState()} and {@code open()} — recovery requires the store to be configured before
- * {@link #handleRecovery(OperatorStateBackend, IntPredicate)} reads from it, and the {@code open()}
- * call ensures the store is also available on the normal (non-recovery) path. The method creates a
- * default Kafka-backed store when one was not pre-injected, and is idempotent on the second call.
- * {@link #handleRecovery(OperatorStateBackend, IntPredicate)} runs from the operator's {@code
- * initializeState()} during recovery. {@link #initRecoveryMarkerState(OperatorStateBackend)} runs
- * from the operator's {@code open()}. {@link #close()} closes the underlying store.
+ * #maybeInitActionStateStore(AgentConfiguration, int, TypeSerializer)} runs from BOTH the
+ * operator's {@code initializeState()} and {@code open()} — recovery requires the store to be
+ * configured before {@link #handleRecovery(OperatorStateBackend, IntPredicate)} reads from it, and
+ * the {@code open()} call ensures the store is also available on the normal (non-recovery) path.
+ * The method creates a default Kafka-backed store when one was not pre-injected, and is idempotent
+ * on the second call. {@link #handleRecovery(OperatorStateBackend, IntPredicate)} runs from the
+ * operator's {@code initializeState()} during recovery. {@link
+ * #initRecoveryMarkerState(OperatorStateBackend)} runs from the operator's {@code open()}. {@link
+ * #close()} closes the underlying store.
  *
  * <p>Design constraint: package-private; no manager-to-manager held references. Cross-cutting data
  * flows via method parameters. In particular, {@link
@@ -96,8 +99,8 @@ class DurableExecutionManager implements ActionStatePersister, AutoCloseable {
 
     /**
      * @param actionStateStore an optional pre-injected store, primarily for tests. When {@code
-     *     null}, {@link #maybeInitActionStateStore(AgentConfiguration, int)} may create a default
-     *     store based on configuration; otherwise durable execution is disabled.
+     *     null}, {@link #maybeInitActionStateStore(AgentConfiguration, int, TypeSerializer)} may
+     *     create a default store based on configuration; otherwise durable execution is disabled.
      */
     DurableExecutionManager(@Nullable ActionStateStore actionStateStore) {
         this.actionStateStore = actionStateStore;
@@ -110,20 +113,27 @@ class DurableExecutionManager implements ActionStatePersister, AutoCloseable {
      * pre-injected.
      *
      * <p>Only creates a store when this manager was constructed without one and the configuration
-     * selects a recognized backend (currently Kafka). Otherwise this is a no-op, which leaves
-     * durable execution disabled.
+     * selects a recognized backend. Otherwise this is a no-op, which leaves durable execution
+     * disabled.
      *
      * @param config the agent configuration carrying the backend selection.
+     * @param maxParallelism the operator maximum parallelism used for key-group assignment.
+     * @param keySerializer the operator serializer that defines durable business-key identity.
      */
-    void maybeInitActionStateStore(AgentConfiguration config, int maxParallelism) {
+    void maybeInitActionStateStore(
+            AgentConfiguration config, int maxParallelism, TypeSerializer<?> keySerializer) {
         if (actionStateStore == null) {
             String backend = config.get(ACTION_STATE_STORE_BACKEND);
             if (KAFKA.getType().equalsIgnoreCase(backend)) {
                 LOG.info("Using Kafka as backend of action state store.");
-                actionStateStore = new KafkaActionStateStore(config, maxParallelism);
+                actionStateStore =
+                        new KafkaActionStateStore(
+                                config, new ActionStateKeyEncoder(maxParallelism, keySerializer));
             } else if (FLUSS.getType().equalsIgnoreCase(backend)) {
                 LOG.info("Using Fluss as backend of action state store.");
-                actionStateStore = new FlussActionStateStore(config, maxParallelism);
+                actionStateStore =
+                        new FlussActionStateStore(
+                                config, new ActionStateKeyEncoder(maxParallelism, keySerializer));
             }
         }
     }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateKeyEncoderTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateKeyEncoderTest.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.actionstate;
+
+import org.apache.flink.agents.api.InputEvent;
+import org.apache.flink.api.common.serialization.SerializerConfigImpl;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link ActionStateKeyEncoder}. */
+class ActionStateKeyEncoderTest {
+
+    private static final int MAX_PARALLELISM = 128;
+
+    @Test
+    void serializerFingerprintIsStableAcrossEquivalentInstances() {
+        ActionStateKeyEncoder first =
+                new ActionStateKeyEncoder(MAX_PARALLELISM, new TestKeySerializer(1));
+        ActionStateKeyEncoder second =
+                new ActionStateKeyEncoder(MAX_PARALLELISM, new TestKeySerializer(1));
+
+        assertThat(first.getSerializerFingerprint()).isEqualTo(second.getSerializerFingerprint());
+    }
+
+    @Test
+    void fingerprintIsStableAcrossIndependentLongSerializers() throws Exception {
+        ActionStateKeyEncoder first =
+                new ActionStateKeyEncoder(
+                        MAX_PARALLELISM,
+                        TypeInformation.of(Long.class)
+                                .createSerializer(new SerializerConfigImpl()));
+        ActionStateKeyEncoder restored =
+                new ActionStateKeyEncoder(
+                        MAX_PARALLELISM,
+                        TypeInformation.of(Long.class)
+                                .createSerializer(new SerializerConfigImpl()));
+
+        assertThat(restored.getSerializerFingerprint()).isEqualTo(first.getSerializerFingerprint());
+        assertThat(
+                        restored.isKeyRetained(
+                                keyGroup -> true,
+                                first.generateKey(
+                                        1L, 1L, new NoOpAction("action"), new InputEvent("input"))))
+                .isTrue();
+    }
+
+    @Test
+    void fingerprintIsStableAcrossIndependentGenericSerializers() throws Exception {
+        ActionStateKeyEncoder first =
+                new ActionStateKeyEncoder(
+                        MAX_PARALLELISM,
+                        TypeInformation.of(Object.class)
+                                .createSerializer(new SerializerConfigImpl()));
+        ActionStateKeyEncoder restored =
+                new ActionStateKeyEncoder(
+                        MAX_PARALLELISM,
+                        TypeInformation.of(Object.class)
+                                .createSerializer(new SerializerConfigImpl()));
+
+        assertThat(restored.getSerializerFingerprint()).isEqualTo(first.getSerializerFingerprint());
+        assertThat(
+                        restored.isKeyRetained(
+                                keyGroup -> true,
+                                first.generateKey(
+                                        "key",
+                                        1L,
+                                        new NoOpAction("action"),
+                                        new InputEvent("input"))))
+                .isTrue();
+    }
+
+    @Test
+    void recoveryRejectsSerializerThatRequiresMigration() throws Exception {
+        TestKeySerializer previousSerializer = new TestKeySerializer(1);
+        TestKeySerializer changedSerializer = new TestKeySerializer(2);
+        assertThat(
+                        changedSerializer
+                                .snapshotConfiguration()
+                                .resolveSchemaCompatibility(
+                                        previousSerializer.snapshotConfiguration())
+                                .isCompatibleAfterMigration())
+                .isTrue();
+
+        ActionStateKeyEncoder writer =
+                new ActionStateKeyEncoder(MAX_PARALLELISM, previousSerializer);
+        String stateKey =
+                writer.generateKey("key", 1L, new NoOpAction("action"), new InputEvent("input"));
+        ActionStateKeyEncoder restored =
+                new ActionStateKeyEncoder(MAX_PARALLELISM, changedSerializer);
+
+        assertThatThrownBy(() -> restored.isKeyRetained(keyGroup -> true, stateKey))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("serializer fingerprint");
+    }
+
+    private static final class TestKeySerializer extends TypeSerializer<Object> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final int encodingVersion;
+
+        private TestKeySerializer(int encodingVersion) {
+            this.encodingVersion = encodingVersion;
+        }
+
+        @Override
+        public boolean isImmutableType() {
+            return true;
+        }
+
+        @Override
+        public TypeSerializer<Object> duplicate() {
+            return new TestKeySerializer(encodingVersion);
+        }
+
+        @Override
+        public Object createInstance() {
+            return "";
+        }
+
+        @Override
+        public Object copy(Object from) {
+            return from;
+        }
+
+        @Override
+        public Object copy(Object from, Object reuse) {
+            return from;
+        }
+
+        @Override
+        public int getLength() {
+            return -1;
+        }
+
+        @Override
+        public void serialize(Object record, DataOutputView target) throws IOException {
+            target.writeInt(encodingVersion);
+            target.writeUTF(record.toString());
+        }
+
+        @Override
+        public Object deserialize(DataInputView source) throws IOException {
+            source.readInt();
+            return source.readUTF();
+        }
+
+        @Override
+        public Object deserialize(Object reuse, DataInputView source) throws IOException {
+            return deserialize(source);
+        }
+
+        @Override
+        public void copy(DataInputView source, DataOutputView target) throws IOException {
+            target.writeInt(source.readInt());
+            target.writeUTF(source.readUTF());
+        }
+
+        @Override
+        public TypeSerializerSnapshot<Object> snapshotConfiguration() {
+            return new TestKeySerializerSnapshot(encodingVersion);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof TestKeySerializer
+                    && encodingVersion == ((TestKeySerializer) other).encodingVersion;
+        }
+
+        @Override
+        public int hashCode() {
+            return encodingVersion;
+        }
+    }
+
+    public static final class TestKeySerializerSnapshot implements TypeSerializerSnapshot<Object> {
+
+        private int encodingVersion;
+
+        public TestKeySerializerSnapshot() {}
+
+        private TestKeySerializerSnapshot(int encodingVersion) {
+            this.encodingVersion = encodingVersion;
+        }
+
+        @Override
+        public int getCurrentVersion() {
+            return 1;
+        }
+
+        @Override
+        public void writeSnapshot(DataOutputView out) throws IOException {
+            out.writeInt(encodingVersion);
+        }
+
+        @Override
+        public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader)
+                throws IOException {
+            encodingVersion = in.readInt();
+        }
+
+        @Override
+        public TypeSerializer<Object> restoreSerializer() {
+            return new TestKeySerializer(encodingVersion);
+        }
+
+        @Override
+        public TypeSerializerSchemaCompatibility<Object> resolveSchemaCompatibility(
+                TypeSerializerSnapshot<Object> oldSerializerSnapshot) {
+            if (!(oldSerializerSnapshot instanceof TestKeySerializerSnapshot)) {
+                return TypeSerializerSchemaCompatibility.incompatible();
+            }
+            TestKeySerializerSnapshot previous = (TestKeySerializerSnapshot) oldSerializerSnapshot;
+            return encodingVersion == previous.encodingVersion
+                    ? TypeSerializerSchemaCompatibility.compatibleAsIs()
+                    : TypeSerializerSchemaCompatibility.compatibleAfterMigration();
+        }
+    }
+}

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateKeyEncoderTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateKeyEncoderTest.java
@@ -118,14 +118,45 @@ class ActionStateKeyEncoderTest {
                 .hasMessageContaining("serializer fingerprint");
     }
 
+    @Test
+    void businessKeySerializationFailureIsReported() {
+        ActionStateKeyEncoder encoder =
+                new ActionStateKeyEncoder(MAX_PARALLELISM, new TestKeySerializer(1, true, false));
+
+        assertThatThrownBy(() -> encoder.generateBusinessKeyIdentity("key"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to serialize the Flink key")
+                .hasCauseInstanceOf(IOException.class);
+    }
+
+    @Test
+    void serializerSnapshotFailureIsReported() {
+        assertThatThrownBy(
+                        () ->
+                                new ActionStateKeyEncoder(
+                                        MAX_PARALLELISM, new TestKeySerializer(1, false, true)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to fingerprint the Flink key serializer")
+                .hasCauseInstanceOf(IOException.class);
+    }
+
     private static final class TestKeySerializer extends TypeSerializer<Object> {
 
         private static final long serialVersionUID = 1L;
 
         private final int encodingVersion;
+        private final boolean failSerialization;
+        private final boolean failSnapshot;
 
         private TestKeySerializer(int encodingVersion) {
+            this(encodingVersion, false, false);
+        }
+
+        private TestKeySerializer(
+                int encodingVersion, boolean failSerialization, boolean failSnapshot) {
             this.encodingVersion = encodingVersion;
+            this.failSerialization = failSerialization;
+            this.failSnapshot = failSnapshot;
         }
 
         @Override
@@ -135,7 +166,7 @@ class ActionStateKeyEncoderTest {
 
         @Override
         public TypeSerializer<Object> duplicate() {
-            return new TestKeySerializer(encodingVersion);
+            return new TestKeySerializer(encodingVersion, failSerialization, failSnapshot);
         }
 
         @Override
@@ -160,6 +191,9 @@ class ActionStateKeyEncoderTest {
 
         @Override
         public void serialize(Object record, DataOutputView target) throws IOException {
+            if (failSerialization) {
+                throw new IOException("key serialization failed");
+            }
             target.writeInt(encodingVersion);
             target.writeUTF(record.toString());
         }
@@ -183,7 +217,7 @@ class ActionStateKeyEncoderTest {
 
         @Override
         public TypeSerializerSnapshot<Object> snapshotConfiguration() {
-            return new TestKeySerializerSnapshot(encodingVersion);
+            return new TestKeySerializerSnapshot(encodingVersion, failSnapshot);
         }
 
         @Override
@@ -201,11 +235,17 @@ class ActionStateKeyEncoderTest {
     public static final class TestKeySerializerSnapshot implements TypeSerializerSnapshot<Object> {
 
         private int encodingVersion;
+        private boolean failWrite;
 
         public TestKeySerializerSnapshot() {}
 
         private TestKeySerializerSnapshot(int encodingVersion) {
+            this(encodingVersion, false);
+        }
+
+        private TestKeySerializerSnapshot(int encodingVersion, boolean failWrite) {
             this.encodingVersion = encodingVersion;
+            this.failWrite = failWrite;
         }
 
         @Override
@@ -215,6 +255,9 @@ class ActionStateKeyEncoderTest {
 
         @Override
         public void writeSnapshot(DataOutputView out) throws IOException {
+            if (failWrite) {
+                throw new IOException("serializer snapshot failed");
+            }
             out.writeInt(encodingVersion);
         }
 

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateKeyPartitionerTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateKeyPartitionerTest.java
@@ -63,9 +63,9 @@ public class ActionStateKeyPartitionerTest {
 
     @Test
     void testValidKeyPartitioning() {
-        String key1 = "0_1_event1_action1_bk1";
-        String key2 = "5_1_event2_action2_bk2";
-        String key3 = "9_1_event3_action3_bk3";
+        String key1 = "v2:0_1_event1_action1_serializer_bk1";
+        String key2 = "v2:5_1_event2_action2_serializer_bk2";
+        String key3 = "v2:9_1_event3_action3_serializer_bk3";
 
         int partition1 =
                 partitioner.partition(TEST_TOPIC, key1, key1.getBytes(), null, null, cluster);
@@ -83,9 +83,9 @@ public class ActionStateKeyPartitionerTest {
     @Test
     void testSameBusinessKeyConsistentPartitioning() {
         // Keys sharing the same business key (trailing segment) go to the same partition
-        String key1 = "5_1_event1_action1_123";
-        String key2 = "5_2_event2_action2_123";
-        String key3 = "5_3_event3_action3_123";
+        String key1 = "v2:5_1_event1_action1_serializer_123";
+        String key2 = "v2:5_2_event2_action2_serializer_123";
+        String key3 = "v2:5_3_event3_action3_serializer_123";
 
         int partition1 =
                 partitioner.partition(TEST_TOPIC, key1, key1.getBytes(), null, null, cluster);
@@ -126,6 +126,7 @@ public class ActionStateKeyPartitionerTest {
         // Keys that lack the expected segment count are rejected.
         String invalidKey1 = "onlyonepart";
         String invalidKey2 = "only_twoparts";
+        String legacyKey = "5_1_event_action_business-key";
 
         IllegalArgumentException exception1 =
                 assertThrows(
@@ -152,25 +153,36 @@ public class ActionStateKeyPartitionerTest {
                                         null,
                                         cluster));
         assertEquals("Key format is invalid", exception2.getMessage());
+
+        IllegalArgumentException legacyException =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                partitioner.partition(
+                                        TEST_TOPIC,
+                                        legacyKey,
+                                        legacyKey.getBytes(),
+                                        null,
+                                        null,
+                                        cluster));
+        assertEquals("Key format is invalid", legacyException.getMessage());
     }
 
     @Test
-    void testEmptyBusinessKeyPartThrowException() {
-        String invalidKey = "5_1_event_action_";
+    void testEmptyBusinessKeyIdentityThrowsException() {
+        String invalidKey = "v2:5_1_event_action_serializer_";
         IllegalArgumentException exception =
                 assertThrows(
                         IllegalArgumentException.class,
                         () ->
                                 partitioner.partition(
                                         TEST_TOPIC, invalidKey, null, null, null, cluster));
-        assertEquals("Business key part of the key cannot be empty", exception.getMessage());
+        assertEquals("Business key identity cannot be empty", exception.getMessage());
     }
 
     @Test
-    void testBusinessKeyContainingSeparatorIsValid() {
-        // The business key occupies the trailing segment, so it may contain the separator
-        // (e.g. "tenant_user") without breaking partitioning.
-        String key = "0_1_event_action_tenant_user";
+    void testEncodedIdentityIsValid() {
+        String key = "v2:0_1_event_action_serializer_dGVuYW50X3VzZXI=";
 
         int partition = partitioner.partition(TEST_TOPIC, key, key.getBytes(), null, null, cluster);
 
@@ -179,12 +191,12 @@ public class ActionStateKeyPartitionerTest {
 
     @Test
     void testPartitionDistribution() {
-        // Test that different first key parts go to potentially different partitions
+        // Test that different trailing business-key identities are distributed across partitions.
         Map<Integer, Integer> partitionCounts = new HashMap<>();
 
         // Generate keys with different business keys (trailing segment)
         for (int i = 0; i < 100; i++) {
-            String key = "0_1_event_action_" + i;
+            String key = "v2:0_1_event_action_serializer_" + i;
             int partition =
                     partitioner.partition(TEST_TOPIC, key, key.getBytes(), null, null, cluster);
 
@@ -220,7 +232,7 @@ public class ActionStateKeyPartitionerTest {
                         java.util.Collections.emptySet(),
                         java.util.Collections.emptySet());
 
-        String key = "5_1_event1_action1_123";
+        String key = "v2:5_1_event1_action1_serializer_123";
         int partition =
                 partitioner.partition(
                         TEST_TOPIC, key, key.getBytes(), null, null, singlePartitionCluster);
@@ -231,7 +243,7 @@ public class ActionStateKeyPartitionerTest {
     @Test
     void testHashConsistency() {
         // Same key should always produce the same partition
-        String key = "5_1_event1_action1_123";
+        String key = "v2:5_1_event1_action1_serializer_123";
 
         int partition1 =
                 partitioner.partition(TEST_TOPIC, key, key.getBytes(), null, null, cluster);

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateTestUtils.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateTestUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.actionstate;
+
+import org.apache.flink.agents.api.Event;
+import org.apache.flink.agents.plan.actions.Action;
+import org.apache.flink.api.common.serialization.SerializerConfigImpl;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import java.io.IOException;
+
+/** Shared typed-key serializer and key-generation helper for action-state tests. */
+final class ActionStateTestUtils {
+
+    static final TypeSerializer<Object> KEY_SERIALIZER = createKeySerializer();
+
+    private ActionStateTestUtils() {}
+
+    static TypeSerializer<Object> createKeySerializer() {
+        return TypeInformation.of(Object.class).createSerializer(new SerializerConfigImpl());
+    }
+
+    static ActionStateKeyEncoder createKeyEncoder(int maxParallelism) {
+        return new ActionStateKeyEncoder(maxParallelism, KEY_SERIALIZER);
+    }
+
+    static String generateKey(
+            Object key, long seqNum, Action action, Event event, int maxParallelism)
+            throws IOException {
+        return createKeyEncoder(maxParallelism).generateKey(key, seqNum, action, event);
+    }
+}

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateUtilTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateUtilTest.java
@@ -22,9 +22,15 @@ import org.apache.flink.agents.plan.actions.Action;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
+import static org.apache.flink.agents.runtime.actionstate.ActionStateTestUtils.KEY_SERIALIZER;
+import static org.apache.flink.agents.runtime.actionstate.ActionStateTestUtils.createKeyEncoder;
+import static org.apache.flink.agents.runtime.actionstate.ActionStateTestUtils.createKeySerializer;
+import static org.apache.flink.agents.runtime.actionstate.ActionStateTestUtils.generateKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -45,11 +51,39 @@ public class ActionStateUtilTest {
         InputEvent inputEvent2 = new InputEvent("same-input");
 
         // Generate keys multiple times
-        String key1 = ActionStateUtil.generateKey(key, 1, action, inputEvent, MAX_PARALLELISM);
-        String key2 = ActionStateUtil.generateKey(key, 1, action, inputEvent2, MAX_PARALLELISM);
+        String key1 = generateKey(key, 1, action, inputEvent, MAX_PARALLELISM);
+        String key2 = generateKey(key, 1, action, inputEvent2, MAX_PARALLELISM);
 
         // Keys should be the same for the same input
         assertEquals(key1, key2);
+    }
+
+    @Test
+    public void testBusinessKeyIdentityIsStableAcrossSerializerInstances() {
+        String first =
+                ActionStateUtil.generateBusinessKeyIdentity(
+                        new SameStringKey(7), createKeySerializer());
+        String afterRecovery =
+                ActionStateUtil.generateBusinessKeyIdentity(
+                        new SameStringKey(7), createKeySerializer());
+
+        assertEquals(first, afterRecovery);
+        assertEquals(44, first.length());
+    }
+
+    @Test
+    public void testBusinessKeyIdentityDoesNotDependOnPriorSerializedKeyTypes() {
+        var firstSerializer = createKeySerializer();
+        var secondSerializer = createKeySerializer();
+        ActionStateUtil.generateBusinessKeyIdentity("priming-string", firstSerializer);
+        ActionStateUtil.generateBusinessKeyIdentity(42L, secondSerializer);
+
+        String first =
+                ActionStateUtil.generateBusinessKeyIdentity(new SameStringKey(7), firstSerializer);
+        String second =
+                ActionStateUtil.generateBusinessKeyIdentity(new SameStringKey(7), secondSerializer);
+
+        assertEquals(first, second);
     }
 
     @Test
@@ -61,8 +95,8 @@ public class ActionStateUtilTest {
         InputEvent inputEvent2 = new InputEvent("input2");
 
         // Generate keys
-        String key1 = ActionStateUtil.generateKey(key, 1, action, inputEvent1, MAX_PARALLELISM);
-        String key2 = ActionStateUtil.generateKey(key, 1, action, inputEvent2, MAX_PARALLELISM);
+        String key1 = generateKey(key, 1, action, inputEvent1, MAX_PARALLELISM);
+        String key2 = generateKey(key, 1, action, inputEvent2, MAX_PARALLELISM);
 
         // Keys should be different for different inputs
         assertNotEquals(key1, key2);
@@ -76,7 +110,7 @@ public class ActionStateUtilTest {
         assertThrows(
                 NullPointerException.class,
                 () -> {
-                    ActionStateUtil.generateKey(null, 1, action, inputEvent, MAX_PARALLELISM);
+                    generateKey(null, 1, action, inputEvent, MAX_PARALLELISM);
                 });
     }
 
@@ -88,7 +122,7 @@ public class ActionStateUtilTest {
         assertThrows(
                 NullPointerException.class,
                 () -> {
-                    ActionStateUtil.generateKey(key, 1, null, inputEvent, MAX_PARALLELISM);
+                    generateKey(key, 1, null, inputEvent, MAX_PARALLELISM);
                 });
     }
 
@@ -100,7 +134,7 @@ public class ActionStateUtilTest {
         assertThrows(
                 NullPointerException.class,
                 () -> {
-                    ActionStateUtil.generateKey(key, 1, action, null, MAX_PARALLELISM);
+                    generateKey(key, 1, action, null, MAX_PARALLELISM);
                 });
     }
 
@@ -111,11 +145,22 @@ public class ActionStateUtilTest {
         InputEvent inputEvent = new InputEvent("test-input");
 
         assertThrows(
-                IllegalArgumentException.class,
-                () -> ActionStateUtil.generateKey(key, 1, action, inputEvent, 0));
+                IllegalArgumentException.class, () -> generateKey(key, 1, action, inputEvent, 0));
+        assertThrows(
+                IllegalArgumentException.class, () -> generateKey(key, 1, action, inputEvent, -1));
+    }
+
+    @Test
+    public void testGenerateKeyRejectsNegativeSequenceNumber() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ActionStateUtil.generateKey(key, 1, action, inputEvent, -1));
+                () ->
+                        generateKey(
+                                "key",
+                                -1,
+                                new NoOpAction("action"),
+                                new InputEvent("input"),
+                                MAX_PARALLELISM));
     }
 
     /**
@@ -129,8 +174,7 @@ public class ActionStateUtilTest {
     public void testActionUUIDSegmentDerivesFromActionName() throws Exception {
         Action action = new NoOpAction("test-action");
         String generatedKey =
-                ActionStateUtil.generateKey(
-                        "test-key", 1, action, new InputEvent("test-input"), MAX_PARALLELISM);
+                generateKey("test-key", 1, action, new InputEvent("test-input"), MAX_PARALLELISM);
 
         String actionUUIDSegment = ActionStateUtil.parseKey(generatedKey).get(3);
         assertEquals(
@@ -147,11 +191,9 @@ public class ActionStateUtilTest {
     public void testSameActionNameYieldsSameKeyAcrossInstances() throws Exception {
         InputEvent event = new InputEvent("test-input");
         String first =
-                ActionStateUtil.generateKey(
-                        "test-key", 7, new NoOpAction("stable-name"), event, MAX_PARALLELISM);
+                generateKey("test-key", 7, new NoOpAction("stable-name"), event, MAX_PARALLELISM);
         String second =
-                ActionStateUtil.generateKey(
-                        "test-key", 7, new NoOpAction("stable-name"), event, MAX_PARALLELISM);
+                generateKey("test-key", 7, new NoOpAction("stable-name"), event, MAX_PARALLELISM);
         assertEquals(first, second);
     }
 
@@ -163,20 +205,21 @@ public class ActionStateUtilTest {
         InputEvent inputEvent = new InputEvent("test-input");
         long seqNum = 123;
 
-        String generatedKey =
-                ActionStateUtil.generateKey(key, seqNum, action, inputEvent, MAX_PARALLELISM);
+        String generatedKey = generateKey(key, seqNum, action, inputEvent, MAX_PARALLELISM);
 
         // Parse the generated key
         List<String> parsedParts = ActionStateUtil.parseKey(generatedKey);
 
-        // Verify the parsed components: [keyGroup, seqNum, eventUUID, actionUUID, businessKey]
-        assertEquals(5, parsedParts.size());
+        // Verify: [keyGroup, seqNum, eventUUID, actionUUID, serializer, businessKeyIdentity].
+        assertEquals(6, parsedParts.size());
         assertTrue(Integer.parseInt(parsedParts.get(0)) >= 0); // keyGroup
         assertEquals(String.valueOf(seqNum), parsedParts.get(1));
         // The event and action UUID segments are non-empty.
         assertTrue(parsedParts.get(2).length() > 0);
         assertTrue(parsedParts.get(3).length() > 0);
-        assertEquals(key.toString(), parsedParts.get(4));
+        assertEquals(
+                ActionStateUtil.generateBusinessKeyIdentity(key, KEY_SERIALIZER),
+                parsedParts.get(5));
     }
 
     @Test
@@ -187,12 +230,12 @@ public class ActionStateUtilTest {
         InputEvent inputEvent = new InputEvent("round-trip-input");
         long seqNum = 456;
 
-        String generatedKey =
-                ActionStateUtil.generateKey(
-                        originalKey, seqNum, action, inputEvent, MAX_PARALLELISM);
+        String generatedKey = generateKey(originalKey, seqNum, action, inputEvent, MAX_PARALLELISM);
         List<String> parsedParts = ActionStateUtil.parseKey(generatedKey);
 
-        assertEquals(originalKey.toString(), parsedParts.get(4));
+        assertEquals(
+                ActionStateUtil.generateBusinessKeyIdentity(originalKey, KEY_SERIALIZER),
+                parsedParts.get(5));
         assertEquals(String.valueOf(seqNum), parsedParts.get(1));
     }
 
@@ -237,11 +280,12 @@ public class ActionStateUtilTest {
         InputEvent inputEvent = new InputEvent("input-with-special@chars");
         long seqNum = 789;
 
-        String generatedKey =
-                ActionStateUtil.generateKey(key, seqNum, action, inputEvent, MAX_PARALLELISM);
+        String generatedKey = generateKey(key, seqNum, action, inputEvent, MAX_PARALLELISM);
         List<String> parsedParts = ActionStateUtil.parseKey(generatedKey);
 
-        assertEquals(key.toString(), parsedParts.get(4));
+        assertEquals(
+                ActionStateUtil.generateBusinessKeyIdentity(key, KEY_SERIALIZER),
+                parsedParts.get(5));
         assertEquals(String.valueOf(seqNum), parsedParts.get(1));
     }
 
@@ -251,14 +295,15 @@ public class ActionStateUtilTest {
         Action action = new NoOpAction("consistency-action");
         InputEvent inputEvent = new InputEvent("consistency-input");
 
-        String key1 = ActionStateUtil.generateKey("key1", 100, action, inputEvent, MAX_PARALLELISM);
-        String key2 = ActionStateUtil.generateKey("key2", 200, action, inputEvent, MAX_PARALLELISM);
+        String key1 = generateKey("key1", 100, action, inputEvent, MAX_PARALLELISM);
+        String key2 = generateKey("key2", 200, action, inputEvent, MAX_PARALLELISM);
 
         List<String> parsed1 = ActionStateUtil.parseKey(key1);
         List<String> parsed2 = ActionStateUtil.parseKey(key2);
 
         // Business keys and sequence numbers differ.
-        assertNotEquals(parsed1.get(4), parsed2.get(4)); // businessKey
+        assertEquals(parsed1.get(4), parsed2.get(4)); // serializer fingerprint
+        assertNotEquals(parsed1.get(5), parsed2.get(5)); // businessKey
         assertNotEquals(parsed1.get(1), parsed2.get(1)); // seqNum
 
         // But event and action UUIDs should be the same (same event and action)
@@ -270,62 +315,130 @@ public class ActionStateUtilTest {
     public void testIsKeyRetainedFiltersForeignKeys() throws Exception {
         Action action = new NoOpAction("owner-action");
         InputEvent event = new InputEvent("owner-input");
-        String ownedKey = ActionStateUtil.generateKey("A", 1, action, event, MAX_PARALLELISM);
-        String foreignKey = ActionStateUtil.generateKey("B", 1, action, event, MAX_PARALLELISM);
+        String ownedKey = generateKey("A", 1, action, event, MAX_PARALLELISM);
+        String foreignKey = generateKey("B", 1, action, event, MAX_PARALLELISM);
 
         int ownedKeyGroup = ActionStateUtil.parseKeyGroup(ownedKey);
-        assertTrue(ActionStateUtil.isKeyRetained(kg -> kg == ownedKeyGroup, ownedKey));
-        assertFalse(ActionStateUtil.isKeyRetained(kg -> kg == ownedKeyGroup, foreignKey));
+        assertTrue(
+                createKeyEncoder(MAX_PARALLELISM)
+                        .isKeyRetained(kg -> kg == ownedKeyGroup, ownedKey));
+        assertFalse(
+                createKeyEncoder(MAX_PARALLELISM)
+                        .isKeyRetained(kg -> kg == ownedKeyGroup, foreignKey));
     }
 
     @Test
     public void testIsKeyRetainedKeepsAllKeysWhenNoFilter() throws Exception {
         Action action = new NoOpAction("no-filter-action");
         InputEvent event = new InputEvent("no-filter-input");
-        String keyA = ActionStateUtil.generateKey("A", 1, action, event, MAX_PARALLELISM);
-        String keyB = ActionStateUtil.generateKey("B", 1, action, event, MAX_PARALLELISM);
+        String keyA = generateKey("A", 1, action, event, MAX_PARALLELISM);
+        String keyB = generateKey("B", 1, action, event, MAX_PARALLELISM);
 
-        assertTrue(ActionStateUtil.isKeyRetained(null, keyA));
-        assertTrue(ActionStateUtil.isKeyRetained(null, keyB));
+        assertTrue(createKeyEncoder(MAX_PARALLELISM).isKeyRetained(null, keyA));
+        assertTrue(createKeyEncoder(MAX_PARALLELISM).isKeyRetained(null, keyB));
     }
 
     @Test
-    public void testIsKeyRetainedDropsUnrecognizedFormatKeys() {
-        // Keys that do not have the current segment count cannot be attributed to a key-group, so
-        // they are dropped during ownership filtering rather than retained in every subtask. This
-        // closes the orphan-state leak; the project does not preserve pre-format durable state.
-        assertFalse(ActionStateUtil.isKeyRetained(kg -> true, "test-key_1_event-uuid_action-uuid"));
-        assertFalse(ActionStateUtil.isKeyRetained(kg -> true, "malformed-key"));
+    public void testIsKeyRetainedRejectsUnrecognizedFormatKeys() {
+        assertThrows(
+                IllegalStateException.class,
+                () ->
+                        createKeyEncoder(MAX_PARALLELISM)
+                                .isKeyRetained(
+                                        kg -> true, "12_1_event-uuid_action-uuid_business-key"));
+        assertThrows(
+                IllegalStateException.class,
+                () -> createKeyEncoder(MAX_PARALLELISM).isKeyRetained(kg -> true, "malformed-key"));
     }
 
     @Test
-    public void testIsKeyRetainedDropsKeyWithUnparsableKeyGroup() {
-        // A well-formed (5-segment) key whose key-group segment is not numeric cannot be
-        // attributed to a key-group and is dropped.
-        assertFalse(
-                ActionStateUtil.isKeyRetained(
-                        kg -> true, "not-a-number_1_event-uuid_action-uuid_bkey"));
+    public void testIsKeyRetainedRejectsKeyWithUnparsableKeyGroup() throws Exception {
+        String valid =
+                generateKey(
+                        "A",
+                        1,
+                        new NoOpAction("valid-action"),
+                        new InputEvent("valid-input"),
+                        MAX_PARALLELISM);
+        String invalid = "v2:not-a-number" + valid.substring(valid.indexOf('_'));
+        IllegalStateException failure =
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> createKeyEncoder(MAX_PARALLELISM).isKeyRetained(kg -> true, invalid));
+
+        assertTrue(failure.getMessage().contains("Invalid key-group"));
+        assertThrows(
+                IllegalStateException.class,
+                () -> createKeyEncoder(MAX_PARALLELISM).isKeyRetained(null, invalid));
+    }
+
+    @Test
+    public void testIsKeyRetainedRejectsMalformedCurrentFormatFields() throws Exception {
+        String valid =
+                generateKey(
+                        "A",
+                        1,
+                        new NoOpAction("valid-action"),
+                        new InputEvent("valid-input"),
+                        MAX_PARALLELISM);
+        List<String> parts = ActionStateUtil.parseKey(valid);
+        String nonCanonicalKeyGroup = withSegment(parts, 0, "+0");
+        IllegalStateException nonCanonicalFailure =
+                assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                createKeyEncoder(MAX_PARALLELISM)
+                                        .isKeyRetained(null, nonCanonicalKeyGroup));
+        assertTrue(nonCanonicalFailure.getMessage().contains("+0"));
+        assertTrue(nonCanonicalFailure.getMessage().contains(nonCanonicalKeyGroup));
+
+        List<String> invalidKeys =
+                List.of(
+                        withSegment(parts, 0, "-1"),
+                        withSegment(parts, 0, String.valueOf(MAX_PARALLELISM)),
+                        withSegment(parts, 0, "00"),
+                        withSegment(parts, 1, "not-a-number"),
+                        withSegment(parts, 1, "+1"),
+                        withSegment(parts, 1, "01"),
+                        withSegment(parts, 1, "-0"),
+                        withSegment(parts, 1, "-1"),
+                        withSegment(parts, 2, "not-a-uuid"),
+                        withSegment(parts, 2, "1-1-1-1-1"),
+                        withSegment(parts, 3, "1-1-1-1-1"),
+                        withSegment(parts, 4, "not-a-digest"),
+                        withSegment(parts, 5, "not-a-digest"));
+
+        for (String invalidKey : invalidKeys) {
+            assertThrows(
+                    IllegalStateException.class,
+                    () -> createKeyEncoder(MAX_PARALLELISM).isKeyRetained(null, invalidKey),
+                    invalidKey);
+        }
     }
 
     @Test
     public void testBusinessKeyContainingSeparatorIsHandled() throws Exception {
-        // A business key containing the separator (e.g. "tenant_user") must still round-trip and
-        // be attributable, because it occupies the trailing segment of the composite key. This is
-        // the exact case that broke the previous segment-count parsing.
         Object businessKey = "tenant_user";
         Action action = new NoOpAction("underscore-action");
         InputEvent event = new InputEvent("underscore-input");
-        String stateKey =
-                ActionStateUtil.generateKey(businessKey, 3, action, event, MAX_PARALLELISM);
+        String stateKey = generateKey(businessKey, 3, action, event, MAX_PARALLELISM);
+        String businessKeyIdentity =
+                ActionStateUtil.generateBusinessKeyIdentity(businessKey, KEY_SERIALIZER);
 
-        assertEquals("tenant_user", ActionStateUtil.businessKeyOf(stateKey));
-        assertEquals("tenant_user", ActionStateUtil.parseKey(stateKey).get(4));
-        assertTrue(ActionStateUtil.matchesBusinessKey(stateKey, businessKey));
-        assertTrue(ActionStateUtil.matchesBusinessKeyAndSeqNum(stateKey, businessKey, 3));
+        assertEquals(businessKeyIdentity, ActionStateUtil.businessKeyIdentityOf(stateKey));
+        assertEquals(businessKeyIdentity, ActionStateUtil.parseKey(stateKey).get(5));
+        assertTrue(ActionStateUtil.matchesBusinessKeyIdentity(stateKey, businessKeyIdentity));
+        assertTrue(
+                ActionStateUtil.matchesBusinessKeyIdentityAndSeqNum(
+                        stateKey, businessKeyIdentity, 3));
 
         int ownedKeyGroup = ActionStateUtil.parseKeyGroup(stateKey);
-        assertTrue(ActionStateUtil.isKeyRetained(kg -> kg == ownedKeyGroup, stateKey));
-        assertFalse(ActionStateUtil.isKeyRetained(kg -> kg != ownedKeyGroup, stateKey));
+        assertTrue(
+                createKeyEncoder(MAX_PARALLELISM)
+                        .isKeyRetained(kg -> kg == ownedKeyGroup, stateKey));
+        assertFalse(
+                createKeyEncoder(MAX_PARALLELISM)
+                        .isKeyRetained(kg -> kg != ownedKeyGroup, stateKey));
     }
 
     @Test
@@ -334,35 +447,105 @@ public class ActionStateUtilTest {
         InputEvent event = new InputEvent("match-input");
         // Numeric business key 1 at seqNum 5: a substring match on "_5_" would wrongly
         // attribute this record to business key 5 via its seqNum segment.
-        String keyOneAtSeqFive = ActionStateUtil.generateKey(1L, 5, action, event, MAX_PARALLELISM);
+        String keyOneAtSeqFive = generateKey(1L, 5, action, event, MAX_PARALLELISM);
+        String keyOneIdentity = ActionStateUtil.generateBusinessKeyIdentity(1L, KEY_SERIALIZER);
+        String keyFiveIdentity = ActionStateUtil.generateBusinessKeyIdentity(5L, KEY_SERIALIZER);
 
-        assertTrue(ActionStateUtil.matchesBusinessKey(keyOneAtSeqFive, 1L));
-        assertFalse(ActionStateUtil.matchesBusinessKey(keyOneAtSeqFive, 5L));
-        assertFalse(ActionStateUtil.matchesBusinessKey("legacy_1_event-uuid_action-uuid", 1L));
+        assertTrue(ActionStateUtil.matchesBusinessKeyIdentity(keyOneAtSeqFive, keyOneIdentity));
+        assertFalse(ActionStateUtil.matchesBusinessKeyIdentity(keyOneAtSeqFive, keyFiveIdentity));
+        assertFalse(
+                ActionStateUtil.matchesBusinessKeyIdentity(
+                        "legacy_1_event-uuid_action-uuid", keyOneIdentity));
     }
 
     @Test
     public void testMatchesBusinessKeyAndSeqNum() throws Exception {
         Action action = new NoOpAction("match-action");
         InputEvent event = new InputEvent("match-input");
-        String stateKey = ActionStateUtil.generateKey("A", 7, action, event, MAX_PARALLELISM);
+        String stateKey = generateKey("A", 7, action, event, MAX_PARALLELISM);
+        String identityA = ActionStateUtil.generateBusinessKeyIdentity("A", KEY_SERIALIZER);
+        String identityB = ActionStateUtil.generateBusinessKeyIdentity("B", KEY_SERIALIZER);
 
-        assertTrue(ActionStateUtil.matchesBusinessKeyAndSeqNum(stateKey, "A", 7));
-        assertFalse(ActionStateUtil.matchesBusinessKeyAndSeqNum(stateKey, "A", 8));
-        assertFalse(ActionStateUtil.matchesBusinessKeyAndSeqNum(stateKey, "B", 7));
+        assertTrue(ActionStateUtil.matchesBusinessKeyIdentityAndSeqNum(stateKey, identityA, 7));
+        assertFalse(ActionStateUtil.matchesBusinessKeyIdentityAndSeqNum(stateKey, identityA, 8));
+        assertFalse(ActionStateUtil.matchesBusinessKeyIdentityAndSeqNum(stateKey, identityB, 7));
     }
 
     @Test
     public void testMatchesBusinessKeyWithSeqNumFilter() throws Exception {
         Action action = new NoOpAction("match-action");
         InputEvent event = new InputEvent("match-input");
-        String keyOneAtSeqFive = ActionStateUtil.generateKey(1L, 5, action, event, MAX_PARALLELISM);
+        String keyOneAtSeqFive = generateKey(1L, 5, action, event, MAX_PARALLELISM);
+        String keyOneIdentity = ActionStateUtil.generateBusinessKeyIdentity(1L, KEY_SERIALIZER);
+        String keyFiveIdentity = ActionStateUtil.generateBusinessKeyIdentity(5L, KEY_SERIALIZER);
 
         assertTrue(
-                ActionStateUtil.matchesBusinessKeyWithSeqNum(keyOneAtSeqFive, 1L, seq -> seq <= 5));
+                ActionStateUtil.matchesBusinessKeyIdentityWithSeqNum(
+                        keyOneAtSeqFive, keyOneIdentity, seq -> seq <= 5));
         assertFalse(
-                ActionStateUtil.matchesBusinessKeyWithSeqNum(keyOneAtSeqFive, 1L, seq -> seq > 5));
+                ActionStateUtil.matchesBusinessKeyIdentityWithSeqNum(
+                        keyOneAtSeqFive, keyOneIdentity, seq -> seq > 5));
         // Wrong business key never matches, regardless of the seqNum filter.
-        assertFalse(ActionStateUtil.matchesBusinessKeyWithSeqNum(keyOneAtSeqFive, 5L, seq -> true));
+        assertFalse(
+                ActionStateUtil.matchesBusinessKeyIdentityWithSeqNum(
+                        keyOneAtSeqFive, keyFiveIdentity, seq -> true));
+    }
+
+    @Test
+    public void testTypedKeysWithSameStringFormHaveDistinctIdentities() throws Exception {
+        Action action = new NoOpAction("typed-key-action");
+        InputEvent event = new InputEvent("typed-key-input");
+
+        String numericKey = generateKey(1L, 1, action, event, 1);
+        String stringKey = generateKey("1", 1, action, event, 1);
+
+        assertNotEquals(numericKey, stringKey);
+        assertFalse(
+                ActionStateUtil.matchesBusinessKeyIdentity(
+                        stringKey,
+                        ActionStateUtil.generateBusinessKeyIdentity(1L, KEY_SERIALIZER)));
+    }
+
+    @Test
+    public void testDistinctCustomKeysWithSameStringFormHaveDistinctIdentities() throws Exception {
+        Action action = new NoOpAction("custom-key-action");
+        InputEvent event = new InputEvent("custom-key-input");
+
+        String first = generateKey(new SameStringKey(1), 1, action, event, 1);
+        String second = generateKey(new SameStringKey(2), 1, action, event, 1);
+        String equalToFirst = generateKey(new SameStringKey(1), 1, action, event, 1);
+
+        assertNotEquals(first, second);
+        assertEquals(first, equalToFirst);
+    }
+
+    private static final class SameStringKey {
+        private final int id;
+
+        private SameStringKey(int id) {
+            this.id = id;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof SameStringKey && id == ((SameStringKey) other).id;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id);
+        }
+
+        @Override
+        public String toString() {
+            return "same";
+        }
+    }
+
+    private static String withSegment(List<String> parsedParts, int index, String replacement) {
+        List<String> parts = new ArrayList<>(parsedParts);
+        parts.set(index, replacement);
+        parts.set(0, "v2:" + parts.get(0));
+        return String.join("_", parts);
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateUtilTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateUtilTest.java
@@ -21,7 +21,9 @@ import org.apache.flink.agents.api.InputEvent;
 import org.apache.flink.agents.plan.actions.Action;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -114,6 +116,43 @@ public class ActionStateUtilTest {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> ActionStateUtil.generateKey(key, 1, action, inputEvent, -1));
+    }
+
+    /**
+     * The action-UUID key segment must be derived from the plan-unique action NAME, never from
+     * {@code Action.hashCode()}: the hash folds in {@code Class.hashCode()} (a per-JVM identity
+     * hash), so a hash-derived segment silently changes across process restarts and recovery
+     * lookups can never hit. This pins the derivation so any future change to the key format is a
+     * conscious, reviewed break of cross-restart state compatibility.
+     */
+    @Test
+    public void testActionUUIDSegmentDerivesFromActionName() throws Exception {
+        Action action = new NoOpAction("test-action");
+        String generatedKey =
+                ActionStateUtil.generateKey(
+                        "test-key", 1, action, new InputEvent("test-input"), MAX_PARALLELISM);
+
+        String actionUUIDSegment = ActionStateUtil.parseKey(generatedKey).get(3);
+        assertEquals(
+                UUID.nameUUIDFromBytes("test-action".getBytes(StandardCharsets.UTF_8)).toString(),
+                actionUUIDSegment);
+    }
+
+    /**
+     * Two separately constructed Action instances with the same name — which is what "the same
+     * action, after a JVM restart" looks like — must produce identical state keys, or recovery can
+     * never replay.
+     */
+    @Test
+    public void testSameActionNameYieldsSameKeyAcrossInstances() throws Exception {
+        InputEvent event = new InputEvent("test-input");
+        String first =
+                ActionStateUtil.generateKey(
+                        "test-key", 7, new NoOpAction("stable-name"), event, MAX_PARALLELISM);
+        String second =
+                ActionStateUtil.generateKey(
+                        "test-key", 7, new NoOpAction("stable-name"), event, MAX_PARALLELISM);
+        assertEquals(first, second);
     }
 
     @Test

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStoreIntegrationTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStoreIntegrationTest.java
@@ -38,6 +38,8 @@ import static org.apache.flink.agents.api.configuration.AgentConfigOptions.FLUSS
 import static org.apache.flink.agents.api.configuration.AgentConfigOptions.FLUSS_ACTION_STATE_TABLE;
 import static org.apache.flink.agents.api.configuration.AgentConfigOptions.FLUSS_ACTION_STATE_TABLE_BUCKETS;
 import static org.apache.flink.agents.api.configuration.AgentConfigOptions.FLUSS_BOOTSTRAP_SERVERS;
+import static org.apache.flink.agents.runtime.actionstate.ActionStateTestUtils.createKeyEncoder;
+import static org.apache.flink.agents.runtime.actionstate.ActionStateTestUtils.generateKey;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Integration tests for {@link FlussActionStateStore} against an embedded Fluss cluster. */
@@ -59,7 +61,7 @@ public class FlussActionStateStoreIntegrationTest {
     @BeforeEach
     void setUp() throws Exception {
         AgentConfiguration config = createAgentConfiguration();
-        store = new FlussActionStateStore(config, MAX_PARALLELISM);
+        store = new FlussActionStateStore(config, createKeyEncoder(MAX_PARALLELISM));
 
         // Wait for table to be ready in the cluster
         waitForTableReady();
@@ -189,7 +191,8 @@ public class FlussActionStateStoreIntegrationTest {
 
         // Simulate recovery: new store instance
         FlussActionStateStore recoveredStore =
-                new FlussActionStateStore(createAgentConfiguration(), MAX_PARALLELISM);
+                new FlussActionStateStore(
+                        createAgentConfiguration(), createKeyEncoder(MAX_PARALLELISM));
         try {
             // Rebuild using the marker; should replay from marker offset to current end
             recoveredStore.rebuildState(List.of(marker));
@@ -225,13 +228,13 @@ public class FlussActionStateStoreIntegrationTest {
 
         // Simulate recovery into a new store instance that owns only key "A".
         FlussActionStateStore recoveredStore =
-                new FlussActionStateStore(createAgentConfiguration(), MAX_PARALLELISM);
+                new FlussActionStateStore(
+                        createAgentConfiguration(), createKeyEncoder(MAX_PARALLELISM));
         try {
             // Own key's key-group computed from the WAL key; the filter accepts only this
             // key-group.
             int ownedKeyGroup =
-                    ActionStateUtil.parseKeyGroup(
-                            ActionStateUtil.generateKey("A", 1L, testAction, testEvent, 128));
+                    ActionStateUtil.parseKeyGroup(generateKey("A", 1L, testAction, testEvent, 128));
             recoveredStore.setOwnershipFilter(kg -> kg == ownedKeyGroup);
             recoveredStore.rebuildState(List.of(marker));
 
@@ -257,7 +260,8 @@ public class FlussActionStateStoreIntegrationTest {
 
         // Simulate recovery: new store instance
         FlussActionStateStore recoveredStore =
-                new FlussActionStateStore(createAgentConfiguration(), MAX_PARALLELISM);
+                new FlussActionStateStore(
+                        createAgentConfiguration(), createKeyEncoder(MAX_PARALLELISM));
         try {
             // Rebuild state from the log using recovery markers
             recoveredStore.rebuildState(List.of(marker));
@@ -286,7 +290,8 @@ public class FlussActionStateStoreIntegrationTest {
         String multiDb = "test_flink_agents_multi";
         String multiTable = "action_state_multi";
         AgentConfiguration multiConfig = createAgentConfiguration(multiDb, multiTable, 4);
-        FlussActionStateStore multiStore = new FlussActionStateStore(multiConfig, MAX_PARALLELISM);
+        FlussActionStateStore multiStore =
+                new FlussActionStateStore(multiConfig, createKeyEncoder(MAX_PARALLELISM));
         try {
             waitForTableReady(multiDb, multiTable);
 
@@ -318,7 +323,7 @@ public class FlussActionStateStoreIntegrationTest {
 
             // Recover into a new store instance
             FlussActionStateStore recoveredStore =
-                    new FlussActionStateStore(multiConfig, MAX_PARALLELISM);
+                    new FlussActionStateStore(multiConfig, createKeyEncoder(MAX_PARALLELISM));
             try {
                 recoveredStore.rebuildState(List.of(marker));
 

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStoreIntegrationTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStoreIntegrationTest.java
@@ -21,9 +21,15 @@ import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.api.InputEvent;
 import org.apache.flink.agents.plan.AgentConfiguration;
 import org.apache.flink.agents.plan.actions.Action;
+import org.apache.fluss.client.Connection;
+import org.apache.fluss.client.ConnectionFactory;
 import org.apache.fluss.client.admin.Admin;
+import org.apache.fluss.client.table.Table;
+import org.apache.fluss.client.table.writer.AppendWriter;
 import org.apache.fluss.metadata.TableInfo;
 import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.row.BinaryString;
+import org.apache.fluss.row.GenericRow;
 import org.apache.fluss.server.testutils.FlussClusterExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,6 +47,7 @@ import static org.apache.flink.agents.api.configuration.AgentConfigOptions.FLUSS
 import static org.apache.flink.agents.runtime.actionstate.ActionStateTestUtils.createKeyEncoder;
 import static org.apache.flink.agents.runtime.actionstate.ActionStateTestUtils.generateKey;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /** Integration tests for {@link FlussActionStateStore} against an embedded Fluss cluster. */
 public class FlussActionStateStoreIntegrationTest {
@@ -207,6 +214,44 @@ public class FlussActionStateStoreIntegrationTest {
             recoveredStore.close();
             // Prevent double-close in tearDown
             store = null;
+        }
+    }
+
+    @Test
+    void testRebuildStateRejectsLegacyRecordFormat() throws Exception {
+        Object marker = store.getRecoveryMarker();
+        String legacyKey = "0_1_event-uuid_action-uuid_business-key";
+        TablePath tablePath = TablePath.of(TEST_DATABASE, TEST_TABLE);
+        try (Connection connection =
+                        ConnectionFactory.createConnection(FLUSS_CLUSTER.getClientConfig());
+                Table table = connection.getTable(tablePath)) {
+            AppendWriter writer = table.newAppend().createWriter();
+            writer.append(
+                            GenericRow.of(
+                                    BinaryString.fromString(legacyKey),
+                                    ActionStateSerde.serialize(new ActionState(testEvent)),
+                                    BinaryString.fromString("legacy-key")))
+                    .get();
+            writer.flush();
+        }
+
+        store.close();
+        store = null;
+        FlussActionStateStore recoveredStore =
+                new FlussActionStateStore(
+                        createAgentConfiguration(), createKeyEncoder(MAX_PARALLELISM));
+        try {
+            recoveredStore.setOwnershipFilter(keyGroup -> true);
+
+            Throwable failure = catchThrowable(() -> recoveredStore.rebuildState(List.of(marker)));
+
+            assertThat(failure).isInstanceOf(RuntimeException.class);
+            assertThat(failure.getCause())
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Unsupported action-state key format")
+                    .hasMessageContaining(legacyKey);
+        } finally {
+            recoveredStore.close();
         }
     }
 

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStoreSaslIntegrationTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStoreSaslIntegrationTest.java
@@ -36,6 +36,7 @@ import static org.apache.flink.agents.api.configuration.AgentConfigOptions.FLUSS
 import static org.apache.flink.agents.api.configuration.AgentConfigOptions.FLUSS_SASL_PASSWORD;
 import static org.apache.flink.agents.api.configuration.AgentConfigOptions.FLUSS_SASL_USERNAME;
 import static org.apache.flink.agents.api.configuration.AgentConfigOptions.FLUSS_SECURITY_PROTOCOL;
+import static org.apache.flink.agents.runtime.actionstate.ActionStateTestUtils.createKeyEncoder;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -65,7 +66,7 @@ public class FlussActionStateStoreSaslIntegrationTest {
     @BeforeEach
     void setUp() throws Exception {
         AgentConfiguration config = createSaslAgentConfiguration();
-        store = new FlussActionStateStore(config, MAX_PARALLELISM);
+        store = new FlussActionStateStore(config, createKeyEncoder(MAX_PARALLELISM));
     }
 
     @AfterEach
@@ -103,7 +104,8 @@ public class FlussActionStateStoreSaslIntegrationTest {
 
         // Recover into a new store instance with SASL
         FlussActionStateStore recoveredStore =
-                new FlussActionStateStore(createSaslAgentConfiguration(), MAX_PARALLELISM);
+                new FlussActionStateStore(
+                        createSaslAgentConfiguration(), createKeyEncoder(MAX_PARALLELISM));
         try {
             recoveredStore.rebuildState(java.util.List.of(marker));
 

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStoreTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStoreTest.java
@@ -26,6 +26,7 @@ import org.apache.fluss.client.table.writer.AppendWriter;
 import org.apache.fluss.row.InternalRow;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -34,12 +35,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import static org.apache.flink.agents.runtime.actionstate.ActionStateTestUtils.KEY_SERIALIZER;
+import static org.apache.flink.agents.runtime.actionstate.ActionStateTestUtils.createKeyEncoder;
+import static org.apache.flink.agents.runtime.actionstate.ActionStateTestUtils.generateKey;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -63,29 +68,49 @@ public class FlussActionStateStoreTest {
                 .thenReturn(CompletableFuture.completedFuture(null));
 
         actionStates = new HashMap<>();
-        store =
-                new FlussActionStateStore(
-                        actionStates,
-                        mock(Connection.class),
-                        mock(Table.class),
-                        mockWriter,
-                        MAX_PARALLELISM);
+        store = createStore(MAX_PARALLELISM);
 
         testAction = new NoOpAction("test-action");
         testEvent = new InputEvent("test data");
         testActionState = new ActionState(testEvent);
     }
 
+    private FlussActionStateStore createStore(int maxParallelism) {
+        return new FlussActionStateStore(
+                actionStates,
+                mock(Connection.class),
+                mock(Table.class),
+                mockWriter,
+                createKeyEncoder(maxParallelism));
+    }
+
     @Test
     void testPutActionState() throws Exception {
         store.put(TEST_KEY, 1L, testAction, testEvent, testActionState);
 
-        verify(mockWriter).append(any(InternalRow.class));
+        ArgumentCaptor<InternalRow> rowCaptor = ArgumentCaptor.forClass(InternalRow.class);
+        verify(mockWriter).append(rowCaptor.capture());
 
-        String stateKey =
-                ActionStateUtil.generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM);
+        String stateKey = generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM);
         assertThat(actionStates).containsKey(stateKey);
         assertThat(actionStates.get(stateKey)).isEqualTo(testActionState);
+        assertThat(rowCaptor.getValue().getString(2).toString())
+                .isEqualTo(ActionStateUtil.generateBusinessKeyIdentity(TEST_KEY, KEY_SERIALIZER))
+                .isNotEqualTo(TEST_KEY);
+    }
+
+    @Test
+    void testPutUsesDistinctDistributionIdentitiesForTypedKeysWithSameStringForm()
+            throws Exception {
+        store.put(1L, 1L, testAction, testEvent, testActionState);
+        store.put("1", 1L, testAction, testEvent, testActionState);
+
+        ArgumentCaptor<InternalRow> rowCaptor = ArgumentCaptor.forClass(InternalRow.class);
+        verify(mockWriter, times(2)).append(rowCaptor.capture());
+
+        assertThat(rowCaptor.getAllValues())
+                .extracting(row -> row.getString(2).toString())
+                .doesNotHaveDuplicates();
     }
 
     @Test
@@ -99,34 +124,29 @@ public class FlussActionStateStoreTest {
                         mock(Connection.class),
                         mock(Table.class),
                         mockWriter,
-                        MAX_PARALLELISM);
+                        createKeyEncoder(MAX_PARALLELISM));
 
         assertThatThrownBy(
                         () -> failStore.put(TEST_KEY, 1L, testAction, testEvent, testActionState))
                 .isInstanceOf(Exception.class);
 
         // Cache should NOT be updated on write failure
-        String stateKey =
-                ActionStateUtil.generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM);
+        String stateKey = generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM);
         assertThat(actionStates).doesNotContainKey(stateKey);
     }
 
     @Test
     void testGetTriggersDivergenceCleanup() throws Exception {
         actionStates.put(
-                ActionStateUtil.generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM),
-                testActionState);
+                generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM), testActionState);
         actionStates.put(
-                ActionStateUtil.generateKey(TEST_KEY, 2L, testAction, testEvent, MAX_PARALLELISM),
-                testActionState);
+                generateKey(TEST_KEY, 2L, testAction, testEvent, MAX_PARALLELISM), testActionState);
         // diverge: same key+seqNum, different action
         actionStates.put(
-                ActionStateUtil.generateKey(
-                        TEST_KEY, 2L, new NoOpAction("test-2"), testEvent, MAX_PARALLELISM),
+                generateKey(TEST_KEY, 2L, new NoOpAction("test-2"), testEvent, MAX_PARALLELISM),
                 testActionState);
         actionStates.put(
-                ActionStateUtil.generateKey(TEST_KEY, 3L, testAction, testEvent, MAX_PARALLELISM),
-                testActionState);
+                generateKey(TEST_KEY, 3L, testAction, testEvent, MAX_PARALLELISM), testActionState);
 
         store.get(TEST_KEY, 2L, new NoOpAction("test-1"), testEvent);
 
@@ -143,10 +163,8 @@ public class FlussActionStateStoreTest {
      */
     @Test
     void testPruneStateDoesNotCrossNumericKeyAndSeqNum() throws Exception {
-        String keyOneAtSeqFive =
-                ActionStateUtil.generateKey(1L, 5L, testAction, testEvent, MAX_PARALLELISM);
-        String keyFiveAtSeqThree =
-                ActionStateUtil.generateKey(5L, 3L, testAction, testEvent, MAX_PARALLELISM);
+        String keyOneAtSeqFive = generateKey(1L, 5L, testAction, testEvent, MAX_PARALLELISM);
+        String keyFiveAtSeqThree = generateKey(5L, 3L, testAction, testEvent, MAX_PARALLELISM);
         actionStates.put(keyOneAtSeqFive, testActionState);
         actionStates.put(keyFiveAtSeqThree, testActionState);
 
@@ -165,8 +183,7 @@ public class FlussActionStateStoreTest {
     @Test
     void testGetCleanupIsScopedToRequestedKey() throws Exception {
         String otherKeyNewerState =
-                ActionStateUtil.generateKey(
-                        "other-key", 9L, testAction, testEvent, MAX_PARALLELISM);
+                generateKey("other-key", 9L, testAction, testEvent, MAX_PARALLELISM);
         actionStates.put(otherKeyNewerState, testActionState);
 
         // Cache miss for TEST_KEY at seqNum 1 triggers cleanup of states with seqNum > 1.
@@ -175,13 +192,36 @@ public class FlussActionStateStoreTest {
         assertThat(actionStates).containsKey(otherKeyNewerState);
     }
 
+    @Test
+    void testGetCleanupSeparatesTypedKeysWithSameStringForm() throws Exception {
+        FlussActionStateStore collisionStore = createStore(1);
+        String stringKeyNewerState = generateKey("1", 9L, testAction, testEvent, 1);
+        actionStates.put(stringKeyNewerState, testActionState);
+
+        assertThat(collisionStore.get(1L, 1L, testAction, testEvent)).isNull();
+
+        assertThat(actionStates).containsKey(stringKeyNewerState);
+    }
+
+    @Test
+    void testPruneSeparatesTypedKeysWithSameStringForm() throws Exception {
+        FlussActionStateStore collisionStore = createStore(1);
+        String numericState = generateKey(1L, 1L, testAction, testEvent, 1);
+        String stringState = generateKey("1", 1L, testAction, testEvent, 1);
+        actionStates.put(numericState, testActionState);
+        actionStates.put(stringState, testActionState);
+
+        collisionStore.pruneState(1L, 1L);
+
+        assertThat(actionStates).doesNotContainKey(numericState).containsKey(stringState);
+    }
+
     // ==================== rebuildState tests ====================
 
     @Test
     void testRebuildStateSkipsOnEmptyMarkers() throws Exception {
         actionStates.put(
-                ActionStateUtil.generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM),
-                testActionState);
+                generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM), testActionState);
 
         store.rebuildState(Collections.emptyList());
 
@@ -192,8 +232,7 @@ public class FlussActionStateStoreTest {
     @Test
     void testRebuildStateSkipsOnNonMapMarker() throws Exception {
         actionStates.put(
-                ActionStateUtil.generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM),
-                testActionState);
+                generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM), testActionState);
 
         // A non-Map marker is ignored, resulting in empty bucketStartOffsets.
         // Note: rebuildState clears the cache before checking offsets,
@@ -206,8 +245,7 @@ public class FlussActionStateStoreTest {
     @Test
     void testRebuildStateSkipsOnEmptyBucketOffsets() throws Exception {
         actionStates.put(
-                ActionStateUtil.generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM),
-                testActionState);
+                generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM), testActionState);
 
         // Empty map marker → no valid bucket offsets.
         // Same as above: cache is cleared before the early-return check.
@@ -224,7 +262,11 @@ public class FlussActionStateStoreTest {
 
         FlussActionStateStore closeableStore =
                 new FlussActionStateStore(
-                        actionStates, mockConnection, mockTable, mockWriter, MAX_PARALLELISM);
+                        actionStates,
+                        mockConnection,
+                        mockTable,
+                        mockWriter,
+                        createKeyEncoder(MAX_PARALLELISM));
 
         closeableStore.close();
 
@@ -245,7 +287,11 @@ public class FlussActionStateStoreTest {
 
         FlussActionStateStore closeableStore =
                 new FlussActionStateStore(
-                        actionStates, mockConnection, failingTable, mockWriter, MAX_PARALLELISM);
+                        actionStates,
+                        mockConnection,
+                        failingTable,
+                        mockWriter,
+                        createKeyEncoder(MAX_PARALLELISM));
 
         assertThat(catchThrowable(closeableStore::close)).isSameAs(tableFailure);
 
@@ -267,7 +313,11 @@ public class FlussActionStateStoreTest {
 
         FlussActionStateStore closeableStore =
                 new FlussActionStateStore(
-                        actionStates, failingConnection, failingTable, mockWriter, MAX_PARALLELISM);
+                        actionStates,
+                        failingConnection,
+                        failingTable,
+                        mockWriter,
+                        createKeyEncoder(MAX_PARALLELISM));
 
         Throwable thrown = catchThrowable(closeableStore::close);
 
@@ -288,7 +338,11 @@ public class FlussActionStateStoreTest {
 
         FlussActionStateStore closeableStore =
                 new FlussActionStateStore(
-                        actionStates, failingConnection, mockTable, mockWriter, MAX_PARALLELISM);
+                        actionStates,
+                        failingConnection,
+                        mockTable,
+                        mockWriter,
+                        createKeyEncoder(MAX_PARALLELISM));
 
         Throwable thrown = catchThrowable(closeableStore::close);
 
@@ -312,7 +366,11 @@ public class FlussActionStateStoreTest {
 
         FlussActionStateStore closeableStore =
                 new FlussActionStateStore(
-                        actionStates, failingConnection, failingTable, mockWriter, MAX_PARALLELISM);
+                        actionStates,
+                        failingConnection,
+                        failingTable,
+                        mockWriter,
+                        createKeyEncoder(MAX_PARALLELISM));
 
         Throwable thrown = catchThrowable(closeableStore::close);
 
@@ -338,7 +396,11 @@ public class FlussActionStateStoreTest {
 
         FlussActionStateStore closeableStore =
                 new FlussActionStateStore(
-                        actionStates, failingConnection, failingTable, mockWriter, MAX_PARALLELISM);
+                        actionStates,
+                        failingConnection,
+                        failingTable,
+                        mockWriter,
+                        createKeyEncoder(MAX_PARALLELISM));
 
         Throwable thrown = catchThrowable(closeableStore::close);
 

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/InMemoryActionStateStore.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/InMemoryActionStateStore.java
@@ -20,13 +20,13 @@ package org.apache.flink.agents.runtime.actionstate;
 import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.plan.actions.Action;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.serialization.SerializerConfigImpl;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.apache.flink.agents.runtime.actionstate.ActionStateUtil.generateKey;
 
 /**
  * An in-memory implementation of {@link ActionStateStore} for testing and local execution purposes.
@@ -36,9 +36,9 @@ public class InMemoryActionStateStore implements ActionStateStore {
 
     private static final int DEFAULT_MAX_PARALLELISM = 128;
 
-    private final Map<String, Map<String, ActionState>> keyedActionStates;
+    private final Map<Object, Map<String, ActionState>> keyedActionStates;
     private final boolean doCleanup;
-    private final int maxParallelism;
+    private final ActionStateKeyEncoder keyEncoder;
 
     public InMemoryActionStateStore(boolean doCleanup) {
         this(doCleanup, DEFAULT_MAX_PARALLELISM);
@@ -47,23 +47,27 @@ public class InMemoryActionStateStore implements ActionStateStore {
     public InMemoryActionStateStore(boolean doCleanup, int maxParallelism) {
         this.keyedActionStates = new HashMap<>();
         this.doCleanup = doCleanup;
-        this.maxParallelism = maxParallelism;
+        this.keyEncoder =
+                new ActionStateKeyEncoder(
+                        maxParallelism,
+                        TypeInformation.of(Object.class)
+                                .createSerializer(new SerializerConfigImpl()));
     }
 
     @Override
     public void put(Object key, long seqNum, Action action, Event event, ActionState state)
             throws IOException {
         Map<String, ActionState> actionStates =
-                keyedActionStates.getOrDefault(key.toString(), new HashMap<>());
-        actionStates.put(generateKey(key, seqNum, action, event, maxParallelism), state);
-        keyedActionStates.put(key.toString(), actionStates);
+                keyedActionStates.getOrDefault(key, new HashMap<>());
+        actionStates.put(keyEncoder.generateKey(key, seqNum, action, event), state);
+        keyedActionStates.put(key, actionStates);
     }
 
     @Override
     public ActionState get(Object key, long seqNum, Action action, Event event) throws IOException {
         return keyedActionStates
-                .getOrDefault(key.toString(), new HashMap<>())
-                .get(generateKey(key, seqNum, action, event, maxParallelism));
+                .getOrDefault(key, new HashMap<>())
+                .get(keyEncoder.generateKey(key, seqNum, action, event));
     }
 
     @Override
@@ -74,12 +78,12 @@ public class InMemoryActionStateStore implements ActionStateStore {
     @Override
     public void pruneState(Object key, long seqNum) {
         if (doCleanup) {
-            keyedActionStates.remove(key.toString());
+            keyedActionStates.remove(key);
         }
     }
 
     @VisibleForTesting
-    public Map<String, Map<String, ActionState>> getKeyedActionStates() {
+    public Map<Object, Map<String, ActionState>> getKeyedActionStates() {
         return keyedActionStates;
     }
 

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStoreTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStoreTest.java
@@ -37,6 +37,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.agents.runtime.actionstate.ActionStateTestUtils.KEY_SERIALIZER;
+import static org.apache.flink.agents.runtime.actionstate.ActionStateTestUtils.createKeyEncoder;
+import static org.apache.flink.agents.runtime.actionstate.ActionStateTestUtils.generateKey;
 import static org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy.EARLIEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -72,19 +75,22 @@ public class KafkaActionStateStoreTest {
         mockConsumer.assign(
                 List.of(new TopicPartition(TEST_TOPIC, 0), new TopicPartition(TEST_TOPIC, 1)));
         actionStates = new HashMap<>();
-        actionStateStore =
-                new KafkaActionStateStore(
-                        actionStates,
-                        new AgentConfiguration(),
-                        mockProducer,
-                        mockConsumer,
-                        TEST_TOPIC,
-                        MAX_PARALLELISM);
+        actionStateStore = createStore(MAX_PARALLELISM);
 
         // Create test objects
         testAction = new NoOpAction("test-action");
         testEvent = new InputEvent("test data");
         testActionState = new ActionState(testEvent);
+    }
+
+    private KafkaActionStateStore createStore(int maxParallelism) {
+        return new KafkaActionStateStore(
+                actionStates,
+                new AgentConfiguration(),
+                mockProducer,
+                mockConsumer,
+                TEST_TOPIC,
+                createKeyEncoder(maxParallelism));
     }
 
     @Test
@@ -97,7 +103,12 @@ public class KafkaActionStateStoreTest {
         assertEquals(1, history.size());
         var record = history.get(0);
         assertEquals(TEST_TOPIC, record.topic());
-        assertThat(ActionStateUtil.matchesBusinessKeyAndSeqNum(record.key(), TEST_KEY, 1L))
+        assertThat(
+                        ActionStateUtil.matchesBusinessKeyIdentityAndSeqNum(
+                                record.key(),
+                                ActionStateUtil.generateBusinessKeyIdentity(
+                                        TEST_KEY, KEY_SERIALIZER),
+                                1L))
                 .isTrue();
         assertNotNull(record.value());
         assertThat(record.value()).isEqualTo(testActionState);
@@ -106,17 +117,13 @@ public class KafkaActionStateStoreTest {
     @Test
     void testGetNonExistentActionState() throws Exception {
         actionStates.put(
-                ActionStateUtil.generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM),
-                testActionState);
+                generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM), testActionState);
         actionStates.put(
-                ActionStateUtil.generateKey(TEST_KEY, 2L, testAction, testEvent, MAX_PARALLELISM),
-                testActionState);
+                generateKey(TEST_KEY, 2L, testAction, testEvent, MAX_PARALLELISM), testActionState);
         actionStates.put(
-                ActionStateUtil.generateKey(TEST_KEY, 3L, testAction, testEvent, MAX_PARALLELISM),
-                testActionState);
+                generateKey(TEST_KEY, 3L, testAction, testEvent, MAX_PARALLELISM), testActionState);
         actionStates.put(
-                ActionStateUtil.generateKey(TEST_KEY, 4L, testAction, testEvent, MAX_PARALLELISM),
-                testActionState);
+                generateKey(TEST_KEY, 4L, testAction, testEvent, MAX_PARALLELISM), testActionState);
 
         actionStateStore.get(TEST_KEY, 2L, new NoOpAction("test-1"), testEvent);
 
@@ -129,22 +136,17 @@ public class KafkaActionStateStoreTest {
     @Test
     void testGetActionStateWithDiverge() throws Exception {
         actionStates.put(
-                ActionStateUtil.generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM),
-                testActionState);
+                generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM), testActionState);
         actionStates.put(
-                ActionStateUtil.generateKey(TEST_KEY, 2L, testAction, testEvent, MAX_PARALLELISM),
-                testActionState);
+                generateKey(TEST_KEY, 2L, testAction, testEvent, MAX_PARALLELISM), testActionState);
         // diverge here
         actionStates.put(
-                ActionStateUtil.generateKey(
-                        TEST_KEY, 2L, new NoOpAction("test-2"), testEvent, MAX_PARALLELISM),
+                generateKey(TEST_KEY, 2L, new NoOpAction("test-2"), testEvent, MAX_PARALLELISM),
                 testActionState);
         actionStates.put(
-                ActionStateUtil.generateKey(TEST_KEY, 3L, testAction, testEvent, MAX_PARALLELISM),
-                testActionState);
+                generateKey(TEST_KEY, 3L, testAction, testEvent, MAX_PARALLELISM), testActionState);
         actionStates.put(
-                ActionStateUtil.generateKey(TEST_KEY, 4L, testAction, testEvent, MAX_PARALLELISM),
-                testActionState);
+                generateKey(TEST_KEY, 4L, testAction, testEvent, MAX_PARALLELISM), testActionState);
 
         actionStateStore.get(TEST_KEY, 2L, testAction, testEvent);
 
@@ -194,14 +196,11 @@ public class KafkaActionStateStoreTest {
     void testPruneState() throws Exception {
         // Arrange
         actionStates.put(
-                ActionStateUtil.generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM),
-                testActionState);
+                generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM), testActionState);
         actionStates.put(
-                ActionStateUtil.generateKey(TEST_KEY, 2L, testAction, testEvent, MAX_PARALLELISM),
-                testActionState);
+                generateKey(TEST_KEY, 2L, testAction, testEvent, MAX_PARALLELISM), testActionState);
         actionStates.put(
-                ActionStateUtil.generateKey(TEST_KEY, 3L, testAction, testEvent, MAX_PARALLELISM),
-                testActionState);
+                generateKey(TEST_KEY, 3L, testAction, testEvent, MAX_PARALLELISM), testActionState);
 
         // Verify all states exist
         assertNotNull(actionStateStore.get(TEST_KEY, 1L, testAction, testEvent));
@@ -214,12 +213,10 @@ public class KafkaActionStateStoreTest {
         // Assert - states 1 and 2 should be pruned, state 3 should remain
         assertNull(
                 actionStates.get(
-                        ActionStateUtil.generateKey(
-                                TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM)));
+                        generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM)));
         assertNull(
                 actionStates.get(
-                        ActionStateUtil.generateKey(
-                                TEST_KEY, 2L, testAction, testEvent, MAX_PARALLELISM)));
+                        generateKey(TEST_KEY, 2L, testAction, testEvent, MAX_PARALLELISM)));
         assertNotNull(actionStateStore.get(TEST_KEY, 3L, testAction, testEvent));
     }
 
@@ -239,7 +236,12 @@ public class KafkaActionStateStoreTest {
         assertEquals(2, history.size());
         var record = history.get(0);
         assertEquals(TEST_TOPIC, record.topic());
-        assertThat(ActionStateUtil.matchesBusinessKeyAndSeqNum(record.key(), TEST_KEY, 1L))
+        assertThat(
+                        ActionStateUtil.matchesBusinessKeyIdentityAndSeqNum(
+                                record.key(),
+                                ActionStateUtil.generateBusinessKeyIdentity(
+                                        TEST_KEY, KEY_SERIALIZER),
+                                1L))
                 .isTrue();
         assertNotNull(record.value());
         assertThat(record.value()).isEqualTo(testActionState);
@@ -269,18 +271,15 @@ public class KafkaActionStateStoreTest {
         // Assert - only the state up to the recovery marker should be restored
         assertThat(
                         actionStates.get(
-                                ActionStateUtil.generateKey(
-                                        TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM)))
+                                generateKey(TEST_KEY, 1L, testAction, testEvent, MAX_PARALLELISM)))
                 .isEqualTo(testActionState);
         assertThat(
                         actionStates.get(
-                                ActionStateUtil.generateKey(
-                                        TEST_KEY, 2L, testAction, testEvent, MAX_PARALLELISM)))
+                                generateKey(TEST_KEY, 2L, testAction, testEvent, MAX_PARALLELISM)))
                 .isEqualTo(secondState);
         assertThat(
                         actionStates.get(
-                                ActionStateUtil.generateKey(
-                                        TEST_KEY, 3L, testAction, testEvent, MAX_PARALLELISM)))
+                                generateKey(TEST_KEY, 3L, testAction, testEvent, MAX_PARALLELISM)))
                 .isEqualTo(thirdState);
     }
 
@@ -292,10 +291,8 @@ public class KafkaActionStateStoreTest {
     void testRebuildStateFiltersForeignKeys() throws Exception {
         String keyA = "A";
         String keyB = "B";
-        String stateKeyA =
-                ActionStateUtil.generateKey(keyA, 1L, testAction, testEvent, MAX_PARALLELISM);
-        String stateKeyB =
-                ActionStateUtil.generateKey(keyB, 1L, testAction, testEvent, MAX_PARALLELISM);
+        String stateKeyA = generateKey(keyA, 1L, testAction, testEvent, MAX_PARALLELISM);
+        String stateKeyB = generateKey(keyB, 1L, testAction, testEvent, MAX_PARALLELISM);
 
         long offset = 0L;
         mockConsumer.addRecord(
@@ -322,10 +319,8 @@ public class KafkaActionStateStoreTest {
      */
     @Test
     void testRebuildStateKeepsAllKeysWhenNoFilter() throws Exception {
-        String stateKeyA =
-                ActionStateUtil.generateKey("A", 1L, testAction, testEvent, MAX_PARALLELISM);
-        String stateKeyB =
-                ActionStateUtil.generateKey("B", 1L, testAction, testEvent, MAX_PARALLELISM);
+        String stateKeyA = generateKey("A", 1L, testAction, testEvent, MAX_PARALLELISM);
+        String stateKeyB = generateKey("B", 1L, testAction, testEvent, MAX_PARALLELISM);
 
         long offset = 0L;
         mockConsumer.addRecord(
@@ -348,10 +343,8 @@ public class KafkaActionStateStoreTest {
      */
     @Test
     void testPruneStateDoesNotCrossNumericKeyAndSeqNum() throws Exception {
-        String keyOneAtSeqFive =
-                ActionStateUtil.generateKey(1L, 5L, testAction, testEvent, MAX_PARALLELISM);
-        String keyFiveAtSeqThree =
-                ActionStateUtil.generateKey(5L, 3L, testAction, testEvent, MAX_PARALLELISM);
+        String keyOneAtSeqFive = generateKey(1L, 5L, testAction, testEvent, MAX_PARALLELISM);
+        String keyFiveAtSeqThree = generateKey(5L, 3L, testAction, testEvent, MAX_PARALLELISM);
         actionStates.put(keyOneAtSeqFive, testActionState);
         actionStates.put(keyFiveAtSeqThree, testActionState);
 
@@ -370,8 +363,7 @@ public class KafkaActionStateStoreTest {
     @Test
     void testGetCleanupIsScopedToRequestedKey() throws Exception {
         String otherKeyNewerState =
-                ActionStateUtil.generateKey(
-                        "other-key", 9L, testAction, testEvent, MAX_PARALLELISM);
+                generateKey("other-key", 9L, testAction, testEvent, MAX_PARALLELISM);
         actionStates.put(otherKeyNewerState, testActionState);
 
         // Cache miss for TEST_KEY at seqNum 1 triggers cleanup of states with seqNum > 1.
@@ -380,63 +372,68 @@ public class KafkaActionStateStoreTest {
         assertThat(actionStates).containsKey(otherKeyNewerState);
     }
 
-    /**
-     * Records whose composite state key is not in the current format — including records written
-     * before the format change and otherwise malformed keys — cannot be attributed to a key-group
-     * and are dropped during rebuild rather than retained in every subtask. This closes the
-     * orphan-state leak; the project does not preserve pre-format durable state.
-     */
     @Test
-    void testRebuildStateDropsUnrecognizedFormatKeys() throws Exception {
-        String legacyKey = TEST_KEY + "_1_event-uuid_action-uuid";
-        String malformedKey = "malformed-key";
-        String stateKeyA =
-                ActionStateUtil.generateKey("A", 1L, testAction, testEvent, MAX_PARALLELISM);
+    void testGetCleanupSeparatesTypedKeysWithSameStringForm() throws Exception {
+        KafkaActionStateStore collisionStore = createStore(1);
+        String stringKeyNewerState = generateKey("1", 9L, testAction, testEvent, 1);
+        actionStates.put(stringKeyNewerState, testActionState);
 
-        long offset = 0L;
-        mockConsumer.addRecord(
-                new ConsumerRecord<>(TEST_TOPIC, 0, offset++, legacyKey, testActionState));
-        mockConsumer.addRecord(
-                new ConsumerRecord<>(TEST_TOPIC, 0, offset++, malformedKey, testActionState));
-        mockConsumer.addRecord(
-                new ConsumerRecord<>(TEST_TOPIC, 0, offset++, stateKeyA, testActionState));
+        assertThat(collisionStore.get(1L, 1L, testAction, testEvent)).isNull();
 
-        List<Object> recoveryMarkers = List.of(Map.of(0, 0L, 1, 0L));
-
-        int ownedKeyGroup = ActionStateUtil.parseKeyGroup(stateKeyA);
-        actionStateStore.setOwnershipFilter(kg -> kg == ownedKeyGroup);
-        actionStateStore.rebuildState(recoveryMarkers);
-
-        assertThat(actionStates).containsKey(stateKeyA);
-        assertThat(actionStates).doesNotContainKey(legacyKey);
-        assertThat(actionStates).doesNotContainKey(malformedKey);
+        assertThat(actionStates).containsKey(stringKeyNewerState);
     }
 
-    /**
-     * A well-formed (5-segment) key whose key-group segment is not numeric cannot be attributed to
-     * a key-group and is dropped during rebuild.
-     */
     @Test
-    void testRebuildStateDropsKeyWithUnparsableKeyGroup() throws Exception {
-        String unparseableGroupKey = "not-a-number_1_event-uuid_action-uuid_bkey";
-        String stateKeyA =
-                ActionStateUtil.generateKey("A", 1L, testAction, testEvent, MAX_PARALLELISM);
+    void testPruneSeparatesTypedKeysWithSameStringForm() throws Exception {
+        KafkaActionStateStore collisionStore = createStore(1);
+        String numericState = generateKey(1L, 1L, testAction, testEvent, 1);
+        String stringState = generateKey("1", 1L, testAction, testEvent, 1);
+        actionStates.put(numericState, testActionState);
+        actionStates.put(stringState, testActionState);
 
-        long offset = 0L;
-        mockConsumer.addRecord(
-                new ConsumerRecord<>(
-                        TEST_TOPIC, 0, offset++, unparseableGroupKey, testActionState));
-        mockConsumer.addRecord(
-                new ConsumerRecord<>(TEST_TOPIC, 0, offset++, stateKeyA, testActionState));
+        collisionStore.pruneState(1L, 1L);
+
+        assertThat(actionStates).doesNotContainKey(numericState).containsKey(stringState);
+    }
+
+    /** Old state-key formats fail recovery instead of being guessed or silently discarded. */
+    @Test
+    void testRebuildStateRejectsUnrecognizedFormatKeys() {
+        String legacyKey = "12_1_event-uuid_action-uuid_business-key";
+        mockConsumer.addRecord(new ConsumerRecord<>(TEST_TOPIC, 0, 0L, legacyKey, testActionState));
 
         List<Object> recoveryMarkers = List.of(Map.of(0, 0L, 1, 0L));
+        actionStateStore.setOwnershipFilter(kg -> true);
 
-        int ownedKeyGroup = ActionStateUtil.parseKeyGroup(stateKeyA);
-        actionStateStore.setOwnershipFilter(kg -> kg == ownedKeyGroup);
-        actionStateStore.rebuildState(recoveryMarkers);
+        RuntimeException failure =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> actionStateStore.rebuildState(recoveryMarkers));
 
-        assertThat(actionStates).containsKey(stateKeyA);
-        assertThat(actionStates).doesNotContainKey(unparseableGroupKey);
+        assertThat(failure.getCause())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Unsupported action-state key format");
+    }
+
+    /** A current-format key with a nonnumeric key-group fails recovery instead of being dropped. */
+    @Test
+    void testRebuildStateRejectsKeyWithUnparsableKeyGroup() throws Exception {
+        String valid = generateKey("A", 1L, testAction, testEvent, MAX_PARALLELISM);
+        String unparseableGroupKey = "v2:not-a-number" + valid.substring(valid.indexOf('_'));
+        mockConsumer.addRecord(
+                new ConsumerRecord<>(TEST_TOPIC, 0, 0L, unparseableGroupKey, testActionState));
+
+        List<Object> recoveryMarkers = List.of(Map.of(0, 0L, 1, 0L));
+        actionStateStore.setOwnershipFilter(kg -> true);
+
+        RuntimeException failure =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> actionStateStore.rebuildState(recoveryMarkers));
+
+        assertThat(failure.getCause())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Invalid key-group");
     }
 
     /** Contract: the consumer is closed even when closing the producer throws. */
@@ -454,7 +451,7 @@ public class KafkaActionStateStoreTest {
                         failingProducer,
                         consumer,
                         TEST_TOPIC,
-                        MAX_PARALLELISM);
+                        createKeyEncoder(MAX_PARALLELISM));
 
         assertThrows(RuntimeException.class, store::close);
 
@@ -482,7 +479,7 @@ public class KafkaActionStateStoreTest {
                         failingProducer,
                         failingConsumer,
                         TEST_TOPIC,
-                        MAX_PARALLELISM);
+                        createKeyEncoder(MAX_PARALLELISM));
 
         RuntimeException thrown = assertThrows(RuntimeException.class, store::close);
 
@@ -509,7 +506,7 @@ public class KafkaActionStateStoreTest {
                         producer,
                         failingConsumer,
                         TEST_TOPIC,
-                        MAX_PARALLELISM);
+                        createKeyEncoder(MAX_PARALLELISM));
 
         RuntimeException thrown = assertThrows(RuntimeException.class, store::close);
 
@@ -537,7 +534,7 @@ public class KafkaActionStateStoreTest {
                         failingProducer,
                         consumer,
                         TEST_TOPIC,
-                        MAX_PARALLELISM);
+                        createKeyEncoder(MAX_PARALLELISM));
 
         assertThat(catchThrowable(store::close)).isSameAs(producerFailure);
 
@@ -567,7 +564,7 @@ public class KafkaActionStateStoreTest {
                         failingProducer,
                         failingConsumer,
                         TEST_TOPIC,
-                        MAX_PARALLELISM);
+                        createKeyEncoder(MAX_PARALLELISM));
 
         Throwable thrown = catchThrowable(store::close);
 

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperatorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperatorTest.java
@@ -910,7 +910,7 @@ public class ActionExecutionOperatorTest {
             operator.waitInFlightEventsFinished();
 
             // Verify that action states were created during processing
-            Map<String, Map<String, ActionState>> actionStates =
+            Map<Object, Map<String, ActionState>> actionStates =
                     actionStateStore.getKeyedActionStates();
             assertThat(actionStates).isNotEmpty();
 
@@ -918,7 +918,7 @@ public class ActionExecutionOperatorTest {
             assertThat(actionStates.size()).isEqualTo(1);
 
             // Verify each action state contains expected information
-            for (Map.Entry<String, Map<String, ActionState>> outerEntry : actionStates.entrySet()) {
+            for (Map.Entry<Object, Map<String, ActionState>> outerEntry : actionStates.entrySet()) {
                 for (Map.Entry<String, ActionState> entry : outerEntry.getValue().entrySet()) {
                     ActionState state = entry.getValue();
                     assertThat(state).isNotNull();
@@ -1527,18 +1527,20 @@ public class ActionExecutionOperatorTest {
             testHarness.processElement(new StreamRecord<>(inputValue));
             operator.waitInFlightEventsFinished();
 
-            Map<String, Map<String, ActionState>> actionStates =
+            Map<Object, Map<String, ActionState>> actionStates =
                     actionStateStore.getKeyedActionStates();
             assertThat(actionStates).hasSize(1);
 
             // Verify specific action states by examining the keys
-            for (Map.Entry<String, Map<String, ActionState>> outerEntry : actionStates.entrySet()) {
+            for (Map.Entry<Object, Map<String, ActionState>> outerEntry : actionStates.entrySet()) {
                 for (Map.Entry<String, ActionState> entry : outerEntry.getValue().entrySet()) {
                     String stateKey = entry.getKey();
                     ActionState state = entry.getValue();
 
-                    // Verify the state key contains the expected key and action information
-                    assertThat(stateKey).contains(inputValue.toString());
+                    // Verify the state key is current-format and belongs to the typed input key.
+                    assertThat(stateKey).startsWith("v2:");
+                    assertThat(ActionStateUtil.parseKeyGroup(stateKey))
+                            .isEqualTo(KeyGroupRangeAssignment.assignToKeyGroup(inputValue, 128));
 
                     // Verify task event is properly stored
                     Event taskEvent = state.getTaskEvent();
@@ -1630,7 +1632,7 @@ public class ActionExecutionOperatorTest {
             operator.waitInFlightEventsFinished();
 
             // Verify initial state creation
-            Map<String, Map<String, ActionState>> actionStates =
+            Map<Object, Map<String, ActionState>> actionStates =
                     actionStateStore.getKeyedActionStates();
             assertThat(actionStates).isNotEmpty();
             int initialStateCount = actionStates.size();
@@ -1876,8 +1878,7 @@ public class ActionExecutionOperatorTest {
                     (List<StreamRecord<Object>>) testHarness.getRecordOutput();
             assertThat(outputRecords).hasSize(1);
             assertThat(outputRecords.get(0).getValue()).isEqualTo((inputValue + 1) * 2);
-            assertThat(actionStateStore.getKeyedActionStates().get(String.valueOf(inputValue)))
-                    .hasSize(2);
+            assertThat(actionStateStore.getKeyedActionStates().get(inputValue)).hasSize(2);
 
             List<RecordedEvent> replayEvents = RecordingEventLogger.events();
             assertThat(replayEvents)

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DurableExecutionManagerTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DurableExecutionManagerTest.java
@@ -23,26 +23,33 @@ import org.apache.flink.agents.api.OutputEvent;
 import org.apache.flink.agents.plan.AgentConfiguration;
 import org.apache.flink.agents.plan.actions.Action;
 import org.apache.flink.agents.runtime.actionstate.ActionState;
+import org.apache.flink.agents.runtime.actionstate.ActionStateKeyEncoder;
 import org.apache.flink.agents.runtime.actionstate.InMemoryActionStateStore;
+import org.apache.flink.agents.runtime.actionstate.KafkaActionStateStore;
 import org.apache.flink.agents.runtime.context.RunnerContextImpl;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.KeyedStateFunction;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.apache.flink.agents.api.configuration.AgentConfigOptions.ACTION_STATE_STORE_BACKEND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -50,6 +57,37 @@ import static org.mockito.Mockito.when;
 
 /** Contract tests for {@link DurableExecutionManager}. */
 class DurableExecutionManagerTest {
+
+    @Test
+    void defaultKafkaStoreUsesProvidedKeySerializerAndMaxParallelism() throws Exception {
+        int maxParallelism = 128;
+        AgentConfiguration config = new AgentConfiguration();
+        config.set(ACTION_STATE_STORE_BACKEND, "kafka");
+        AtomicReference<ActionStateKeyEncoder> capturedEncoder = new AtomicReference<>();
+
+        try (MockedConstruction<KafkaActionStateStore> stores =
+                mockConstruction(
+                        KafkaActionStateStore.class,
+                        (store, context) ->
+                                capturedEncoder.set(
+                                        (ActionStateKeyEncoder) context.arguments().get(1)))) {
+            DurableExecutionManager manager = new DurableExecutionManager(null);
+
+            manager.maybeInitActionStateStore(config, maxParallelism, LongSerializer.INSTANCE);
+
+            assertThat(stores.constructed()).hasSize(1);
+            assertThat(manager.getActionStateStore()).isSameAs(stores.constructed().get(0));
+            Action action = TestActions.noopAction();
+            Event event = new InputEvent(1L);
+            String actual = capturedEncoder.get().generateKey(1L, 0L, action, event);
+            String expected =
+                    new ActionStateKeyEncoder(maxParallelism, LongSerializer.INSTANCE)
+                            .generateKey(1L, 0L, action, event);
+            assertThat(actual).isEqualTo(expected);
+
+            manager.close();
+        }
+    }
 
     @Test
     void noStoreModeMakesAllMaybeOperationsNoOp() throws Exception {

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DurableExecutionManagerTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DurableExecutionManagerTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.KeyedStateFunction;
 import org.apache.flink.runtime.state.OperatorStateBackend;
@@ -54,7 +55,7 @@ class DurableExecutionManagerTest {
     void noStoreModeMakesAllMaybeOperationsNoOp() throws Exception {
         DurableExecutionManager dem = new DurableExecutionManager(null);
         // No ACTION_STATE_STORE_BACKEND set → no default store should be created.
-        dem.maybeInitActionStateStore(new AgentConfiguration(), 128);
+        dem.maybeInitActionStateStore(new AgentConfiguration(), 128, mock(TypeSerializer.class));
 
         assertThat(dem.hasDurableStore()).isFalse();
         assertThat(dem.getActionStateStore()).isNull();


### PR DESCRIPTION
Closes #1099.

This branch is stacked on PR #1094, which makes the action identifier stable across JVM restarts. The two changes fix separate parts of the action-state key.

### Purpose of change

Flink Agents stores action progress under the current key so recovery can find completed work and avoid repeating its side effects. The existing format turns that key into text. Different typed keys with the same text, such as `Long(1)` and `String("1")`, can therefore point to the same action state. A lookup or prune for one key can remove the other key's completed state, allowing recovery to run that action again.

This change gives each typed key a durable identity derived from its serialized bytes. Kafka and Fluss use that identity consistently for writes, lookups, cleanup, partitioning, and recovery.

#### Runtime flow

1. During operator initialization, the store receives the keyed backend's serializer and maximum parallelism.
2. `ActionStateKeyEncoder` serializes the typed key and hashes the bytes with SHA-256. The state key contains that digest, the key-group, sequence number, event ID, and action ID.
3. Kafka partitions by the business-key digest. Fluss uses it as the table's distribution identity. Both stores use it for lookup, divergence cleanup, and pruning.
4. Recovery validates the fields and key-group range before applying the subtask ownership filter and caching each owned record.


#### Key decisions

- Serialized bytes preserve type information and align the identity with keyed state. A fixed-length digest keeps raw key data out of backend keys and gives every record a bounded key size.
- Serializer snapshots can change during normal operation as POJO subclass caches grow. The key therefore uses serialized key bytes without a snapshot fingerprint.
- The store supports one record format. Existing records and changes to key types or serializer configuration during recovery are unsupported; field validation cannot reliably detect every incompatible record.

#### Related work

Issue #1034 manages the Kafka offset boundary for deleting an older log prefix, while this PR defines the identity of each record. PR #885 manages Kafka tombstones. When those changes are combined, replay must validate the record key before applying a value or tombstone, and pruning must derive the same typed identity.

### Behavioral Semantics

#### Interaction decisions

| Record during recovery | Ownership | Result |
|---|---|---|
| Valid current-format fields | Owned | Cache the record |
| Valid current-format fields | Foreign | Skip the record |
| Malformed field or out-of-range key-group | Any | Stop and identify the invalid field and key |

#### Behavioral contracts

- `Long(1)`, `String("1")`, and custom keys sharing a string representation receive separate identities, including at maximum parallelism `1`.
- Equivalent serializers produce the same key identity.
- Unchanged POJO jobs recover completed action state even when runtime subclass caching changes their serializer snapshots.
- Kafka and Fluss share one typed identity across storage, lookup, cleanup, distribution, and recovery.
- Recovery validates each record first, then caches records owned by the current subtask.
- Generated keys use canonical fields and a nonnegative sequence number.

#### Failure behavior

- Key serialization failures raise immediately and retain their original causes.
- Malformed fields, noncanonical values, and out-of-range key-groups stop recovery with a specific error. Recovery errors bound every echoed key and field.
- Pruning preserves records whose format or sequence number prevents safe attribution.

### API

The supported user-facing API and configuration remain unchanged. The stores, key utilities, and Kafka partitioner now carry explicit `@Internal` annotations. Their construction path receives an `ActionStateKeyEncoder`, so direct callers of these implementation classes must update their constructor calls.

The durable record format changes incompatibly. Existing action-state records are unsupported; use a fresh Kafka topic or Fluss table and start without an older checkpoint or savepoint when upgrading. For subsequent recovery, preserve the key type and serializer configuration. Flink may accept a serializer change that produces different key bytes; the action-state store does not detect that change and may miss completed work.

### Documentation

- [ ] `doc-needed`
- [ ] `doc-not-needed`
- [x] `doc-included`

The deployment and configuration documentation explains the format transition, serializer compatibility, backend isolation, and digest security boundary.

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No
