### PR TITLE
[runtime] Reject RuntimeExecutionMode.BATCH with the default batch state backend

### DIFF
--- a/runtime/src/main/java/org/apache/flink/agents/runtime/CompileUtils.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/CompileUtils.java
@@ -22,15 +22,19 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.agents.plan.AgentPlan;
 import org.apache.flink.agents.runtime.operator.ActionExecutionOperatorFactory;
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.KeyedStream;
 import org.apache.flink.streaming.api.typeinfo.python.PickledByteArrayTypeInfo;
 import org.apache.flink.types.Row;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /** A utility class that bridges Flink DataStream/SQL with the Flink Agents agent. */
 public class CompileUtils {
@@ -97,6 +101,7 @@ public class CompileUtils {
             TypeInformation<OUT> outTypeInformation,
             boolean inputIsJava,
             boolean pythonKeyIsPickled) {
+        checkBatchStateBackendCompatibility(keyedInputStream);
         return (DataStream<OUT>)
                 keyedInputStream
                         .transform(
@@ -105,6 +110,42 @@ public class CompileUtils {
                                 new ActionExecutionOperatorFactory(
                                         agentPlan, inputIsJava, pythonKeyIsPickled))
                         .setParallelism(keyedInputStream.getParallelism());
+    }
+
+    /**
+     * Rejects a job configuration known to silently drop records: explicit {@code
+     * RuntimeExecutionMode.BATCH} together with Flink's batch-specific keyed-state backend (enabled
+     * by default in that mode).
+     *
+     * <p>{@link ActionExecutionOperatorFactory}'s operator keeps pending action tasks in keyed
+     * state across mailbox continuations that can span multiple keys of the same subtask. Flink's
+     * batch keyed-state backend assumes a key is fully processed before moving to the next one and
+     * clears keyed state on every key switch, so a continuation for one key can be silently
+     * discarded by the operator moving on to process another key first. The job still reports
+     * {@code FINISHED}; only the affected records go missing. See
+     * https://github.com/apache/flink-agents/issues/939.
+     *
+     * <p>This only catches an explicitly configured {@code BATCH} runtime mode. {@code
+     * RuntimeExecutionMode.AUTOMATIC} (the default) that later resolves to batch execution because
+     * every source happens to be bounded is not detected here, since that resolution has not
+     * happened yet at graph-construction time.
+     */
+    private static void checkBatchStateBackendCompatibility(KeyedStream<?, ?> keyedInputStream) {
+        ReadableConfig configuration =
+                keyedInputStream.getExecutionEnvironment().getConfiguration();
+        boolean isExplicitBatchMode =
+                configuration.get(ExecutionOptions.RUNTIME_MODE) == RuntimeExecutionMode.BATCH;
+        boolean usesBatchStateBackend = configuration.get(ExecutionOptions.USE_BATCH_STATE_BACKEND);
+        checkState(
+                !isExplicitBatchMode || !usesBatchStateBackend,
+                "Flink Agents does not support RuntimeExecutionMode.BATCH with Flink's batch"
+                        + " keyed-state backend (execution.batch-state-backend.enabled, enabled by"
+                        + " default in BATCH mode): pending action-task state can be silently"
+                        + " discarded when the operator processes another key before a key's"
+                        + " workflow finishes, causing records to be dropped without any error."
+                        + " Either run this job with RuntimeExecutionMode.STREAMING, or set"
+                        + " execution.batch-state-backend.enabled to false. See"
+                        + " https://github.com/apache/flink-agents/issues/939 for details.");
     }
 
     /** Returns whether a PyFlink Row field uses its default pickle representation. */

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/CompileUtilsTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/CompileUtilsTest.java
@@ -20,9 +20,12 @@ package org.apache.flink.agents.runtime;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.flink.agents.plan.AgentPlan;
 import org.apache.flink.agents.runtime.operator.ActionExecutionOperatorTest;
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.KeyedStream;
@@ -39,6 +42,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link CompileUtils}. */
@@ -101,6 +106,35 @@ public class CompileUtilsTest {
         resultList.sort(Long::compareTo);
 
         checkResult(resultList);
+    }
+
+    @Test
+    void rejectsExplicitBatchModeWithDefaultBatchStateBackend() {
+        // execution.batch-state-backend.enabled defaults to true in BATCH mode, which is exactly
+        // the combination that silently drops records (issue #939).
+        Configuration conf = new Configuration();
+        conf.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(conf);
+        KeyedStream<Long, Long> keyedInputStream = env.fromData(testSequence).keyBy(x -> x);
+
+        assertThatIllegalStateException()
+                .isThrownBy(() -> CompileUtils.connectToAgent(keyedInputStream, TEST_AGENT_PLAN))
+                .withMessageContaining("RuntimeExecutionMode.BATCH")
+                .withMessageContaining("execution.batch-state-backend.enabled");
+    }
+
+    @Test
+    void allowsExplicitBatchModeWithBatchStateBackendDisabled() {
+        // The documented workaround: disabling the batch-specific state backend restores the
+        // per-key-processed-to-completion semantics the operator relies on.
+        Configuration conf = new Configuration();
+        conf.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
+        conf.set(ExecutionOptions.USE_BATCH_STATE_BACKEND, false);
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(conf);
+        KeyedStream<Long, Long> keyedInputStream = env.fromData(testSequence).keyBy(x -> x);
+
+        assertThatCode(() -> CompileUtils.connectToAgent(keyedInputStream, TEST_AGENT_PLAN))
+                .doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION
Linked issue: #939

### Purpose of change

A job configured with `RuntimeExecutionMode.BATCH` and Flink's batch keyed-state backend (`execution.batch-state-backend.enabled`, enabled by default in `BATCH` mode) now fails immediately at job-graph construction with a clear error, instead of running to completion and silently dropping records.

`ActionExecutionOperator` keeps pending action tasks in keyed state across mailbox continuations that can span multiple keys of the same subtask. The batch keyed-state backend assumes a key is fully processed before the operator moves to the next one and clears keyed state on every key switch, so a continuation for one key can be discarded when the operator processes another key first — the job still reports `FINISHED`; only the affected records go missing.

**Runtime flow:** `CompileUtils.connectToAgent` (both the Python and Java entry points funnel into the same private overload) now calls `checkBatchStateBackendCompatibility` before constructing the `ActionExecutionOperator`. That reads `ExecutionOptions.RUNTIME_MODE` and `ExecutionOptions.USE_BATCH_STATE_BACKEND` off `keyedInputStream.getExecutionEnvironment().getConfiguration()` and throws before the operator is ever wired into the graph.

**Key decisions:**
- Fail fast at graph construction rather than attempt the deeper fix (making the operator safe under batch key-switch semantics), which is a separate, larger change out of scope here.
- Only an explicitly configured `BATCH` mode is detected. `RuntimeExecutionMode.AUTOMATIC` (the default) that later resolves to batch execution because every source happens to be bounded is not caught, since that resolution hasn't happened yet at graph-construction time — inspecting source boundedness to predict `AUTOMATIC`'s eventual resolution was rejected as disproportionate for a case the explicit, documented `BATCH` setting already covers.

### Behavioral Semantics

#### Interaction decisions

| `RUNTIME_MODE` | `USE_BATCH_STATE_BACKEND` | Behavior |
|---|---|---|
| `STREAMING` | `true` / `false` | Unaffected — check only fires for `BATCH` |
| `BATCH` | `true` (default) | Rejected: `IllegalStateException` before the operator is constructed |
| `BATCH` | `false` | Allowed — the documented workaround |
| `AUTOMATIC` | `true` / `false` | Unaffected — not detected (see Key decisions) |

#### Behavioral contracts
1. `connectToAgent` throws `IllegalStateException` before constructing the operator when `RUNTIME_MODE=BATCH` and `USE_BATCH_STATE_BACKEND=true`.
2. `connectToAgent` behaves exactly as before this change for every other `RUNTIME_MODE`/`USE_BATCH_STATE_BACKEND` combination.
3. The exception message names both workarounds (`RuntimeExecutionMode.STREAMING`, or setting `execution.batch-state-backend.enabled=false`) and links to #939.

#### Failure behavior
The only new failure path: an unsupported `BATCH` + batch-state-backend-enabled configuration raises `IllegalStateException` synchronously, before any operator is created — not a retry, not silently absorbed. For the Python entry point, this check runs after the existing pickled-input-type and agent-plan-JSON validations, so it doesn't change their ordering or messages. No other failure path changes.

### Tests

| Contract | Test |
|---|---|
| 1 | `rejectsExplicitBatchModeWithDefaultBatchStateBackend` |
| 2 (BATCH + disabled) | `allowsExplicitBatchModeWithBatchStateBackendDisabled` |
| 2 (STREAMING, unaffected) | pre-existing `testJavaNoKeyedStreamConnectToAgent` / `testJavaKeyedStreamConnectToAgent` |
| 3 | `rejectsExplicitBatchModeWithDefaultBatchStateBackend` asserts the message contains both `RuntimeExecutionMode.BATCH` and `execution.batch-state-backend.enabled` |

Not verified: `AUTOMATIC` mode resolving to batch execution via all-bounded sources; an actual executed `BATCH` job reproducing the original multi-key data-loss scenario (would need a heavier MiniCluster run) — the causal chain for *why* the collision happens relies on the issue's own trace of Flink's batch state-backend semantics, not a reproduction inside this PR.

<details>
<summary>Verification evidence</summary>

Ran `CompileUtilsTest` (9/9 pass) plus the full `operator`, `context`, and `skill` packages after a clean rebuild (`mvn -pl runtime clean`, then `mvn -pl api,plan -am install -DskipTests` to pick up unrelated upstream API changes already on `main`). 249 tests, 7 pre-existing failures unrelated to this change: 4 are a Windows-only temp-directory-deletion quirk in `ClasspathSkillRepositoryTest` (locked JAR files), and 3 (`FileSystemSkillRepositoryTest`, `SkillManagerTest` x2) pick up this machine's own local Claude Code skills directory contents (`github`, `nano-banana-pro`) rather than the repo's test fixtures — both reproduce identically on unmodified `main` in this environment. `mvn -pl runtime spotless:check` clean.

</details>

### API

No public API changes. `connectToAgent`'s signature and behavior for every previously-supported configuration are unchanged; this adds a new, additive rejection for a configuration that was previously accepted but silently broken.

### Documentation

- [x] `doc-not-needed`

### Was this patch authored or co-authored using generative AI tooling?

- [x] Yes

Generated-by: AI coding assistant

